### PR TITLE
feat(ts): FinalizationRegistry safety net for leaked kernels

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -171,11 +171,26 @@ function wrap<T>(operation: string, fn: () => T): T {
 }
 
 /**
+ * Safety net: releases the raw Embind kernel if an OcctKernel instance is
+ * garbage-collected without being disposed. Prefer `using` or explicit
+ * `kernel[Symbol.dispose]()` — the FinalizationRegistry is a last resort.
+ */
+const kernelRegistry = new FinalizationRegistry<RawKernel>((raw) => {
+    try {
+        raw.releaseAll();
+        raw.delete();
+    } catch {
+        // Already disposed — ignore.
+    }
+});
+
+/**
  * OCCT kernel compiled to WASM. Arena-based shape management
  * with branded handle types for type safety.
  *
  * Create via `OcctKernel.init()`. Dispose via `kernel[Symbol.dispose]()` or
- * the `using` keyword.
+ * the `using` keyword. A FinalizationRegistry safety net catches leaked
+ * instances, but deterministic disposal is strongly preferred.
  */
 export class OcctKernel {
     readonly #raw: RawKernel;
@@ -184,6 +199,7 @@ export class OcctKernel {
     private constructor(module: EmscriptenModule) {
         this.#module = module;
         this.#raw = new module.OcctKernel();
+        kernelRegistry.register(this, this.#raw, this);
     }
 
     /**
@@ -557,6 +573,7 @@ export class OcctKernel {
     }
 
     [Symbol.dispose](): void {
+        kernelRegistry.unregister(this);
         this.#raw.releaseAll();
         this.#raw.delete();
     }


### PR DESCRIPTION
## Summary
- Adds a `FinalizationRegistry` that catches leaked `OcctKernel` instances
- If an `OcctKernel` is GC'd without being disposed, the registry calls `releaseAll()` + `delete()` on the underlying Embind object
- On explicit `Symbol.dispose`, unregisters from the registry to prevent double-free
- Primary disposal mechanism remains `using` / `Symbol.dispose` — this is a last-resort safety net

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 45 integration tests pass
- [x] Existing `Symbol.dispose` tests verify unregister path