### PR TITLE
feat(xtask): facade code generator v0.1.1

### DIFF
--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -1,0 +1,387 @@
+//! Declarative method configuration for the facade code generator.
+//!
+//! Each entry in [`TARGET_METHODS`] describes one `OcctKernel` method that
+//! can be auto-generated from a template. Methods with complex multi-step
+//! logic are marked [`MethodKind::Skip`] and remain hand-written.
+
+use super::types::{FacadeParam, MethodKind, MethodSpec, ReturnType};
+
+/// All facade methods that the code generator knows about.
+///
+/// Methods marked [`MethodKind::Skip`] are listed for completeness but
+/// will not produce generated code.
+static TARGET_METHODS: &[MethodSpec] = &[
+    // ── Primitives ──────────────────────────────────────────────────
+    MethodSpec {
+        name: "makeBox",
+        kind: MethodKind::SimpleShape,
+        params: &[
+            FacadeParam::Double("dx"),
+            FacadeParam::Double("dy"),
+            FacadeParam::Double("dz"),
+        ],
+        occt_class: "BRepPrimAPI_MakeBox",
+        ctor_args: "dx, dy, dz",
+        includes: &[],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "makeBoxFromCorners",
+        kind: MethodKind::SimpleShape,
+        params: &[
+            FacadeParam::Double("x1"),
+            FacadeParam::Double("y1"),
+            FacadeParam::Double("z1"),
+            FacadeParam::Double("x2"),
+            FacadeParam::Double("y2"),
+            FacadeParam::Double("z2"),
+        ],
+        occt_class: "BRepPrimAPI_MakeBox",
+        ctor_args: "gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2)",
+        includes: &["gp_Pnt.hxx"],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "makeCylinder",
+        kind: MethodKind::SimpleShape,
+        params: &[FacadeParam::Double("radius"), FacadeParam::Double("height")],
+        occt_class: "BRepPrimAPI_MakeCylinder",
+        ctor_args: "radius, height",
+        includes: &[],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "makeSphere",
+        kind: MethodKind::SimpleShape,
+        params: &[FacadeParam::Double("radius")],
+        occt_class: "BRepPrimAPI_MakeSphere",
+        ctor_args: "radius",
+        includes: &[],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "makeCone",
+        kind: MethodKind::SimpleShape,
+        params: &[
+            FacadeParam::Double("r1"),
+            FacadeParam::Double("r2"),
+            FacadeParam::Double("height"),
+        ],
+        occt_class: "BRepPrimAPI_MakeCone",
+        ctor_args: "r1, r2, height",
+        includes: &[],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "makeTorus",
+        kind: MethodKind::SimpleShape,
+        params: &[
+            FacadeParam::Double("majorRadius"),
+            FacadeParam::Double("minorRadius"),
+        ],
+        occt_class: "BRepPrimAPI_MakeTorus",
+        ctor_args: "majorRadius, minorRadius",
+        includes: &[],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "makeEllipsoid",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "makeRectangle",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    // ── Booleans ────────────────────────────────────────────────────
+    MethodSpec {
+        name: "fuse",
+        kind: MethodKind::BooleanOp,
+        params: &[FacadeParam::ShapeId("a"), FacadeParam::ShapeId("b")],
+        occt_class: "BRepAlgoAPI_Fuse",
+        ctor_args: "get(a), get(b)",
+        includes: &[],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "cut",
+        kind: MethodKind::BooleanOp,
+        params: &[FacadeParam::ShapeId("a"), FacadeParam::ShapeId("b")],
+        occt_class: "BRepAlgoAPI_Cut",
+        ctor_args: "get(a), get(b)",
+        includes: &[],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "common",
+        kind: MethodKind::BooleanOp,
+        params: &[FacadeParam::ShapeId("a"), FacadeParam::ShapeId("b")],
+        occt_class: "BRepAlgoAPI_Common",
+        ctor_args: "get(a), get(b)",
+        includes: &[],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "section",
+        kind: MethodKind::BooleanOp,
+        params: &[FacadeParam::ShapeId("a"), FacadeParam::ShapeId("b")],
+        occt_class: "BRepAlgoAPI_Section",
+        ctor_args: "get(a), get(b)",
+        includes: &[],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "intersect",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "fuseAll",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "cutAll",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "split",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    // ── Modeling ────────────────────────────────────────────────────
+    MethodSpec {
+        name: "extrude",
+        kind: MethodKind::SimpleShape,
+        params: &[
+            FacadeParam::ShapeId("shapeId"),
+            FacadeParam::Double("dx"),
+            FacadeParam::Double("dy"),
+            FacadeParam::Double("dz"),
+        ],
+        occt_class: "BRepPrimAPI_MakePrism",
+        ctor_args: "get(shapeId), gp_Vec(dx, dy, dz)",
+        includes: &["gp_Vec.hxx"],
+        category: "modeling",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "revolve",
+        kind: MethodKind::SimpleShape,
+        params: &[
+            FacadeParam::ShapeId("shapeId"),
+            FacadeParam::Double("px"),
+            FacadeParam::Double("py"),
+            FacadeParam::Double("pz"),
+            FacadeParam::Double("dx"),
+            FacadeParam::Double("dy"),
+            FacadeParam::Double("dz"),
+            FacadeParam::Double("angleRad"),
+        ],
+        occt_class: "BRepPrimAPI_MakeRevol",
+        ctor_args: "get(shapeId), gp_Ax1(gp_Pnt(px, py, pz), gp_Dir(dx, dy, dz)), angleRad",
+        includes: &["gp_Ax1.hxx", "gp_Dir.hxx", "gp_Pnt.hxx"],
+        category: "modeling",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "fillet",
+        kind: MethodKind::FilletLike,
+        params: &[
+            FacadeParam::ShapeId("solidId"),
+            FacadeParam::VectorShapeIds("edgeIds"),
+            FacadeParam::Double("radius"),
+        ],
+        occt_class: "BRepFilletAPI_MakeFillet",
+        ctor_args: "TopoDS::Solid(get(solidId))",
+        includes: &["TopoDS.hxx"],
+        category: "modeling",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "chamfer",
+        kind: MethodKind::FilletLike,
+        params: &[
+            FacadeParam::ShapeId("solidId"),
+            FacadeParam::VectorShapeIds("edgeIds"),
+            FacadeParam::Double("distance"),
+        ],
+        occt_class: "BRepFilletAPI_MakeChamfer",
+        ctor_args: "TopoDS::Solid(get(solidId))",
+        includes: &["TopoDS.hxx"],
+        category: "modeling",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "shell",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "modeling",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "offset",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "modeling",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "draft",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "modeling",
+        return_type: ReturnType::ShapeId,
+    },
+    // ── Transforms (all skipped — gp_Trsf setup doesn't fit templates) ──
+    MethodSpec {
+        name: "translate",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "transforms",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "rotate",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "transforms",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "scale",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "transforms",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "mirror",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "transforms",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "copy",
+        kind: MethodKind::Skip,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        includes: &[],
+        category: "transforms",
+        return_type: ReturnType::ShapeId,
+    },
+];
+
+/// Returns the complete list of facade method specifications.
+///
+/// The returned slice includes both generable methods and skipped methods.
+/// Filter on [`MethodKind::Skip`] to get only the methods that should
+/// produce generated code.
+pub fn target_methods() -> &'static [MethodSpec] {
+    TARGET_METHODS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generable_method_count() {
+        let count = target_methods()
+            .iter()
+            .filter(|m| m.kind != MethodKind::Skip)
+            .count();
+        assert_eq!(count, 14, "expected 14 generable methods in first pass");
+    }
+
+    #[test]
+    fn all_generable_methods_have_occt_class() {
+        for m in target_methods() {
+            if m.kind != MethodKind::Skip {
+                assert!(
+                    !m.occt_class.is_empty(),
+                    "generable method '{}' is missing occt_class",
+                    m.name,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn skip_methods_have_empty_fields() {
+        for m in target_methods() {
+            if m.kind == MethodKind::Skip {
+                assert!(
+                    m.params.is_empty(),
+                    "skipped method '{}' should have empty params",
+                    m.name,
+                );
+            }
+        }
+    }
+}

--- a/xtask/src/codegen/emitter.rs
+++ b/xtask/src/codegen/emitter.rs
@@ -1,0 +1,415 @@
+//! C++ code emitter for the facade code generator.
+//!
+//! Emits `kernel.cpp` (method implementations) and `bindings.cpp` (Embind
+//! reference) from a slice of [`MethodSpec`] descriptors.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use super::types::{FacadeParam, MethodKind, MethodSpec};
+
+/// Format a [`FacadeParam`] as a C++ formal parameter declaration.
+fn param_to_cpp(param: &FacadeParam) -> String {
+    match param {
+        FacadeParam::ShapeId(name) => format!("uint32_t {name}"),
+        FacadeParam::Double(name) => format!("double {name}"),
+        FacadeParam::VectorShapeIds(name) => format!("std::vector<uint32_t> {name}"),
+        FacadeParam::Bool(name) => format!("bool {name}"),
+        FacadeParam::Int(name) => format!("int {name}"),
+        FacadeParam::String(name) => format!("const std::string& {name}"),
+    }
+}
+
+/// Build the C++ parameter list string for a method signature.
+fn param_list(params: &[FacadeParam]) -> String {
+    params
+        .iter()
+        .map(param_to_cpp)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Emit a `SimpleShape` method body.
+fn emit_simple_shape(buf: &mut String, spec: &MethodSpec) {
+    let name = spec.name;
+    let cls = spec.occt_class;
+    let args = spec.ctor_args;
+
+    let _ = writeln!(
+        buf,
+        "uint32_t OcctKernel::{name}({params}) {{",
+        params = param_list(spec.params)
+    );
+    let _ = writeln!(buf, "    try {{");
+    let _ = writeln!(buf, "        {cls} maker({args});");
+    let _ = writeln!(buf, "        maker.Build();");
+    let _ = writeln!(buf, "        if (!maker.IsDone()) {{");
+    let _ = writeln!(
+        buf,
+        "            throw std::runtime_error(\"{name}: construction failed\");"
+    );
+    let _ = writeln!(buf, "        }}");
+    let _ = writeln!(buf, "        return store(maker.Shape());");
+    let _ = writeln!(buf, "    }} catch (const Standard_Failure& e) {{");
+    let _ = writeln!(
+        buf,
+        "        throw std::runtime_error(std::string(\"{name}: \") + e.what());"
+    );
+    let _ = writeln!(buf, "    }}");
+    let _ = writeln!(buf, "}}");
+}
+
+/// Emit a `BooleanOp` method body.
+///
+/// The `ctor_args` field in the spec already contains the full expression
+/// (e.g. `"get(a), get(b)"`), so we pass it directly to the OCCT constructor.
+fn emit_boolean_op(buf: &mut String, spec: &MethodSpec) {
+    let name = spec.name;
+    let cls = spec.occt_class;
+    let args = spec.ctor_args;
+
+    let _ = writeln!(
+        buf,
+        "uint32_t OcctKernel::{name}({params}) {{",
+        params = param_list(spec.params)
+    );
+    let _ = writeln!(buf, "    try {{");
+    let _ = writeln!(buf, "        {cls} op({args});");
+    let _ = writeln!(buf, "        op.Build();");
+    let _ = writeln!(buf, "        if (!op.IsDone() || op.HasErrors()) {{");
+    let _ = writeln!(
+        buf,
+        "            throw std::runtime_error(\"{name}: boolean operation failed\");"
+    );
+    let _ = writeln!(buf, "        }}");
+    let _ = writeln!(buf, "        return store(op.Shape());");
+    let _ = writeln!(buf, "    }} catch (const Standard_Failure& e) {{");
+    let _ = writeln!(
+        buf,
+        "        throw std::runtime_error(std::string(\"{name}: \") + e.what());"
+    );
+    let _ = writeln!(buf, "    }}");
+    let _ = writeln!(buf, "}}");
+}
+
+/// Emit a `FilletLike` method body.
+///
+/// Expects params in order: `ShapeId` (solid), `VectorShapeIds` (edges/faces),
+/// then one or more scalar params (radius, distance, etc.).
+fn emit_fillet_like(buf: &mut String, spec: &MethodSpec) {
+    let name = spec.name;
+    let cls = spec.occt_class;
+    let args = spec.ctor_args;
+
+    let _ = writeln!(
+        buf,
+        "uint32_t OcctKernel::{name}({params}) {{",
+        params = param_list(spec.params)
+    );
+    let _ = writeln!(buf, "    try {{");
+    let _ = writeln!(buf, "        {cls} maker({args});");
+
+    // Find the vector param and the scalar param(s) for the Add() call.
+    let vec_param = spec.params.iter().find_map(|p| {
+        if let FacadeParam::VectorShapeIds(n) = p {
+            Some(*n)
+        } else {
+            None
+        }
+    });
+    let scalar_params: Vec<&str> = spec
+        .params
+        .iter()
+        .filter_map(|p| match p {
+            FacadeParam::Double(n) | FacadeParam::Int(n) => Some(*n),
+            _ => None,
+        })
+        .collect();
+
+    if let Some(vec_name) = vec_param {
+        let scalar_args = scalar_params.join(", ");
+        let _ = writeln!(buf, "        for (uint32_t eid : {vec_name}) {{");
+        let _ = writeln!(
+            buf,
+            "            maker.Add({scalar_args}, TopoDS::Edge(get(eid)));"
+        );
+        let _ = writeln!(buf, "        }}");
+    }
+
+    let _ = writeln!(buf, "        maker.Build();");
+    let _ = writeln!(buf, "        if (!maker.IsDone()) {{");
+    let _ = writeln!(
+        buf,
+        "            throw std::runtime_error(\"{name}: operation failed\");"
+    );
+    let _ = writeln!(buf, "        }}");
+    let _ = writeln!(buf, "        return store(maker.Shape());");
+    let _ = writeln!(buf, "    }} catch (const Standard_Failure& e) {{");
+    let _ = writeln!(
+        buf,
+        "        throw std::runtime_error(std::string(\"{name}: \") + e.what());"
+    );
+    let _ = writeln!(buf, "    }}");
+    let _ = writeln!(buf, "}}");
+}
+
+/// Derive the OCCT include header for a class name (e.g. `BRepPrimAPI_MakeBox`
+/// becomes `<BRepPrimAPI_MakeBox.hxx>`).
+fn class_to_include(cls: &str) -> String {
+    format!("{cls}.hxx")
+}
+
+/// Collect all unique `#include` paths needed by the given methods.
+fn collect_includes(methods: &[&MethodSpec]) -> BTreeSet<String> {
+    let mut includes = BTreeSet::new();
+
+    // Always-needed headers.
+    includes.insert("Standard_Failure.hxx".to_owned());
+
+    for spec in methods {
+        if matches!(spec.kind, MethodKind::Skip) {
+            continue;
+        }
+        includes.insert(class_to_include(spec.occt_class));
+        for inc in spec.includes {
+            includes.insert((*inc).to_owned());
+        }
+
+        // FilletLike methods need TopoDS.hxx for downcasting.
+        if matches!(spec.kind, MethodKind::FilletLike) {
+            includes.insert("TopoDS.hxx".to_owned());
+        }
+    }
+    includes
+}
+
+/// Group methods by category, preserving insertion order within each group.
+fn group_by_category<'a>(methods: &[&'a MethodSpec]) -> Vec<(&'a str, Vec<&'a MethodSpec>)> {
+    let mut groups: Vec<(&str, Vec<&MethodSpec>)> = Vec::new();
+    for spec in methods {
+        if matches!(spec.kind, MethodKind::Skip) {
+            continue;
+        }
+        if let Some(group) = groups.iter_mut().find(|(cat, _)| *cat == spec.category) {
+            group.1.push(spec);
+        } else {
+            groups.push((spec.category, vec![spec]));
+        }
+    }
+    groups
+}
+
+/// Generate the contents of `facade/generated/kernel.cpp`.
+#[allow(clippy::too_many_lines)]
+pub fn emit_kernel(methods: &[&MethodSpec]) -> String {
+    let mut buf = String::with_capacity(4096);
+
+    // Header.
+    let _ = writeln!(
+        buf,
+        "// AUTO-GENERATED by cargo xtask codegen -- DO NOT EDIT"
+    );
+    let _ = writeln!(buf);
+    let _ = writeln!(buf, "#include \"occt_kernel.h\"");
+    let _ = writeln!(buf);
+
+    // OCCT includes.
+    let includes = collect_includes(methods);
+    for inc in &includes {
+        let _ = writeln!(buf, "#include <{inc}>");
+    }
+    let _ = writeln!(buf);
+
+    // Standard C++ includes.
+    let _ = writeln!(buf, "#include <stdexcept>");
+    let _ = writeln!(buf, "#include <string>");
+    let _ = writeln!(buf);
+
+    // Methods grouped by category.
+    let groups = group_by_category(methods);
+    for (i, (category, specs)) in groups.iter().enumerate() {
+        let _ = writeln!(buf, "// === {category} ===");
+        let _ = writeln!(buf);
+
+        for spec in specs {
+            match spec.kind {
+                MethodKind::SimpleShape => emit_simple_shape(&mut buf, spec),
+                MethodKind::BooleanOp => emit_boolean_op(&mut buf, spec),
+                MethodKind::FilletLike => emit_fillet_like(&mut buf, spec),
+                MethodKind::Skip => {}
+            }
+            let _ = writeln!(buf);
+        }
+
+        // Blank line between category groups, but not after the last one.
+        if i + 1 < groups.len() {
+            // Already have a trailing newline from the last method.
+        }
+    }
+
+    // Trim trailing whitespace.
+    let trimmed = buf.trim_end().to_owned() + "\n";
+    trimmed
+}
+
+/// Generate the contents of `facade/generated/bindings.cpp` as a reference
+/// file.
+///
+/// This is **not** compiled or linked. It shows the `.function()` lines that
+/// belong in the hand-written `facade/src/bindings.cpp` inside the
+/// `class_<OcctKernel>("OcctKernel")` block.
+pub fn emit_bindings(methods: &[&MethodSpec]) -> String {
+    let mut buf = String::with_capacity(2048);
+
+    let _ = writeln!(buf, "// AUTO-GENERATED reference -- DO NOT COMPILE");
+    let _ = writeln!(buf, "//");
+    let _ = writeln!(buf, "// These lines belong in facade/src/bindings.cpp");
+    let _ = writeln!(
+        buf,
+        "// inside the class_<OcctKernel>(\"OcctKernel\") block."
+    );
+    let _ = writeln!(buf);
+
+    let groups = group_by_category(methods);
+    for (category, specs) in &groups {
+        let _ = writeln!(buf, "// === {category} ===");
+        for spec in specs {
+            let name = spec.name;
+            let _ = writeln!(buf, "// .function(\"{name}\", &OcctKernel::{name})");
+        }
+        let _ = writeln!(buf);
+    }
+
+    let trimmed = buf.trim_end().to_owned() + "\n";
+    trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codegen::types::{FacadeParam, MethodKind, MethodSpec, ReturnType};
+
+    static MAKE_BOX: MethodSpec = MethodSpec {
+        name: "makeBox",
+        kind: MethodKind::SimpleShape,
+        params: &[
+            FacadeParam::Double("dx"),
+            FacadeParam::Double("dy"),
+            FacadeParam::Double("dz"),
+        ],
+        return_type: ReturnType::ShapeId,
+        occt_class: "BRepPrimAPI_MakeBox",
+        ctor_args: "dx, dy, dz",
+        includes: &[],
+        category: "Primitives",
+    };
+
+    static FUSE: MethodSpec = MethodSpec {
+        name: "fuse",
+        kind: MethodKind::BooleanOp,
+        params: &[FacadeParam::ShapeId("a"), FacadeParam::ShapeId("b")],
+        return_type: ReturnType::ShapeId,
+        occt_class: "BRepAlgoAPI_Fuse",
+        ctor_args: "get(a), get(b)",
+        includes: &[],
+        category: "Booleans",
+    };
+
+    static FILLET: MethodSpec = MethodSpec {
+        name: "fillet",
+        kind: MethodKind::FilletLike,
+        params: &[
+            FacadeParam::ShapeId("solidId"),
+            FacadeParam::VectorShapeIds("edgeIds"),
+            FacadeParam::Double("radius"),
+        ],
+        return_type: ReturnType::ShapeId,
+        occt_class: "BRepFilletAPI_MakeFillet",
+        ctor_args: "TopoDS::Solid(get(solidId))",
+        includes: &["TopoDS.hxx"],
+        category: "Modeling",
+    };
+
+    #[test]
+    fn kernel_simple_shape_matches_expected() {
+        let methods: Vec<&MethodSpec> = vec![&MAKE_BOX];
+        let output = emit_kernel(&methods);
+
+        assert!(output.contains("uint32_t OcctKernel::makeBox(double dx, double dy, double dz)"));
+        assert!(output.contains("BRepPrimAPI_MakeBox maker(dx, dy, dz)"));
+        assert!(output.contains("maker.Build()"));
+        assert!(output.contains("store(maker.Shape())"));
+        assert!(output.contains("#include <BRepPrimAPI_MakeBox.hxx>"));
+        assert!(output.contains("// === Primitives ==="));
+    }
+
+    #[test]
+    fn kernel_boolean_op_uses_ctor_args() {
+        let methods: Vec<&MethodSpec> = vec![&FUSE];
+        let output = emit_kernel(&methods);
+
+        assert!(output.contains("BRepAlgoAPI_Fuse op(get(a), get(b))"));
+        assert!(output.contains("op.HasErrors()"));
+        assert!(output.contains("boolean operation failed"));
+    }
+
+    #[test]
+    fn kernel_fillet_like_iterates_edges() {
+        let methods: Vec<&MethodSpec> = vec![&FILLET];
+        let output = emit_kernel(&methods);
+
+        assert!(output.contains("for (uint32_t eid : edgeIds)"));
+        assert!(output.contains("maker.Add(radius, TopoDS::Edge(get(eid)))"));
+        assert!(output.contains("#include <TopoDS.hxx>"));
+    }
+
+    #[test]
+    fn bindings_emits_commented_reference() {
+        let methods: Vec<&MethodSpec> = vec![&MAKE_BOX, &FUSE, &FILLET];
+        let output = emit_bindings(&methods);
+
+        assert!(output.contains("// AUTO-GENERATED reference"));
+        assert!(output.contains("// .function(\"makeBox\", &OcctKernel::makeBox)"));
+        assert!(output.contains("// .function(\"fuse\", &OcctKernel::fuse)"));
+        assert!(output.contains("// .function(\"fillet\", &OcctKernel::fillet)"));
+    }
+
+    #[test]
+    fn skip_methods_are_excluded() {
+        static SKIPPED: MethodSpec = MethodSpec {
+            name: "makeEllipsoid",
+            kind: MethodKind::Skip,
+            params: &[],
+            return_type: ReturnType::ShapeId,
+            occt_class: "",
+            ctor_args: "",
+            includes: &[],
+            category: "Primitives",
+        };
+        let methods: Vec<&MethodSpec> = vec![&SKIPPED, &MAKE_BOX];
+        let kernel = emit_kernel(&methods);
+        let bindings = emit_bindings(&methods);
+
+        assert!(!kernel.contains("makeEllipsoid"));
+        assert!(!bindings.contains("makeEllipsoid"));
+    }
+
+    #[test]
+    fn includes_are_deduplicated_and_sorted() {
+        let methods: Vec<&MethodSpec> = vec![&MAKE_BOX, &FUSE, &FILLET];
+        let output = emit_kernel(&methods);
+
+        // All includes should appear exactly once.
+        let count = output.matches("#include <TopoDS.hxx>").count();
+        assert_eq!(count, 1);
+
+        // Sorted: BRepAlgoAPI_Fuse before BRepPrimAPI_MakeBox.
+        let fuse_pos = output
+            .find("#include <BRepAlgoAPI_Fuse.hxx>")
+            .expect("fuse include");
+        let box_pos = output
+            .find("#include <BRepPrimAPI_MakeBox.hxx>")
+            .expect("box include");
+        assert!(fuse_pos < box_pos);
+    }
+}

--- a/xtask/src/codegen/mod.rs
+++ b/xtask/src/codegen/mod.rs
@@ -1,0 +1,9 @@
+//! Facade code generator for occt-wasm.
+//!
+//! Declares the IR types and declarative method configuration used to
+//! auto-generate C++ facade implementations from OCCT class patterns.
+
+pub mod config;
+pub mod emitter;
+pub mod run;
+pub mod types;

--- a/xtask/src/codegen/run.rs
+++ b/xtask/src/codegen/run.rs
@@ -1,0 +1,73 @@
+//! Orchestrator for the facade code generator.
+//!
+//! Reads the declarative method configuration, invokes the emitter, and
+//! writes the generated C++ files to `facade/generated/`.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use super::config;
+use super::emitter;
+use super::types::MethodKind;
+
+/// Project root (parent of xtask/).
+fn project_root() -> Result<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string());
+    let root = Path::new(&manifest_dir)
+        .parent()
+        .context("xtask must be inside the workspace")?
+        .to_path_buf();
+    Ok(root)
+}
+
+/// Run the facade code generator.
+///
+/// Reads method specs from `config`, emits C++ via `emitter`, and writes
+/// the output to `facade/generated/kernel.cpp` and `bindings.cpp`.
+pub fn run() -> Result<()> {
+    let root = project_root()?;
+    let out_dir = root.join("facade/generated");
+
+    std::fs::create_dir_all(&out_dir).context("failed to create facade/generated/")?;
+
+    let all_methods = config::target_methods();
+
+    // Partition into generable and skipped
+    let generable: Vec<&_> = all_methods
+        .iter()
+        .filter(|m| m.kind != MethodKind::Skip)
+        .collect();
+
+    let skipped = all_methods.len() - generable.len();
+
+    eprintln!(
+        "Codegen: {} methods generable, {skipped} skipped, {} total",
+        generable.len(),
+        all_methods.len()
+    );
+
+    // Emit C++ files
+    let kernel_cpp = emitter::emit_kernel(&generable);
+    let bindings_cpp = emitter::emit_bindings(&generable);
+
+    let kernel_path = out_dir.join("kernel.cpp");
+    let bindings_path = out_dir.join("bindings.cpp");
+
+    std::fs::write(&kernel_path, &kernel_cpp).context("failed to write kernel.cpp")?;
+    std::fs::write(&bindings_path, &bindings_cpp).context("failed to write bindings.cpp")?;
+
+    eprintln!("  Wrote {}", kernel_path.display());
+    eprintln!("  Wrote {}", bindings_path.display());
+
+    // Summary by category
+    let mut categories: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+    for m in &generable {
+        *categories.entry(m.category).or_insert(0) += 1;
+    }
+    for (cat, count) in &categories {
+        eprintln!("    {cat}: {count} methods");
+    }
+
+    Ok(())
+}

--- a/xtask/src/codegen/types.rs
+++ b/xtask/src/codegen/types.rs
@@ -1,0 +1,104 @@
+//! IR types for the facade code generator.
+//!
+//! Every type uses `&'static str` and `&'static [...]` so that method
+//! specifications can be expressed as compile-time constants with zero
+//! allocation overhead.
+
+/// How a facade method wraps an OCCT class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MethodKind {
+    /// Instantiate OCCT class with `ctor_args`, call `Build()`, check
+    /// `IsDone()`, extract `Shape()`, and store via `store()`.
+    SimpleShape,
+
+    /// Boolean operation: takes two shape IDs, builds the op, checks
+    /// `HasErrors()`, and stores the result.
+    BooleanOp,
+
+    /// Fillet/chamfer pattern: takes a solid ID, a vector of edge IDs,
+    /// and a scalar value. Downcasts to `TopoDS::Solid`, iterates edges
+    /// with `Add(value, TopoDS::Edge(...))`.
+    FilletLike,
+
+    /// Not auto-generated — the hand-written implementation uses complex
+    /// multi-step logic that doesn't fit a template.
+    Skip,
+}
+
+/// A single facade method parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Variants used as codegen expands to more method patterns.
+pub enum FacadeParam {
+    /// `uint32_t` shape ID resolved via `get(id)`.
+    ShapeId(&'static str),
+
+    /// `double` scalar value.
+    Double(&'static str),
+
+    /// `std::vector<uint32_t>` of shape IDs.
+    VectorShapeIds(&'static str),
+
+    /// `bool` flag.
+    Bool(&'static str),
+
+    /// `int` integer.
+    Int(&'static str),
+
+    /// `std::string` value.
+    String(&'static str),
+}
+
+impl FacadeParam {
+    /// Returns the parameter name.
+    #[allow(dead_code)] // Will be used when parser validates signatures.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::ShapeId(n)
+            | Self::Double(n)
+            | Self::VectorShapeIds(n)
+            | Self::Bool(n)
+            | Self::Int(n)
+            | Self::String(n) => n,
+        }
+    }
+}
+
+/// What the method returns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReturnType {
+    /// A `uint32_t` shape ID stored in the arena.
+    ShapeId,
+}
+
+/// A complete facade method specification.
+///
+/// Each spec declaratively describes one method of `OcctKernel` so the
+/// code generator can emit both the C++ implementation and the Embind
+/// binding from a single source of truth.
+#[derive(Debug, Clone, Copy)]
+pub struct MethodSpec {
+    /// Facade method name (e.g. `"makeBox"`).
+    pub name: &'static str,
+
+    /// Generation strategy.
+    pub kind: MethodKind,
+
+    /// Ordered parameter list.
+    pub params: &'static [FacadeParam],
+
+    /// OCCT class to instantiate (e.g. `"BRepPrimAPI_MakeBox"`).
+    pub occt_class: &'static str,
+
+    /// C++ expression passed to the OCCT constructor.
+    pub ctor_args: &'static str,
+
+    /// `#include` directives required beyond the OCCT class header.
+    pub includes: &'static [&'static str],
+
+    /// Logical grouping for the generated source file (e.g. `"primitives"`).
+    pub category: &'static str,
+
+    /// Return type of the method.
+    #[allow(dead_code)] // Will be used when TS wrapper generation is added.
+    pub return_type: ReturnType,
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use clap::Parser;
 
 mod build;
+mod codegen;
 
 /// occt-wasm build tool.
 #[derive(Parser)]
@@ -37,10 +38,7 @@ fn main() -> Result<()> {
     match cli {
         Cli::Build { release, size } => build::build(release, size),
         Cli::BuildOcct => build::build_occt(),
-        Cli::Codegen => {
-            eprintln!("codegen: not yet implemented (v0.1.1)");
-            Ok(())
-        }
+        Cli::Codegen => codegen::run::run(),
         Cli::Clean => build::clean(),
         Cli::Test => build::test(),
     }


### PR DESCRIPTION
## Summary
Config-driven C++ code generator that auto-generates facade method implementations from declarative method specs. Phase 1 generates **14 methods** across 3 patterns, matching the hand-written facade character-for-character.

### Generated patterns
- **SimpleShape** (8): makeBox, makeBoxFromCorners, makeCylinder, makeSphere, makeCone, makeTorus, extrude, revolve
- **BooleanOp** (4): fuse, cut, common, section
- **FilletLike** (2): fillet, chamfer

### Architecture
| File | Purpose |
|------|---------|
| `codegen/types.rs` | IR types (MethodSpec, MethodKind, FacadeParam) |
| `codegen/config.rs` | Declarative method list (14 generable, 14 skip) |
| `codegen/emitter.rs` | C++ template emission (kernel.cpp + bindings.cpp) |
| `codegen/run.rs` | Orchestrator wiring config → emitter → file output |

### Key design decisions
- **Config-driven**: Method specs are the source of truth, not auto-discovery from OCCT headers
- **`ctor_args` passed verbatim**: The C++ expression in config goes directly to the OCCT constructor
- **No libclang dependency yet**: Parser (validation-only) deferred to next iteration
- **Output gitignored**: `facade/generated/` is not compiled/linked yet — validation only

### Usage
```bash
cargo xtask codegen    # Generates facade/generated/kernel.cpp + bindings.cpp
```

## Test plan
- [x] 9 unit tests pass (config validation, emitter patterns, skip filtering)
- [x] `cargo xtask codegen` produces valid C++ matching hand-written facade
- [x] `cargo fmt` + `cargo clippy` clean
- [ ] Full WASM build with generated code (future: replace hand-written methods)