### PR TITLE
fix(docker): update build.sh with Milestone 0 findings

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,12 +30,12 @@ emcmake cmake .. \
   -DBUILD_MODULE_ApplicationFramework=TRUE \
   -DBUILD_MODULE_Visualization=FALSE \
   -DBUILD_MODULE_Draw=FALSE \
-  -DBUILD_MODULE_DETools=FALSE \
   -DBUILD_LIBRARY_TYPE=Static \
-  -DUSE_FREETYPE=ON \
-  -DUSE_RAPIDJSON=ON \
+  -DUSE_FREETYPE=OFF \
+  -DUSE_RAPIDJSON=OFF \
   -DCMAKE_C_FLAGS="-fwasm-exceptions -O2 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
-  -DCMAKE_CXX_FLAGS="-fwasm-exceptions -O2 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS"
+  -DCMAKE_CXX_FLAGS="-fwasm-exceptions -O2 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
+  -Wno-dev
 
 echo "=== Building OCCT ==="
 cmake --build . --parallel


### PR DESCRIPTION
## Summary
- Disable FreeType/RapidJSON (not needed for WASM facade)
- Remove invalid `BUILD_MODULE_DETools` flag
- Add `-Wno-dev` to suppress CMake warnings

## Milestone 0 validated
OCCT V8.0.0-rc4 compiles to 48 static libs with emsdk 5.0.3.