### PR TITLE
feat(perf): SIMD, -O3, batch methods, and benchmark suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Run tests
         run: cd ts && npx vitest run
 
+      - name: Run benchmarks
+        run: cd ts && npx vitest run ../test/bench.test.ts
+
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
         with:

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -195,6 +195,11 @@ class OcctKernel {
                              double az, double angle, int count);
     std::vector<double> composeTransform(std::vector<double> m1, std::vector<double> m2);
 
+    // --- Batch operations ---
+    std::vector<uint32_t> translateBatch(std::vector<uint32_t> ids, std::vector<double> offsets);
+    uint32_t booleanPipeline(uint32_t baseId, std::vector<int> opCodes,
+                             std::vector<uint32_t> toolIds);
+
     // --- Topology query ---
     std::string getShapeType(uint32_t id);
     std::vector<uint32_t> getSubShapes(uint32_t id, const std::string& shapeType);

--- a/facade/src/bindings.cpp
+++ b/facade/src/bindings.cpp
@@ -160,6 +160,10 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("circularPattern", &OcctKernel::circularPattern)
         .function("composeTransform", &OcctKernel::composeTransform)
 
+        // Batch operations
+        .function("translateBatch", &OcctKernel::translateBatch)
+        .function("booleanPipeline", &OcctKernel::booleanPipeline)
+
         // Topology
         .function("getShapeType", &OcctKernel::getShapeType)
         .function("getSubShapes", &OcctKernel::getSubShapes)

--- a/facade/src/booleans.cpp
+++ b/facade/src/booleans.cpp
@@ -6,6 +6,7 @@
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepAlgoAPI_Splitter.hxx>
 #include <NCollection_List.hxx>
+#include <ShapeUpgrade_UnifySameDomain.hxx>
 #include <Standard_Failure.hxx>
 #include <TopoDS_Shape.hxx>
 
@@ -65,6 +66,58 @@ uint32_t OcctKernel::cutAll(uint32_t shapeId, std::vector<uint32_t> toolIds) {
         return store(cutter.Shape());
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("cutAll: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::booleanPipeline(uint32_t baseId, std::vector<int> opCodes,
+                                     std::vector<uint32_t> toolIds) {
+    try {
+        if (opCodes.size() != toolIds.size()) {
+            throw std::runtime_error("booleanPipeline: opCodes and toolIds must have same length");
+        }
+        TopoDS_Shape current = get(baseId);
+        for (size_t i = 0; i < opCodes.size(); i++) {
+            const auto& tool = get(toolIds[i]);
+            bool isLast = (i == opCodes.size() - 1);
+            Message_ProgressRange progress;
+
+            switch (opCodes[i]) {
+            case 0: { // fuse
+                BRepAlgoAPI_Fuse op(current, tool, progress);
+                if (!op.IsDone() || op.HasErrors())
+                    throw std::runtime_error("booleanPipeline: fuse step failed");
+                current = op.Shape();
+                break;
+            }
+            case 1: { // cut
+                BRepAlgoAPI_Cut op(current, tool, progress);
+                if (!op.IsDone() || op.HasErrors())
+                    throw std::runtime_error("booleanPipeline: cut step failed");
+                current = op.Shape();
+                break;
+            }
+            case 2: { // intersect
+                BRepAlgoAPI_Common op(current, tool, progress);
+                if (!op.IsDone() || op.HasErrors())
+                    throw std::runtime_error("booleanPipeline: intersect step failed");
+                current = op.Shape();
+                break;
+            }
+            default:
+                throw std::runtime_error("booleanPipeline: unknown opCode");
+            }
+
+            // Only simplify the final result
+            if (isLast) {
+                ShapeUpgrade_UnifySameDomain upgrader(current, Standard_True, Standard_True,
+                                                      Standard_False);
+                upgrader.Build();
+                current = upgrader.Shape();
+            }
+        }
+        return store(current);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("booleanPipeline: ") + e.what());
     }
 }
 

--- a/facade/src/transforms.cpp
+++ b/facade/src/transforms.cpp
@@ -115,6 +115,26 @@ uint32_t OcctKernel::generalTransform(uint32_t id, std::vector<double> matrix) {
     }
 }
 
+std::vector<uint32_t> OcctKernel::translateBatch(std::vector<uint32_t> ids,
+                                                 std::vector<double> offsets) {
+    try {
+        if (offsets.size() != ids.size() * 3) {
+            throw std::runtime_error("translateBatch: offsets must have 3 * ids.size() elements");
+        }
+        std::vector<uint32_t> results;
+        results.reserve(ids.size());
+        for (size_t i = 0; i < ids.size(); i++) {
+            gp_Trsf trsf;
+            trsf.SetTranslation(gp_Vec(offsets[i * 3], offsets[i * 3 + 1], offsets[i * 3 + 2]));
+            BRepBuilderAPI_Transform maker(get(ids[i]), trsf, true);
+            results.push_back(store(maker.Shape()));
+        }
+        return results;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("translateBatch: ") + e.what());
+    }
+}
+
 std::vector<double> OcctKernel::composeTransform(std::vector<double> m1, std::vector<double> m2) {
     try {
         if (m1.size() != 12 || m2.size() != 12) {

--- a/test/bench.test.ts
+++ b/test/bench.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Raw facade-level performance benchmarks.
+ *
+ * Measures occt-wasm's WASM kernel directly (no brepjs adapter overhead).
+ * Core 5: makeBox, fuse, translate×100, mesh-sphere, exportSTEP.
+ *
+ * Usage:
+ *   cargo xtask test               # runs all tests including bench
+ *   npx vitest run test/bench.test.ts  # bench only
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { resolve } from "node:path";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let Module: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let kernel: any;
+
+beforeAll(async () => {
+    const wasmPath = resolve(__dirname, "../dist/occt-wasm.wasm");
+    const jsPath = resolve(__dirname, "../dist/occt-wasm.js");
+    const createOcctWasm = (await import(jsPath)).default;
+    Module = await createOcctWasm({
+        locateFile: (path: string) => {
+            if (path.endsWith(".wasm")) return wasmPath;
+            return path;
+        },
+    });
+    kernel = new Module.OcctKernel();
+}, 30_000);
+
+afterAll(() => {
+    if (kernel) {
+        kernel.releaseAll();
+        kernel.delete();
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface BenchResult {
+    name: string;
+    median: number;
+    mean: number;
+    min: number;
+    max: number;
+    iterations: number;
+}
+
+function bench(
+    name: string,
+    fn: () => void,
+    { warmup = 3, iterations = 10 }: { warmup?: number; iterations?: number } = {}
+): BenchResult {
+    for (let i = 0; i < warmup; i++) fn();
+    const times: number[] = [];
+    for (let i = 0; i < iterations; i++) {
+        const start = performance.now();
+        fn();
+        times.push(performance.now() - start);
+    }
+    const sorted = [...times].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    const median =
+        sorted.length % 2 !== 0
+            ? sorted[mid]!
+            : (sorted[mid - 1]! + sorted[mid]!) / 2;
+    const mean = times.reduce((a, b) => a + b, 0) / times.length;
+    return {
+        name,
+        median,
+        mean,
+        min: Math.min(...times),
+        max: Math.max(...times),
+        iterations,
+    };
+}
+
+const ALL_RESULTS: BenchResult[] = [];
+
+function record(r: BenchResult): void {
+    ALL_RESULTS.push(r);
+}
+
+// ---------------------------------------------------------------------------
+// Core 5 Benchmarks
+// ---------------------------------------------------------------------------
+
+describe("Core 5 — raw facade benchmarks", () => {
+    it("makeBox ×100", () => {
+        const r = bench("makeBox ×100", () => {
+            for (let i = 0; i < 100; i++) kernel.makeBox(10, 20, 30);
+        });
+        record(r);
+        expect(r.median).toBeLessThan(50); // sanity: <50ms for 100 boxes
+    });
+
+    it("fuse ×10", () => {
+        const r = bench("fuse ×10", () => {
+            for (let i = 0; i < 10; i++) {
+                const a = kernel.makeBox(10, 10, 10);
+                const b = kernel.translate(kernel.makeBox(5, 5, 5), 5, 5, 5);
+                kernel.fuse(a, b);
+            }
+        });
+        record(r);
+        expect(r.median).toBeLessThan(500); // sanity: <500ms for 10 fuses
+    });
+
+    it("translate ×1000", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const r = bench("translate ×1000", () => {
+            for (let i = 0; i < 1000; i++) {
+                kernel.translate(box, i * 0.01, 0, 0);
+            }
+        });
+        record(r);
+        expect(r.median).toBeLessThan(100); // sanity: <100ms
+    });
+
+    it("mesh sphere (tol=0.01)", () => {
+        const sphere = kernel.makeSphere(10);
+        const r = bench("mesh sphere (tol=0.01)", () => {
+            kernel.tessellate(sphere, 0.01, 0.5);
+        });
+        record(r);
+        expect(r.median).toBeLessThan(200); // sanity
+    });
+
+    it("exportSTEP ×10", () => {
+        const box = kernel.makeBox(10, 20, 30);
+        const r = bench("exportSTEP ×10", () => {
+            for (let i = 0; i < 10; i++) kernel.exportStep(box);
+        });
+        record(r);
+        expect(r.median).toBeLessThan(100); // sanity
+    });
+
+    it("translateBatch ×1000 (single call)", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const ids = new Module.VectorUint32();
+        const offsets = new Module.VectorDouble();
+        for (let i = 0; i < 1000; i++) {
+            ids.push_back(box);
+            offsets.push_back(i * 0.01);
+            offsets.push_back(0);
+            offsets.push_back(0);
+        }
+        const r = bench("translateBatch ×1000", () => {
+            kernel.translateBatch(ids, offsets);
+        });
+        ids.delete();
+        offsets.delete();
+        record(r);
+        expect(r.median).toBeLessThan(100);
+    });
+
+    it("booleanPipeline ×3 (fuse+cut+fuse)", () => {
+        const r = bench("booleanPipeline ×3", () => {
+            const base = kernel.makeBox(20, 20, 20);
+            const t1 = kernel.translate(kernel.makeSphere(8), 10, 10, 10);
+            const t2 = kernel.translate(kernel.makeCylinder(3, 30), 10, 10, 0);
+            const t3 = kernel.translate(kernel.makeBox(5, 5, 5), -2, -2, -2);
+            const ops = new Module.VectorInt();
+            const tools = new Module.VectorUint32();
+            ops.push_back(0); tools.push_back(t1); // fuse
+            ops.push_back(1); tools.push_back(t2); // cut
+            ops.push_back(0); tools.push_back(t3); // fuse
+            kernel.booleanPipeline(base, ops, tools);
+            ops.delete();
+            tools.delete();
+        });
+        record(r);
+        expect(r.median).toBeLessThan(500);
+    });
+
+    it("print results", () => {
+        console.log(
+            "\n| Benchmark | Min (ms) | Median (ms) | Mean (ms) | Max (ms) |"
+        );
+        console.log(
+            "|-----------|----------|-------------|-----------|----------|"
+        );
+        for (const r of ALL_RESULTS) {
+            console.log(
+                `| ${r.name} | ${r.min.toFixed(1)} | ${r.median.toFixed(1)} | ${r.mean.toFixed(1)} | ${r.max.toFixed(1)} |`
+            );
+        }
+    });
+});

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -61,7 +61,7 @@ pub fn build_occt() -> Result<()> {
     } else {
         eprintln!("Step 1a: Configuring OCCT with emcmake cmake...");
 
-        let c_flags = "-fwasm-exceptions -O2 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS";
+        let c_flags = "-fwasm-exceptions -O3 -msimd128 -mrelaxed-simd -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS";
         let cxx_flags = c_flags;
         let rapidjson_inc = root.join("3rdparty/rapidjson").display().to_string();
 
@@ -156,7 +156,7 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
         let obj_str = obj.display().to_string();
         cmd!(
             sh,
-            "em++ -std=c++17 -fwasm-exceptions -O2
+            "em++ -std=c++17 -fwasm-exceptions -O3 -msimd128 -mrelaxed-simd
             -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS
             -I{occt_inc_str} -I{facade_inc_str}
             -w -c {src_str} -o {obj_str}"
@@ -249,6 +249,9 @@ fn link_wasm(
     let mut args: Vec<String> = vec![
         "-lembind".into(),
         "-fwasm-exceptions".into(),
+        "-msimd128".into(),
+        "-mrelaxed-simd".into(),
+        "-mtail-call".into(),
         opt_level.into(),
         "-sINITIAL_MEMORY=134217728".into(),
         "-sMAXIMUM_MEMORY=4294967296".into(),
@@ -312,9 +315,11 @@ fn optimize_wasm(sh: &Shell, root: &Path) -> Result<()> {
     cmd!(
         sh,
         "{wasm_opt_bin} -O4 --strip-debug --strip-producers
+        --converge --gufa
         --enable-bulk-memory --enable-sign-ext
         --enable-nontrapping-float-to-int --enable-mutable-globals
-        --enable-exception-handling
+        --enable-exception-handling --enable-simd --enable-tail-call
+        --enable-relaxed-simd
         {wasm_str} -o {wasm_str}"
     )
     .run()?;


### PR DESCRIPTION
## Summary
- Compile OCCT + facade at `-O3` (was `-O2`), add `-msimd128 -mrelaxed-simd -mtail-call`
- Add `--converge --gufa` wasm-opt passes with SIMD/tail-call feature flags
- New `translateBatch` and `booleanPipeline` C++ batch methods
- New `test/bench.test.ts` raw facade benchmark suite (Core 5 + batch ops)
- CI runs benchmarks after tests

## Benchmark results (Docker build)
| Benchmark | Median (ms) |
|-----------|-------------|
| makeBox ×100 | 2.1 |
| fuse ×10 | 76.2 |
| translate ×1000 | 42.1 |
| mesh sphere (tol=0.01) | 51.5 |
| exportSTEP ×10 | 20.9 |
| translateBatch ×1000 | 71.6 |
| booleanPipeline ×3 | 9.5 |

## Test plan
- [x] Docker build succeeds with new flags
- [x] All 53 tests pass (45 existing + 8 new bench tests)
- [x] brepjs full suite: 2556/2556 passing, 0 failures