### PR TITLE
feat(facade): phase 1 core gaps for brepjs kernel adapter

### DIFF
--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -71,6 +71,9 @@ class OcctKernel {
     uint32_t cut(uint32_t a, uint32_t b);
     uint32_t common(uint32_t a, uint32_t b);
     uint32_t section(uint32_t a, uint32_t b);
+    uint32_t fuseAll(std::vector<uint32_t> shapeIds);
+    uint32_t cutAll(uint32_t shapeId, std::vector<uint32_t> toolIds);
+    uint32_t split(uint32_t shapeId, std::vector<uint32_t> toolIds);
 
     // --- Modeling operations ---
     uint32_t extrude(uint32_t shapeId, double dx, double dy, double dz);
@@ -108,6 +111,12 @@ class OcctKernel {
     std::string getShapeType(uint32_t id);
     std::vector<uint32_t> getSubShapes(uint32_t id, const std::string& shapeType);
     double distanceBetween(uint32_t a, uint32_t b);
+    bool isSame(uint32_t a, uint32_t b);
+    bool isEqual(uint32_t a, uint32_t b);
+    bool isNull(uint32_t id);
+    int hashCode(uint32_t id, int upperBound);
+    std::string shapeOrientation(uint32_t id);
+    std::vector<uint32_t> sharedEdges(uint32_t faceA, uint32_t faceB);
 
     // --- Tessellation ---
     MeshData tessellate(uint32_t id, double linearDeflection, double angularDeflection);
@@ -117,11 +126,22 @@ class OcctKernel {
     uint32_t importStep(const std::string& data);
     std::string exportStep(uint32_t id);
     std::string exportStl(uint32_t id, double linearDeflection);
+    std::string toBREP(uint32_t id);
+    uint32_t fromBREP(const std::string& data);
 
     // --- Query ---
     BBoxData getBoundingBox(uint32_t id);
     double getVolume(uint32_t id);
     double getSurfaceArea(uint32_t id);
+    double getLength(uint32_t id);
+    std::vector<double> getCenterOfMass(uint32_t id);
+
+    // --- Vertex/surface query ---
+    std::vector<double> vertexPosition(uint32_t vertexId);
+    std::string surfaceType(uint32_t faceId);
+    std::vector<double> surfaceNormal(uint32_t faceId, double u, double v);
+    std::vector<double> pointOnSurface(uint32_t faceId, double u, double v);
+    uint32_t outerWire(uint32_t faceId);
 
     // --- Healing ---
     uint32_t fixShape(uint32_t id);

--- a/facade/src/bindings.cpp
+++ b/facade/src/bindings.cpp
@@ -29,6 +29,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
 
     // Vector types for Embind
     register_vector<uint32_t>("VectorUint32");
+    register_vector<double>("VectorDouble");
 
     // OcctKernel
     class_<OcctKernel>("OcctKernel")
@@ -51,6 +52,9 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("cut", &OcctKernel::cut)
         .function("common", &OcctKernel::common)
         .function("section", &OcctKernel::section)
+        .function("fuseAll", &OcctKernel::fuseAll)
+        .function("cutAll", &OcctKernel::cutAll)
+        .function("split", &OcctKernel::split)
 
         // Modeling
         .function("extrude", &OcctKernel::extrude)
@@ -85,6 +89,12 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("getShapeType", &OcctKernel::getShapeType)
         .function("getSubShapes", &OcctKernel::getSubShapes)
         .function("distanceBetween", &OcctKernel::distanceBetween)
+        .function("isSame", &OcctKernel::isSame)
+        .function("isEqual", &OcctKernel::isEqual)
+        .function("isNull", &OcctKernel::isNull)
+        .function("hashCode", &OcctKernel::hashCode)
+        .function("shapeOrientation", &OcctKernel::shapeOrientation)
+        .function("sharedEdges", &OcctKernel::sharedEdges)
 
         // Tessellation
         .function("tessellate", &OcctKernel::tessellate)
@@ -94,11 +104,22 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("importStep", &OcctKernel::importStep)
         .function("exportStep", &OcctKernel::exportStep)
         .function("exportStl", &OcctKernel::exportStl)
+        .function("toBREP", &OcctKernel::toBREP)
+        .function("fromBREP", &OcctKernel::fromBREP)
 
         // Query
         .function("getBoundingBox", &OcctKernel::getBoundingBox)
         .function("getVolume", &OcctKernel::getVolume)
         .function("getSurfaceArea", &OcctKernel::getSurfaceArea)
+        .function("getLength", &OcctKernel::getLength)
+        .function("getCenterOfMass", &OcctKernel::getCenterOfMass)
+
+        // Vertex/surface query
+        .function("vertexPosition", &OcctKernel::vertexPosition)
+        .function("surfaceType", &OcctKernel::surfaceType)
+        .function("surfaceNormal", &OcctKernel::surfaceNormal)
+        .function("pointOnSurface", &OcctKernel::pointOnSurface)
+        .function("outerWire", &OcctKernel::outerWire)
 
         // Healing
         .function("fixShape", &OcctKernel::fixShape)

--- a/facade/src/booleans.cpp
+++ b/facade/src/booleans.cpp
@@ -1,9 +1,13 @@
 #include "occt_kernel.h"
 
+#include <BRepAlgoAPI_BuilderAlgo.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <BRepAlgoAPI_Cut.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
+#include <BRepAlgoAPI_Splitter.hxx>
+#include <NCollection_List.hxx>
 #include <Standard_Failure.hxx>
+#include <TopoDS_Shape.hxx>
 
 #include <stdexcept>
 #include <string>
@@ -50,5 +54,78 @@ uint32_t OcctKernel::common(uint32_t a, uint32_t b) {
         return store(op.Shape());
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("common: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::fuseAll(std::vector<uint32_t> shapeIds) {
+    try {
+        if (shapeIds.empty()) {
+            throw std::runtime_error("fuseAll: no shapes provided");
+        }
+        if (shapeIds.size() == 1) {
+            return store(get(shapeIds[0]));
+        }
+        NCollection_List<TopoDS_Shape> args;
+        for (uint32_t sid : shapeIds) {
+            args.Append(get(sid));
+        }
+        BRepAlgoAPI_BuilderAlgo builder;
+        builder.SetArguments(args);
+        builder.SetRunParallel(true);
+        builder.SetUseOBB(true);
+        builder.Build();
+        if (!builder.IsDone() || builder.HasErrors()) {
+            throw std::runtime_error("fuseAll: operation failed");
+        }
+        return store(builder.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("fuseAll: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::cutAll(uint32_t shapeId, std::vector<uint32_t> toolIds) {
+    try {
+        if (toolIds.empty()) {
+            return store(get(shapeId));
+        }
+        NCollection_List<TopoDS_Shape> args;
+        args.Append(get(shapeId));
+        NCollection_List<TopoDS_Shape> tools;
+        for (uint32_t tid : toolIds) {
+            tools.Append(get(tid));
+        }
+        BRepAlgoAPI_Cut cutter;
+        cutter.SetArguments(args);
+        cutter.SetTools(tools);
+        cutter.SetRunParallel(true);
+        cutter.SetUseOBB(true);
+        cutter.Build();
+        if (!cutter.IsDone() || cutter.HasErrors()) {
+            throw std::runtime_error("cutAll: operation failed");
+        }
+        return store(cutter.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("cutAll: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::split(uint32_t shapeId, std::vector<uint32_t> toolIds) {
+    try {
+        NCollection_List<TopoDS_Shape> args;
+        args.Append(get(shapeId));
+        NCollection_List<TopoDS_Shape> tools;
+        for (uint32_t tid : toolIds) {
+            tools.Append(get(tid));
+        }
+        BRepAlgoAPI_Splitter splitter;
+        splitter.SetArguments(args);
+        splitter.SetTools(tools);
+        splitter.Build();
+        if (!splitter.IsDone() || splitter.HasErrors()) {
+            throw std::runtime_error("split: operation failed");
+        }
+        return store(splitter.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("split: ") + e.what());
     }
 }

--- a/facade/src/io.cpp
+++ b/facade/src/io.cpp
@@ -7,6 +7,9 @@
 #include <Standard_Failure.hxx>
 
 #include <BRepMesh_IncrementalMesh.hxx>
+#include <BRepTools.hxx>
+#include <BRep_Builder.hxx>
+#include <Message_ProgressRange.hxx>
 #include <StlAPI_Writer.hxx>
 
 #include <sstream>
@@ -111,5 +114,32 @@ std::string OcctKernel::exportStl(uint32_t id, double linearDeflection) {
         return result;
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("exportStl: ") + e.what());
+    }
+}
+
+std::string OcctKernel::toBREP(uint32_t id) {
+    try {
+        std::ostringstream oss(std::ios::binary);
+        oss << std::setprecision(17);
+        BRepTools::Write(get(id), oss);
+        return oss.str();
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("toBREP: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::fromBREP(const std::string& data) {
+    try {
+        std::istringstream iss(data, std::ios::binary);
+        TopoDS_Shape shape;
+        BRep_Builder builder;
+        Message_ProgressRange progress;
+        BRepTools::Read(shape, iss, builder, progress);
+        if (shape.IsNull()) {
+            throw std::runtime_error("fromBREP: failed to read shape");
+        }
+        return store(shape);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("fromBREP: ") + e.what());
     }
 }

--- a/facade/src/query.cpp
+++ b/facade/src/query.cpp
@@ -1,10 +1,18 @@
 #include "occt_kernel.h"
 
+#include <BRepAdaptor_Surface.hxx>
 #include <BRepBndLib.hxx>
 #include <BRepGProp.hxx>
+#include <BRep_Tool.hxx>
 #include <Bnd_Box.hxx>
 #include <GProp_GProps.hxx>
+#include <GeomAbs_SurfaceType.hxx>
+#include <ShapeAnalysis.hxx>
 #include <Standard_Failure.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
 
 #include <stdexcept>
 #include <string>
@@ -44,5 +52,107 @@ double OcctKernel::getSurfaceArea(uint32_t id) {
         return props.Mass();
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("getSurfaceArea: ") + e.what());
+    }
+}
+
+double OcctKernel::getLength(uint32_t id) {
+    try {
+        const auto& shape = get(id);
+        GProp_GProps props;
+        BRepGProp::LinearProperties(shape, props);
+        return props.Mass();
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("getLength: ") + e.what());
+    }
+}
+
+std::vector<double> OcctKernel::getCenterOfMass(uint32_t id) {
+    try {
+        const auto& shape = get(id);
+        GProp_GProps props;
+        BRepGProp::VolumeProperties(shape, props);
+        gp_Pnt com = props.CentreOfMass();
+        return {com.X(), com.Y(), com.Z()};
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("getCenterOfMass: ") + e.what());
+    }
+}
+
+std::vector<double> OcctKernel::vertexPosition(uint32_t vertexId) {
+    try {
+        gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(get(vertexId)));
+        return {p.X(), p.Y(), p.Z()};
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("vertexPosition: ") + e.what());
+    }
+}
+
+std::string OcctKernel::surfaceType(uint32_t faceId) {
+    try {
+        BRepAdaptor_Surface surf(TopoDS::Face(get(faceId)));
+        switch (surf.GetType()) {
+        case GeomAbs_Plane:
+            return "plane";
+        case GeomAbs_Cylinder:
+            return "cylinder";
+        case GeomAbs_Cone:
+            return "cone";
+        case GeomAbs_Sphere:
+            return "sphere";
+        case GeomAbs_Torus:
+            return "torus";
+        case GeomAbs_BezierSurface:
+            return "bezier";
+        case GeomAbs_BSplineSurface:
+            return "bspline";
+        case GeomAbs_SurfaceOfRevolution:
+            return "revolution";
+        case GeomAbs_SurfaceOfExtrusion:
+            return "extrusion";
+        case GeomAbs_OffsetSurface:
+            return "offset";
+        default:
+            return "other";
+        }
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("surfaceType: ") + e.what());
+    }
+}
+
+std::vector<double> OcctKernel::surfaceNormal(uint32_t faceId, double u, double v) {
+    try {
+        BRepAdaptor_Surface surf(TopoDS::Face(get(faceId)));
+        gp_Pnt pt;
+        gp_Vec d1u, d1v;
+        surf.D1(u, v, pt, d1u, d1v);
+        gp_Vec normal = d1u.Crossed(d1v);
+        if (normal.Magnitude() > 1e-10) {
+            normal.Normalize();
+        }
+        return {normal.X(), normal.Y(), normal.Z()};
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("surfaceNormal: ") + e.what());
+    }
+}
+
+std::vector<double> OcctKernel::pointOnSurface(uint32_t faceId, double u, double v) {
+    try {
+        BRepAdaptor_Surface surf(TopoDS::Face(get(faceId)));
+        gp_Pnt pt = surf.Value(u, v);
+        return {pt.X(), pt.Y(), pt.Z()};
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("pointOnSurface: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::outerWire(uint32_t faceId) {
+    try {
+        TopoDS_Wire wire = ShapeAnalysis::OuterWire(TopoDS::Face(get(faceId)));
+        if (wire.IsNull()) {
+            throw std::runtime_error("outerWire: face has no outer wire");
+        }
+        return store(wire);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("outerWire: ") + e.what());
     }
 }

--- a/facade/src/topology.cpp
+++ b/facade/src/topology.cpp
@@ -1,9 +1,13 @@
 #include "occt_kernel.h"
 
 #include <BRepExtrema_DistShapeShape.hxx>
+#include <BRep_Tool.hxx>
 #include <Standard_Failure.hxx>
+#include <TopAbs_Orientation.hxx>
 #include <TopAbs_ShapeEnum.hxx>
+#include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
 #include <TopoDS.hxx>
 
 #include <stdexcept>
@@ -76,5 +80,55 @@ double OcctKernel::distanceBetween(uint32_t a, uint32_t b) {
         return dist.Value();
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("distanceBetween: ") + e.what());
+    }
+}
+
+bool OcctKernel::isSame(uint32_t a, uint32_t b) {
+    return get(a).IsSame(get(b));
+}
+
+bool OcctKernel::isEqual(uint32_t a, uint32_t b) {
+    return get(a).IsEqual(get(b));
+}
+
+bool OcctKernel::isNull(uint32_t id) {
+    return get(id).IsNull();
+}
+
+int OcctKernel::hashCode(uint32_t id, int upperBound) {
+    return static_cast<int>(TopTools_ShapeMapHasher{}(get(id)) % static_cast<size_t>(upperBound));
+}
+
+std::string OcctKernel::shapeOrientation(uint32_t id) {
+    switch (get(id).Orientation()) {
+    case TopAbs_FORWARD:
+        return "forward";
+    case TopAbs_REVERSED:
+        return "reversed";
+    case TopAbs_INTERNAL:
+        return "internal";
+    case TopAbs_EXTERNAL:
+        return "external";
+    default:
+        return "unknown";
+    }
+}
+
+std::vector<uint32_t> OcctKernel::sharedEdges(uint32_t faceA, uint32_t faceB) {
+    try {
+        const auto& fa = get(faceA);
+        const auto& fb = get(faceB);
+        std::vector<uint32_t> result;
+        for (TopExp_Explorer exA(fa, TopAbs_EDGE); exA.More(); exA.Next()) {
+            for (TopExp_Explorer exB(fb, TopAbs_EDGE); exB.More(); exB.Next()) {
+                if (exA.Current().IsSame(exB.Current())) {
+                    result.push_back(store(exA.Current()));
+                    break;
+                }
+            }
+        }
+        return result;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("sharedEdges: ") + e.what());
     }
 }


### PR DESCRIPTION
## Summary
17 new facade methods for brepjs KernelAdapter compatibility:
- Booleans: fuseAll, cutAll, split
- Topology: isSame, isEqual, isNull, hashCode, shapeOrientation, sharedEdges
- Measure: getLength, getCenterOfMass
- Surface: vertexPosition, surfaceType, surfaceNormal, pointOnSurface, outerWire
- I/O: toBREP, fromBREP

Coverage: **57/188** KernelAdapter methods (30%)
All 37 tests pass. WASM: 17.1MB.