### PR TITLE
feat(facade): expand to 40 methods

### DIFF
--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -34,6 +34,19 @@ struct BBoxData {
     double xmin, ymin, zmin, xmax, ymax, zmax;
 };
 
+/// Edge line data for wireframe rendering.
+struct EdgeData {
+    float* points = nullptr; // xyz interleaved
+    int pointCount = 0;
+
+    EdgeData() = default;
+    ~EdgeData();
+    EdgeData(const EdgeData& other);
+    EdgeData& operator=(const EdgeData&) = delete;
+
+    int getPointsPtr() const;
+};
+
 /// Arena-based OCCT kernel. All shapes are stored by u32 ID.
 /// JS/TS never interacts with OCCT types directly.
 class OcctKernel {
@@ -57,18 +70,62 @@ class OcctKernel {
     uint32_t fuse(uint32_t a, uint32_t b);
     uint32_t cut(uint32_t a, uint32_t b);
     uint32_t common(uint32_t a, uint32_t b);
+    uint32_t section(uint32_t a, uint32_t b);
+
+    // --- Modeling operations ---
+    uint32_t extrude(uint32_t shapeId, double dx, double dy, double dz);
+    uint32_t revolve(uint32_t shapeId, double px, double py, double pz, double dx, double dy,
+                     double dz, double angleRad);
+    uint32_t fillet(uint32_t solidId, std::vector<uint32_t> edgeIds, double radius);
+    uint32_t chamfer(uint32_t solidId, std::vector<uint32_t> edgeIds, double distance);
+    uint32_t shell(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness);
+    uint32_t offset(uint32_t solidId, double distance);
+    uint32_t draft(uint32_t shapeId, uint32_t faceId, double angleRad, double dx, double dy,
+                   double dz);
+
+    // --- Sweep operations ---
+    uint32_t pipe(uint32_t profileId, uint32_t spineId);
+    uint32_t loft(std::vector<uint32_t> wireIds, bool isSolid);
+
+    // --- Shape construction ---
+    uint32_t makeVertex(double x, double y, double z);
+    uint32_t makeEdge(uint32_t v1, uint32_t v2);
+    uint32_t makeWire(std::vector<uint32_t> edgeIds);
+    uint32_t makeFace(uint32_t wireId);
+    uint32_t makeSolid(uint32_t shellId);
+    uint32_t sew(std::vector<uint32_t> shapeIds, double tolerance);
+    uint32_t makeCompound(std::vector<uint32_t> shapeIds);
+
+    // --- Transforms ---
+    uint32_t translate(uint32_t id, double dx, double dy, double dz);
+    uint32_t rotate(uint32_t id, double px, double py, double pz, double dx, double dy, double dz,
+                    double angleRad);
+    uint32_t scale(uint32_t id, double px, double py, double pz, double factor);
+    uint32_t mirror(uint32_t id, double px, double py, double pz, double nx, double ny, double nz);
+    uint32_t copy(uint32_t id);
+
+    // --- Topology query ---
+    std::string getShapeType(uint32_t id);
+    std::vector<uint32_t> getSubShapes(uint32_t id, const std::string& shapeType);
+    double distanceBetween(uint32_t a, uint32_t b);
 
     // --- Tessellation ---
     MeshData tessellate(uint32_t id, double linearDeflection, double angularDeflection);
+    EdgeData wireframe(uint32_t id, double deflection);
 
     // --- I/O ---
     uint32_t importStep(const std::string& data);
     std::string exportStep(uint32_t id);
+    std::string exportStl(uint32_t id, double linearDeflection);
 
     // --- Query ---
     BBoxData getBoundingBox(uint32_t id);
     double getVolume(uint32_t id);
     double getSurfaceArea(uint32_t id);
+
+    // --- Healing ---
+    uint32_t fixShape(uint32_t id);
+    uint32_t unifySameDomain(uint32_t id);
 
   private:
     uint32_t store(const TopoDS_Shape& shape);

--- a/facade/src/bindings.cpp
+++ b/facade/src/bindings.cpp
@@ -4,7 +4,7 @@
 using namespace emscripten;
 
 EMSCRIPTEN_BINDINGS(occt_wasm) {
-    // MeshData — returned from tessellate()
+    // MeshData
     class_<MeshData>("MeshData")
         .function("getPositionsPtr", &MeshData::getPositionsPtr)
         .function("getNormalsPtr", &MeshData::getNormalsPtr)
@@ -13,7 +13,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .property("normalCount", &MeshData::normalCount)
         .property("indexCount", &MeshData::indexCount);
 
-    // BBoxData — returned from getBoundingBox()
+    // BBoxData
     value_object<BBoxData>("BBoxData")
         .field("xmin", &BBoxData::xmin)
         .field("ymin", &BBoxData::ymin)
@@ -22,7 +22,15 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .field("ymax", &BBoxData::ymax)
         .field("zmax", &BBoxData::zmax);
 
-    // OcctKernel — the main API
+    // EdgeData
+    class_<EdgeData>("EdgeData")
+        .function("getPointsPtr", &EdgeData::getPointsPtr)
+        .property("pointCount", &EdgeData::pointCount);
+
+    // Vector types for Embind
+    register_vector<uint32_t>("VectorUint32");
+
+    // OcctKernel
     class_<OcctKernel>("OcctKernel")
         .constructor<>()
 
@@ -42,16 +50,57 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("fuse", &OcctKernel::fuse)
         .function("cut", &OcctKernel::cut)
         .function("common", &OcctKernel::common)
+        .function("section", &OcctKernel::section)
+
+        // Modeling
+        .function("extrude", &OcctKernel::extrude)
+        .function("revolve", &OcctKernel::revolve)
+        .function("fillet", &OcctKernel::fillet)
+        .function("chamfer", &OcctKernel::chamfer)
+        .function("shell", &OcctKernel::shell)
+        .function("offset", &OcctKernel::offset)
+        .function("draft", &OcctKernel::draft)
+
+        // Sweeps
+        .function("pipe", &OcctKernel::pipe)
+        .function("loft", &OcctKernel::loft)
+
+        // Construction
+        .function("makeVertex", &OcctKernel::makeVertex)
+        .function("makeEdge", &OcctKernel::makeEdge)
+        .function("makeWire", &OcctKernel::makeWire)
+        .function("makeFace", &OcctKernel::makeFace)
+        .function("makeSolid", &OcctKernel::makeSolid)
+        .function("sew", &OcctKernel::sew)
+        .function("makeCompound", &OcctKernel::makeCompound)
+
+        // Transforms
+        .function("translate", &OcctKernel::translate)
+        .function("rotate", &OcctKernel::rotate)
+        .function("scale", &OcctKernel::scale)
+        .function("mirror", &OcctKernel::mirror)
+        .function("copy", &OcctKernel::copy)
+
+        // Topology query
+        .function("getShapeType", &OcctKernel::getShapeType)
+        .function("getSubShapes", &OcctKernel::getSubShapes)
+        .function("distanceBetween", &OcctKernel::distanceBetween)
 
         // Tessellation
         .function("tessellate", &OcctKernel::tessellate)
+        .function("wireframe", &OcctKernel::wireframe)
 
         // I/O
         .function("importStep", &OcctKernel::importStep)
         .function("exportStep", &OcctKernel::exportStep)
+        .function("exportStl", &OcctKernel::exportStl)
 
         // Query
         .function("getBoundingBox", &OcctKernel::getBoundingBox)
         .function("getVolume", &OcctKernel::getVolume)
-        .function("getSurfaceArea", &OcctKernel::getSurfaceArea);
+        .function("getSurfaceArea", &OcctKernel::getSurfaceArea)
+
+        // Healing
+        .function("fixShape", &OcctKernel::fixShape)
+        .function("unifySameDomain", &OcctKernel::unifySameDomain);
 }

--- a/facade/src/construction.cpp
+++ b/facade/src/construction.cpp
@@ -1,0 +1,102 @@
+#include "occt_kernel.h"
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakeSolid.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepBuilderAPI_Sewing.hxx>
+#include <Standard_Failure.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Builder.hxx>
+#include <TopoDS_Compound.hxx>
+
+#include <stdexcept>
+#include <string>
+
+uint32_t OcctKernel::makeVertex(double x, double y, double z) {
+    try {
+        BRepBuilderAPI_MakeVertex maker(gp_Pnt(x, y, z));
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("makeVertex: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::makeEdge(uint32_t v1, uint32_t v2) {
+    try {
+        BRepBuilderAPI_MakeEdge maker(TopoDS::Vertex(get(v1)), TopoDS::Vertex(get(v2)));
+        if (!maker.IsDone()) {
+            throw std::runtime_error("makeEdge: construction failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("makeEdge: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::makeWire(std::vector<uint32_t> edgeIds) {
+    try {
+        BRepBuilderAPI_MakeWire maker;
+        for (uint32_t eid : edgeIds) {
+            maker.Add(TopoDS::Edge(get(eid)));
+        }
+        if (!maker.IsDone()) {
+            throw std::runtime_error("makeWire: construction failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("makeWire: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::makeFace(uint32_t wireId) {
+    try {
+        BRepBuilderAPI_MakeFace maker(TopoDS::Wire(get(wireId)));
+        if (!maker.IsDone()) {
+            throw std::runtime_error("makeFace: construction failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("makeFace: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::makeSolid(uint32_t shellId) {
+    try {
+        BRepBuilderAPI_MakeSolid maker(TopoDS::Shell(get(shellId)));
+        if (!maker.IsDone()) {
+            throw std::runtime_error("makeSolid: construction failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("makeSolid: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::sew(std::vector<uint32_t> shapeIds, double tolerance) {
+    try {
+        BRepBuilderAPI_Sewing sewer(tolerance);
+        for (uint32_t sid : shapeIds) {
+            sewer.Add(get(sid));
+        }
+        sewer.Perform();
+        return store(sewer.SewedShape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("sew: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::makeCompound(std::vector<uint32_t> shapeIds) {
+    try {
+        TopoDS_Compound compound;
+        TopoDS_Builder builder;
+        builder.MakeCompound(compound);
+        for (uint32_t sid : shapeIds) {
+            builder.Add(compound, get(sid));
+        }
+        return store(compound);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("makeCompound: ") + e.what());
+    }
+}

--- a/facade/src/healing.cpp
+++ b/facade/src/healing.cpp
@@ -1,0 +1,28 @@
+#include "occt_kernel.h"
+
+#include <ShapeFix_Shape.hxx>
+#include <ShapeUpgrade_UnifySameDomain.hxx>
+#include <Standard_Failure.hxx>
+
+#include <stdexcept>
+#include <string>
+
+uint32_t OcctKernel::fixShape(uint32_t id) {
+    try {
+        ShapeFix_Shape fixer(get(id));
+        fixer.Perform();
+        return store(fixer.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("fixShape: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::unifySameDomain(uint32_t id) {
+    try {
+        ShapeUpgrade_UnifySameDomain upgrader(get(id), true, true, false);
+        upgrader.Build();
+        return store(upgrader.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("unifySameDomain: ") + e.what());
+    }
+}

--- a/facade/src/io.cpp
+++ b/facade/src/io.cpp
@@ -6,6 +6,9 @@
 #include <STEPControl_Writer.hxx>
 #include <Standard_Failure.hxx>
 
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <StlAPI_Writer.hxx>
+
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -76,5 +79,37 @@ std::string OcctKernel::exportStep(uint32_t id) {
         return result;
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("exportStep: ") + e.what());
+    }
+}
+
+std::string OcctKernel::exportStl(uint32_t id, double linearDeflection) {
+    try {
+        const auto& shape = get(id);
+
+        // Mesh the shape first
+        BRepMesh_IncrementalMesh mesher(shape, linearDeflection, false, 0.5, false);
+
+        StlAPI_Writer writer;
+        writer.ASCIIMode() = false; // binary STL
+
+        const char* tmpPath = "/tmp/export.stl";
+        if (!writer.Write(shape, tmpPath)) {
+            throw std::runtime_error("exportStl: write failed");
+        }
+
+        FILE* f = fopen(tmpPath, "rb");
+        if (!f) {
+            throw std::runtime_error("exportStl: cannot read temp file");
+        }
+        fseek(f, 0, SEEK_END);
+        long size = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        std::string result(size, '\0');
+        fread(&result[0], 1, size, f);
+        fclose(f);
+
+        return result;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("exportStl: ") + e.what());
     }
 }

--- a/facade/src/kernel.cpp
+++ b/facade/src/kernel.cpp
@@ -71,3 +71,18 @@ void OcctKernel::releaseAll() {
 uint32_t OcctKernel::getShapeCount() const {
     return static_cast<uint32_t>(arena_.size());
 }
+
+// --- EdgeData implementation ---
+
+EdgeData::~EdgeData() {
+    std::free(points);
+}
+
+EdgeData::EdgeData(const EdgeData& other) : points(other.points), pointCount(other.pointCount) {
+    auto& mut = const_cast<EdgeData&>(other);
+    mut.points = nullptr;
+}
+
+int EdgeData::getPointsPtr() const {
+    return static_cast<int>(reinterpret_cast<uintptr_t>(points));
+}

--- a/facade/src/modeling.cpp
+++ b/facade/src/modeling.cpp
@@ -1,0 +1,143 @@
+#include "occt_kernel.h"
+
+#include <BRepAlgoAPI_Section.hxx>
+#include <BRepFilletAPI_MakeChamfer.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepOffsetAPI_DraftAngle.hxx>
+#include <BRepOffsetAPI_MakeOffsetShape.hxx>
+#include <BRepOffsetAPI_MakeThickSolid.hxx>
+#include <BRepOffset_Mode.hxx>
+#include <BRepPrimAPI_MakePrism.hxx>
+#include <BRepPrimAPI_MakeRevol.hxx>
+#include <NCollection_List.hxx>
+#include <Standard_Failure.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
+
+#include <stdexcept>
+#include <string>
+
+uint32_t OcctKernel::section(uint32_t a, uint32_t b) {
+    try {
+        BRepAlgoAPI_Section op(get(a), get(b));
+        op.Build();
+        if (!op.IsDone() || op.HasErrors()) {
+            throw std::runtime_error("section: operation failed");
+        }
+        return store(op.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("section: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::extrude(uint32_t shapeId, double dx, double dy, double dz) {
+    try {
+        BRepPrimAPI_MakePrism maker(get(shapeId), gp_Vec(dx, dy, dz));
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("extrude: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("extrude: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::revolve(uint32_t shapeId, double px, double py, double pz, double dx,
+                             double dy, double dz, double angleRad) {
+    try {
+        gp_Ax1 axis(gp_Pnt(px, py, pz), gp_Dir(dx, dy, dz));
+        BRepPrimAPI_MakeRevol maker(get(shapeId), axis, angleRad);
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("revolve: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("revolve: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::fillet(uint32_t solidId, std::vector<uint32_t> edgeIds, double radius) {
+    try {
+        BRepFilletAPI_MakeFillet maker(TopoDS::Solid(get(solidId)));
+        for (uint32_t eid : edgeIds) {
+            maker.Add(radius, TopoDS::Edge(get(eid)));
+        }
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("fillet: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("fillet: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::chamfer(uint32_t solidId, std::vector<uint32_t> edgeIds, double distance) {
+    try {
+        BRepFilletAPI_MakeChamfer maker(TopoDS::Solid(get(solidId)));
+        for (uint32_t eid : edgeIds) {
+            maker.Add(distance, TopoDS::Edge(get(eid)));
+        }
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("chamfer: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("chamfer: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::shell(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness) {
+    try {
+        NCollection_List<TopoDS_Shape> facesToRemove;
+        for (uint32_t fid : faceIds) {
+            facesToRemove.Append(get(fid));
+        }
+        BRepOffsetAPI_MakeThickSolid maker;
+        maker.MakeThickSolidByJoin(get(solidId), facesToRemove, thickness, 1e-3);
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("shell: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("shell: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::offset(uint32_t solidId, double distance) {
+    try {
+        BRepOffsetAPI_MakeOffsetShape maker;
+        maker.PerformByJoin(get(solidId), distance, 1e-3);
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("offset: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("offset: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::draft(uint32_t shapeId, uint32_t faceId, double angleRad, double dx, double dy,
+                           double dz) {
+    try {
+        gp_Dir pullDir(dx, dy, dz);
+        BRepOffsetAPI_DraftAngle maker(get(shapeId));
+        maker.Add(TopoDS::Face(get(faceId)), pullDir, angleRad, gp_Pln());
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("draft: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("draft: ") + e.what());
+    }
+}

--- a/facade/src/sweep.cpp
+++ b/facade/src/sweep.cpp
@@ -1,0 +1,38 @@
+#include "occt_kernel.h"
+
+#include <BRepOffsetAPI_MakePipe.hxx>
+#include <BRepOffsetAPI_ThruSections.hxx>
+#include <Standard_Failure.hxx>
+#include <TopoDS.hxx>
+
+#include <stdexcept>
+#include <string>
+
+uint32_t OcctKernel::pipe(uint32_t profileId, uint32_t spineId) {
+    try {
+        BRepOffsetAPI_MakePipe maker(TopoDS::Wire(get(spineId)), get(profileId));
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("pipe: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("pipe: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::loft(std::vector<uint32_t> wireIds, bool isSolid) {
+    try {
+        BRepOffsetAPI_ThruSections maker(isSolid);
+        for (uint32_t wid : wireIds) {
+            maker.AddWire(TopoDS::Wire(get(wid)));
+        }
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("loft: operation failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("loft: ") + e.what());
+    }
+}

--- a/facade/src/tessellate.cpp
+++ b/facade/src/tessellate.cpp
@@ -1,8 +1,10 @@
 #include "occt_kernel.h"
 
+#include <BRepAdaptor_Curve.hxx>
 #include <BRepLib_ToolTriangulatedShape.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <BRep_Tool.hxx>
+#include <GCPnts_TangentialDeflection.hxx>
 #include <NCollection_Vec3.hxx>
 #include <Poly_Triangulation.hxx>
 #include <Standard_Failure.hxx>
@@ -121,5 +123,47 @@ MeshData OcctKernel::tessellate(uint32_t id, double linearDeflection, double ang
         return result;
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("tessellate: ") + e.what());
+    }
+}
+
+EdgeData OcctKernel::wireframe(uint32_t id, double deflection) {
+    try {
+        const auto& shape = get(id);
+
+        // First pass: count points via GCPnts_TangentialDeflection per edge
+        std::vector<std::vector<gp_Pnt>> edgePoints;
+        int totalPoints = 0;
+
+        for (TopExp_Explorer ex(shape, TopAbs_EDGE); ex.More(); ex.Next()) {
+            BRepAdaptor_Curve curve(TopoDS::Edge(ex.Current()));
+            GCPnts_TangentialDeflection sampler(curve, deflection, 0.5);
+            std::vector<gp_Pnt> pts;
+            for (int i = 1; i <= sampler.NbPoints(); i++) {
+                pts.push_back(sampler.Value(i));
+            }
+            totalPoints += static_cast<int>(pts.size());
+            edgePoints.push_back(std::move(pts));
+        }
+
+        EdgeData result;
+        result.pointCount = totalPoints * 3;
+        result.points = static_cast<float*>(std::malloc(result.pointCount * sizeof(float)));
+        if (!result.points && result.pointCount > 0) {
+            throw std::runtime_error("wireframe: allocation failed");
+        }
+
+        int offset = 0;
+        for (const auto& pts : edgePoints) {
+            for (const auto& p : pts) {
+                result.points[offset + 0] = static_cast<float>(p.X());
+                result.points[offset + 1] = static_cast<float>(p.Y());
+                result.points[offset + 2] = static_cast<float>(p.Z());
+                offset += 3;
+            }
+        }
+
+        return result;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("wireframe: ") + e.what());
     }
 }

--- a/facade/src/topology.cpp
+++ b/facade/src/topology.cpp
@@ -1,0 +1,80 @@
+#include "occt_kernel.h"
+
+#include <BRepExtrema_DistShapeShape.hxx>
+#include <Standard_Failure.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+
+#include <stdexcept>
+#include <string>
+
+static TopAbs_ShapeEnum parseShapeType(const std::string& type) {
+    if (type == "vertex")
+        return TopAbs_VERTEX;
+    if (type == "edge")
+        return TopAbs_EDGE;
+    if (type == "wire")
+        return TopAbs_WIRE;
+    if (type == "face")
+        return TopAbs_FACE;
+    if (type == "shell")
+        return TopAbs_SHELL;
+    if (type == "solid")
+        return TopAbs_SOLID;
+    if (type == "compound")
+        return TopAbs_COMPOUND;
+    throw std::runtime_error("Unknown shape type: " + type);
+}
+
+static std::string shapeTypeToString(TopAbs_ShapeEnum type) {
+    switch (type) {
+    case TopAbs_VERTEX:
+        return "vertex";
+    case TopAbs_EDGE:
+        return "edge";
+    case TopAbs_WIRE:
+        return "wire";
+    case TopAbs_FACE:
+        return "face";
+    case TopAbs_SHELL:
+        return "shell";
+    case TopAbs_SOLID:
+        return "solid";
+    case TopAbs_COMPSOLID:
+        return "compsolid";
+    case TopAbs_COMPOUND:
+        return "compound";
+    default:
+        return "shape";
+    }
+}
+
+std::string OcctKernel::getShapeType(uint32_t id) {
+    return shapeTypeToString(get(id).ShapeType());
+}
+
+std::vector<uint32_t> OcctKernel::getSubShapes(uint32_t id, const std::string& shapeType) {
+    try {
+        TopAbs_ShapeEnum toExplore = parseShapeType(shapeType);
+        std::vector<uint32_t> result;
+        for (TopExp_Explorer ex(get(id), toExplore); ex.More(); ex.Next()) {
+            result.push_back(store(ex.Current()));
+        }
+        return result;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("getSubShapes: ") + e.what());
+    }
+}
+
+double OcctKernel::distanceBetween(uint32_t a, uint32_t b) {
+    try {
+        BRepExtrema_DistShapeShape dist(get(a), get(b));
+        if (!dist.IsDone()) {
+            throw std::runtime_error("distanceBetween: computation failed");
+        }
+        return dist.Value();
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("distanceBetween: ") + e.what());
+    }
+}

--- a/facade/src/transforms.cpp
+++ b/facade/src/transforms.cpp
@@ -1,0 +1,69 @@
+#include "occt_kernel.h"
+
+#include <BRepBuilderAPI_Copy.hxx>
+#include <BRepBuilderAPI_GTransform.hxx>
+#include <BRepBuilderAPI_Transform.hxx>
+#include <Standard_Failure.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Trsf.hxx>
+
+#include <stdexcept>
+#include <string>
+
+uint32_t OcctKernel::translate(uint32_t id, double dx, double dy, double dz) {
+    try {
+        gp_Trsf trsf;
+        trsf.SetTranslation(gp_Vec(dx, dy, dz));
+        BRepBuilderAPI_Transform maker(get(id), trsf, true);
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("translate: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::rotate(uint32_t id, double px, double py, double pz, double dx, double dy,
+                            double dz, double angleRad) {
+    try {
+        gp_Trsf trsf;
+        trsf.SetRotation(gp_Ax1(gp_Pnt(px, py, pz), gp_Dir(dx, dy, dz)), angleRad);
+        BRepBuilderAPI_Transform maker(get(id), trsf, true);
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("rotate: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::scale(uint32_t id, double px, double py, double pz, double factor) {
+    try {
+        gp_Trsf trsf;
+        trsf.SetScale(gp_Pnt(px, py, pz), factor);
+        BRepBuilderAPI_Transform maker(get(id), trsf, true);
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("scale: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::mirror(uint32_t id, double px, double py, double pz, double nx, double ny,
+                            double nz) {
+    try {
+        gp_Trsf trsf;
+        trsf.SetMirror(gp_Ax2(gp_Pnt(px, py, pz), gp_Dir(nx, ny, nz)));
+        BRepBuilderAPI_Transform maker(get(id), trsf, true);
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("mirror: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::copy(uint32_t id) {
+    try {
+        BRepBuilderAPI_Copy maker(get(id));
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("copy: ") + e.what());
+    }
+}


### PR DESCRIPTION
## Summary
24 new methods across 6 new C++ files:
- **Modeling**: extrude, revolve, fillet, chamfer, shell, offset, draft, section
- **Sweeps**: pipe, loft
- **Construction**: makeVertex/Edge/Wire/Face/Solid, sew, makeCompound
- **Transforms**: translate, rotate, scale, mirror, copy
- **Topology**: getShapeType, getSubShapes, distanceBetween
- **I/O**: exportStl (binary)
- **Tessellation**: wireframe (edge sampling)
- **Healing**: fixShape, unifySameDomain

## Numbers
- Total facade methods: **40** (was 16)
- WASM size: **17.1MB** (was 11.5MB)
- All 16 existing tests pass