### PR TITLE
fix(ci): use correct rust-toolchain action syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.85
+        uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: "1.85"
           components: rustfmt, clippy
 
       - name: Rust cache

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
+    "lib": ["ES2022", "ESNext.Disposable", "DOM"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "declaration": true,


### PR DESCRIPTION
Fixes rustfmt/clippy not installed in CI.