### PR TITLE
chore: publish script improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build:occt": "cargo xtask build-occt",
     "test": "cd ts && npx vitest run",
     "lint": "cd ts && npx eslint src/",
-    "typecheck": "cd ts && npx tsc --noEmit"
+    "typecheck": "cd ts && npx tsc --noEmit",
+    "publish:dry": "./scripts/publish.sh --dry-run",
+    "publish:npm": "./scripts/publish.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^19",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -40,10 +40,11 @@ echo "Running tests..."
 npx vitest run
 
 # Publish
+PUBLISH_ARGS="--access public --provenance=false"
 if [ "${1:-}" = "--dry-run" ]; then
   echo "Dry run — skipping publish."
-  npm publish --dry-run --access public
+  npm publish --dry-run $PUBLISH_ARGS
 else
-  npm publish --access public
+  npm publish $PUBLISH_ARGS
   echo "Published @occt-wasm/core@$VERSION"
 fi

--- a/ts/package.json
+++ b/ts/package.json
@@ -32,7 +32,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/andymai/occt-wasm.git",
+    "url": "git+https://github.com/andymai/occt-wasm.git",
     "directory": "ts"
   },
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## Summary
- Add `npm run publish:dry` and `npm run publish:npm` root scripts for convenience
- Fix `--provenance` flag that breaks local publishes (only works in CI with OIDC)
- Normalize repository URL in ts/package.json to suppress npm publish warning

## Context
First npm publish of `occt-wasm@0.1.6` completed successfully. These fixes address issues encountered during the publish.