### PR TITLE
chore(docs): add CODEOWNERS and security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything
+* @andymai

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it by emailing the maintainer directly rather than opening a public issue.
+
+## Scope
+
+The occt-wasm build tooling (xtask, Dockerfile, scripts) is MIT/Apache-2.0 licensed.
+
+The compiled WASM output inherits OCCT's LGPL-2.1 license and includes OCCT's C++ code. Security issues in OCCT itself should be reported to [OpenCascade](https://dev.opencascade.org/).


### PR DESCRIPTION
## Summary
- `.github/CODEOWNERS`: @andymai owns everything
- `SECURITY.md`: vulnerability reporting guidance

## Repo hygiene also configured via API
- Squash merge only (no merge commits, no rebase)
- Auto-delete head branches on merge
- Disabled: wiki, projects, discussions
- Branch ruleset: require PR for main, no force push, admin bypass
- Custom labels: domain (facade, xtask, ts, docker, ci, docs), milestone (0, 1), priority (P0-P2)