### PR TITLE
docs: add npm install instructions, fix package name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,20 +4,20 @@ OCCT-to-WASM build pipeline. Compiles OpenCascade C++ to WebAssembly with a clea
 
 ## Architecture
 
-Emscripten compiles OCCT C++ to WASM. A hand-written C++ facade (`OcctKernel` class) wraps OCCT with an arena-based API (u32 shape IDs). Embind bridges C++ to JS. A TypeScript wrapper (`@occt-wasm/core`) provides the public API.
+Emscripten compiles OCCT C++ to WASM. A hand-written C++ facade (`OcctKernel` class) wraps OCCT with an arena-based API (u32 shape IDs). Embind bridges C++ to JS. A TypeScript wrapper (`occt-wasm`) provides the public API.
 
 ```
 OCCT C++ (submodule) → emcmake cmake → static libs
 C++ facade (facade/)  → emcc → .o files
 Link (static libs + facade) → emcc -lembind → .wasm + .js
 Post-optimize → wasm-opt -O4 → dist/
-TS wrapper (ts/) → tsc → @occt-wasm/core
+TS wrapper (ts/) → tsc → occt-wasm
 ```
 
 ## Repo Layout
 
 - `facade/` — C++ facade (OcctKernel class + Embind bindings)
-- `ts/` — TypeScript wrapper (@occt-wasm/core npm package)
+- `ts/` — TypeScript wrapper (occt-wasm npm package)
 - `xtask/` — Rust build orchestration (clap + anyhow + xshell)
 - `occt/` — OCCT V8.0.0-rc4 (git submodule)
 - `3rdparty/` — Isolated third-party headers (RapidJSON for glTF, gitignored)

--- a/README.md
+++ b/README.md
@@ -9,30 +9,18 @@ A better OCCT-to-WASM compilation pipeline. Compiles [OpenCascade](https://www.o
 - **Arena-based API** — u32 shape handles, no manual `.delete()`, `Symbol.dispose` support
 - **TypeScript-first** — branded `ShapeHandle` type, `OcctError` with operation context
 
-## Quick Start
+## Install
 
 ```bash
-# Prerequisites: Rust 1.85+, emsdk 5.0.3 (or Docker)
-
-git clone --recurse-submodules https://github.com/andymai/occt-wasm
-cd occt-wasm
-npm install && cd ts && npm install && cd ..
-
-# Build OCCT + facade → WASM
-cargo xtask build
-
-# Run tests
-cargo xtask test
-
-# View the Three.js example
-npx serve .
-# Open http://localhost:3000/examples/three-js/
+npm install occt-wasm
 ```
 
-## API
+## Quick Start
 
 ```typescript
-const kernel = new Module.OcctKernel();
+import { OcctKernel } from 'occt-wasm';
+
+const kernel = await OcctKernel.init();
 
 // Create shapes
 const box = kernel.makeBox(20, 20, 20);
@@ -65,6 +53,29 @@ const bbox = kernel.getBoundingBox(shape);
 // Memory management
 kernel.release(shape);
 kernel.releaseAll();
+
+// Deterministic cleanup (recommended)
+{
+  using k = await OcctKernel.init();
+  const box = k.makeBox(10, 10, 10);
+  // k is disposed at end of block
+}
+```
+
+## Building from Source
+
+```bash
+# Prerequisites: Rust 1.85+, emsdk 5.0.3
+git clone --recurse-submodules https://github.com/andymai/occt-wasm
+cd occt-wasm
+npm install && cd ts && npm install && cd ..
+
+cargo xtask build       # Build OCCT + facade → WASM
+cargo xtask test        # Run tests
+
+# View the Three.js example
+npx serve .
+# Open http://localhost:3000/examples/three-js/
 ```
 
 ## All 40 Methods

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Publish @occt-wasm/core to npm from a local release build.
+# Publish occt-wasm to npm from a local release build.
 # Usage: ./scripts/publish.sh [--dry-run]
 set -euo pipefail
 
@@ -25,7 +25,7 @@ if [ "$VERSION" != "$PKG_VERSION" ]; then
   exit 1
 fi
 
-echo "Publishing @occt-wasm/core@$VERSION from tag $TAG"
+echo "Publishing occt-wasm@$VERSION from tag $TAG"
 
 # Build
 echo "Building WASM (release)..."
@@ -46,5 +46,5 @@ if [ "${1:-}" = "--dry-run" ]; then
   npm publish --dry-run $PUBLISH_ARGS
 else
   npm publish $PUBLISH_ARGS
-  echo "Published @occt-wasm/core@$VERSION"
+  echo "Published occt-wasm@$VERSION"
 fi

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * @occt-wasm/core — OCCT compiled to WASM with clean TypeScript bindings.
+ * occt-wasm — OCCT compiled to WASM with clean TypeScript bindings.
  *
  * @example
  * ```ts
- * import { OcctKernel } from '@occt-wasm/core';
+ * import { OcctKernel } from 'occt-wasm';
  *
  * const kernel = await OcctKernel.init();
  * const box = kernel.makeBox(10, 20, 30);
@@ -212,7 +212,7 @@ export class OcctKernel {
      *
      * // Node.js with explicit path:
      * const kernel = await OcctKernel.init({
-     *   wasmPath: './node_modules/@occt-wasm/core/dist/occt-wasm.wasm'
+     *   wasmPath: './node_modules/occt-wasm/dist/occt-wasm.wasm'
      * });
      * ```
      */


### PR DESCRIPTION
## Summary
- Lead README with `npm install occt-wasm` now that package is published
- Add `Symbol.dispose`/`using` example, move build-from-source to own section
- Replace stale `@occt-wasm/core` references with `occt-wasm` in CLAUDE.md, publish.sh, TS source, and Obsidian docs

## Context
The npm package was published as `occt-wasm` (unscoped), but docs still referenced the old `@occt-wasm/core` name from early planning.