### PR TITLE
feat(facade): add importStl for STL file import

### DIFF
--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -219,6 +219,7 @@ class OcctKernel {
     // --- I/O ---
     uint32_t importStep(const std::string& data);
     std::string exportStep(uint32_t id);
+    uint32_t importStl(const std::string& data);
     std::string exportStl(uint32_t id, double linearDeflection, bool ascii);
     std::string toBREP(uint32_t id);
     uint32_t fromBREP(const std::string& data);

--- a/facade/src/bindings.cpp
+++ b/facade/src/bindings.cpp
@@ -184,6 +184,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         // I/O
         .function("importStep", &OcctKernel::importStep)
         .function("exportStep", &OcctKernel::exportStep)
+        .function("importStl", &OcctKernel::importStl)
         .function("exportStl", &OcctKernel::exportStl)
         .function("toBREP", &OcctKernel::toBREP)
         .function("fromBREP", &OcctKernel::fromBREP)

--- a/facade/src/io.cpp
+++ b/facade/src/io.cpp
@@ -10,6 +10,7 @@
 #include <BRepTools.hxx>
 #include <BRep_Builder.hxx>
 #include <Message_ProgressRange.hxx>
+#include <StlAPI_Reader.hxx>
 #include <StlAPI_Writer.hxx>
 
 #include <sstream>
@@ -114,6 +115,35 @@ std::string OcctKernel::exportStl(uint32_t id, double linearDeflection, bool asc
         return result;
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("exportStl: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::importStl(const std::string& data) {
+    try {
+        // If data is non-empty, write it to the virtual FS.
+        // If empty, assume the caller already wrote to /tmp/import.stl via FS API.
+        if (!data.empty()) {
+            FILE* f = fopen("/tmp/import.stl", "wb");
+            if (!f) {
+                throw std::runtime_error("importStl: cannot create temp file");
+            }
+            fwrite(data.c_str(), 1, data.size(), f);
+            fclose(f);
+        }
+
+        TopoDS_Shape shape;
+        StlAPI_Reader reader;
+        if (!reader.Read(shape, "/tmp/import.stl")) {
+            throw std::runtime_error("importStl: failed to read STL data");
+        }
+
+        if (shape.IsNull()) {
+            throw std::runtime_error("importStl: no shape produced from STL data");
+        }
+
+        return store(shape);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("importStl: ") + e.what());
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `importStl` method to C++ facade using `StlAPI_Reader`
- Supports both direct string data and pre-written files via Emscripten FS (empty string sentinel)
- Wired in Embind bindings

## Notes
- OCCT V8 RC4's `StlAPI_Reader.Read` currently throws internally on valid STL data — this method is ready for V8.0.0 final
- Companion brepjs adapter change wires `importSTL` using `FS.writeFile` for binary data

## Test plan
- [x] `cargo xtask test` — 45/45 passing
- [x] Docker build succeeds
- [x] brepjs full suite: 2556/2556 passing, 0 failures (no regressions)