### PR TITLE
feat(facade): add meshBatch and CI benchmark tooling

### DIFF
--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -80,6 +80,27 @@ struct NurbsCurveData {
     std::vector<double> weights;
 };
 
+/// Batch mesh data: concatenated positions/normals/indices with per-shape offsets.
+struct MeshBatchData {
+    float* positions = nullptr;
+    float* normals = nullptr;
+    uint32_t* indices = nullptr;
+    int32_t* shapeOffsets = nullptr; // [posStart, posCount, idxStart, idxCount] per shape
+    int positionCount = 0;
+    int normalCount = 0;
+    int indexCount = 0;
+    int shapeCount = 0; // number of shapes (shapeOffsets has shapeCount * 4 int32s)
+
+    MeshBatchData() = default;
+    ~MeshBatchData();
+    MeshBatchData(const MeshBatchData& other);
+    MeshBatchData& operator=(const MeshBatchData&) = delete;
+    int getPositionsPtr() const;
+    int getNormalsPtr() const;
+    int getIndicesPtr() const;
+    int getShapeOffsetsPtr() const;
+};
+
 /// XCAF label info returned from queries.
 struct XCAFLabelInfo {
     int labelId = 0;
@@ -220,6 +241,8 @@ class OcctKernel {
     EdgeData wireframe(uint32_t id, double deflection);
     bool hasTriangulation(uint32_t id);
     MeshData meshShape(uint32_t id, double linearDeflection, double angularDeflection);
+    MeshBatchData meshBatch(std::vector<uint32_t> ids, double linearDeflection,
+                            double angularDeflection);
 
     // --- I/O ---
     uint32_t importStep(const std::string& data);

--- a/facade/src/bindings.cpp
+++ b/facade/src/bindings.cpp
@@ -20,6 +20,17 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("getFaceGroupsPtr", &MeshData::getFaceGroupsPtr)
         .property("faceGroupCount", &MeshData::faceGroupCount);
 
+    // MeshBatchData
+    class_<MeshBatchData>("MeshBatchData")
+        .function("getPositionsPtr", &MeshBatchData::getPositionsPtr)
+        .function("getNormalsPtr", &MeshBatchData::getNormalsPtr)
+        .function("getIndicesPtr", &MeshBatchData::getIndicesPtr)
+        .function("getShapeOffsetsPtr", &MeshBatchData::getShapeOffsetsPtr)
+        .property("positionCount", &MeshBatchData::positionCount)
+        .property("normalCount", &MeshBatchData::normalCount)
+        .property("indexCount", &MeshBatchData::indexCount)
+        .property("shapeCount", &MeshBatchData::shapeCount);
+
     // BBoxData
     value_object<BBoxData>("BBoxData")
         .field("xmin", &BBoxData::xmin)
@@ -184,6 +195,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("wireframe", &OcctKernel::wireframe)
         .function("hasTriangulation", &OcctKernel::hasTriangulation)
         .function("meshShape", &OcctKernel::meshShape)
+        .function("meshBatch", &OcctKernel::meshBatch)
 
         // I/O
         .function("importStep", &OcctKernel::importStep)

--- a/facade/src/kernel.cpp
+++ b/facade/src/kernel.cpp
@@ -82,6 +82,42 @@ uint32_t OcctKernel::makeNullShape() {
     return store(TopoDS_Shape());
 }
 
+// --- MeshBatchData implementation ---
+
+MeshBatchData::~MeshBatchData() {
+    std::free(positions);
+    std::free(normals);
+    std::free(indices);
+    std::free(shapeOffsets);
+}
+
+MeshBatchData::MeshBatchData(const MeshBatchData& other)
+    : positions(other.positions), normals(other.normals), indices(other.indices),
+      shapeOffsets(other.shapeOffsets), positionCount(other.positionCount),
+      normalCount(other.normalCount), indexCount(other.indexCount), shapeCount(other.shapeCount) {
+    auto& mut = const_cast<MeshBatchData&>(other);
+    mut.positions = nullptr;
+    mut.normals = nullptr;
+    mut.indices = nullptr;
+    mut.shapeOffsets = nullptr;
+}
+
+int MeshBatchData::getPositionsPtr() const {
+    return static_cast<int>(reinterpret_cast<uintptr_t>(positions));
+}
+
+int MeshBatchData::getNormalsPtr() const {
+    return static_cast<int>(reinterpret_cast<uintptr_t>(normals));
+}
+
+int MeshBatchData::getIndicesPtr() const {
+    return static_cast<int>(reinterpret_cast<uintptr_t>(indices));
+}
+
+int MeshBatchData::getShapeOffsetsPtr() const {
+    return static_cast<int>(reinterpret_cast<uintptr_t>(shapeOffsets));
+}
+
 // --- EdgeData implementation ---
 
 EdgeData::~EdgeData() {

--- a/facade/src/tessellate.cpp
+++ b/facade/src/tessellate.cpp
@@ -148,6 +148,128 @@ MeshData OcctKernel::meshShape(uint32_t id, double linearDeflection, double angu
     return tessellate(id, linearDeflection, angularDeflection);
 }
 
+MeshBatchData OcctKernel::meshBatch(std::vector<uint32_t> ids, double linearDeflection,
+                                    double angularDeflection) {
+    try {
+        // First pass: mesh all shapes and count totals
+        struct ShapeMesh {
+            int posStart, posCount, idxStart, idxCount;
+        };
+        std::vector<ShapeMesh> shapeMeshes;
+        shapeMeshes.reserve(ids.size());
+
+        int totalNodes = 0;
+        int totalTris = 0;
+
+        for (uint32_t id : ids) {
+            const auto& shape = get(id);
+            BRepMesh_IncrementalMesh mesher(shape, linearDeflection, false, angularDeflection,
+                                            false);
+
+            int shapeNodes = 0;
+            int shapeTris = 0;
+            for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
+                TopLoc_Location loc;
+                auto tri = BRep_Tool::Triangulation(TopoDS::Face(ex.Current()), loc);
+                if (tri.IsNull())
+                    continue;
+                shapeNodes += tri->NbNodes();
+                shapeTris += tri->NbTriangles();
+            }
+            shapeMeshes.push_back({totalNodes * 3, shapeNodes * 3, totalTris * 3, shapeTris * 3});
+            totalNodes += shapeNodes;
+            totalTris += shapeTris;
+        }
+
+        // Allocate
+        MeshBatchData result;
+        result.positionCount = totalNodes * 3;
+        result.normalCount = totalNodes * 3;
+        result.indexCount = totalTris * 3;
+        result.shapeCount = static_cast<int>(ids.size());
+
+        result.positions = static_cast<float*>(std::malloc(result.positionCount * sizeof(float)));
+        result.normals = static_cast<float*>(std::malloc(result.normalCount * sizeof(float)));
+        result.indices = static_cast<uint32_t*>(std::malloc(result.indexCount * sizeof(uint32_t)));
+        result.shapeOffsets =
+            static_cast<int32_t*>(std::malloc(result.shapeCount * 4 * sizeof(int32_t)));
+
+        // Second pass: extract geometry
+        int vertexOffset = 0;
+        int triOffset = 0;
+
+        for (size_t si = 0; si < ids.size(); si++) {
+            const auto& shape = get(ids[si]);
+
+            for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
+                const auto& face = TopoDS::Face(ex.Current());
+                TopLoc_Location loc;
+                auto tri = BRep_Tool::Triangulation(face, loc);
+                if (tri.IsNull())
+                    continue;
+
+                const auto& trsf = loc.Transformation();
+                int nbNodes = tri->NbNodes();
+                int nbTri = tri->NbTriangles();
+
+                for (int i = 1; i <= nbNodes; i++) {
+                    gp_Pnt p = tri->Node(i).Transformed(trsf);
+                    int base = (vertexOffset + i - 1) * 3;
+                    result.positions[base + 0] = static_cast<float>(p.X());
+                    result.positions[base + 1] = static_cast<float>(p.Y());
+                    result.positions[base + 2] = static_cast<float>(p.Z());
+                }
+
+                if (!tri->HasNormals()) {
+                    BRepLib_ToolTriangulatedShape::ComputeNormals(face, tri);
+                }
+                for (int i = 1; i <= nbNodes; i++) {
+                    gp_Dir d(0, 0, 1);
+                    if (tri->HasNormals()) {
+                        NCollection_Vec3<float> nv;
+                        tri->Normal(i, nv);
+                        if (nv.x() != 0.0f || nv.y() != 0.0f || nv.z() != 0.0f) {
+                            d = gp_Dir(nv.x(), nv.y(), nv.z());
+                        }
+                    }
+                    d = d.Transformed(trsf);
+                    int base = (vertexOffset + i - 1) * 3;
+                    result.normals[base + 0] = static_cast<float>(d.X());
+                    result.normals[base + 1] = static_cast<float>(d.Y());
+                    result.normals[base + 2] = static_cast<float>(d.Z());
+                }
+
+                bool isReversed = (face.Orientation() != TopAbs_FORWARD);
+                for (int t = 1; t <= nbTri; t++) {
+                    const auto& triangle = tri->Triangle(t);
+                    int n1 = triangle.Value(1);
+                    int n2 = triangle.Value(2);
+                    int n3 = triangle.Value(3);
+                    if (isReversed)
+                        std::swap(n1, n2);
+                    result.indices[triOffset + 0] = static_cast<uint32_t>(n1 - 1 + vertexOffset);
+                    result.indices[triOffset + 1] = static_cast<uint32_t>(n2 - 1 + vertexOffset);
+                    result.indices[triOffset + 2] = static_cast<uint32_t>(n3 - 1 + vertexOffset);
+                    triOffset += 3;
+                }
+
+                vertexOffset += nbNodes;
+            }
+
+            // Store per-shape offsets: [posStart, posCount, idxStart, idxCount]
+            int oi = static_cast<int>(si) * 4;
+            result.shapeOffsets[oi + 0] = shapeMeshes[si].posStart;
+            result.shapeOffsets[oi + 1] = shapeMeshes[si].posCount;
+            result.shapeOffsets[oi + 2] = shapeMeshes[si].idxStart;
+            result.shapeOffsets[oi + 3] = shapeMeshes[si].idxCount;
+        }
+
+        return result;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("meshBatch: ") + e.what());
+    }
+}
+
 EdgeData OcctKernel::wireframe(uint32_t id, double deflection) {
     try {
         const auto& shape = get(id);

--- a/scripts/bench-check.js
+++ b/scripts/bench-check.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Compare benchmark output against a stored baseline.
+ * Fails with exit code 1 if any Core 5 benchmark regresses >15%.
+ *
+ * Usage:
+ *   npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
+ *   node scripts/bench-check.js < bench-output.txt
+ *
+ * To update the baseline:
+ *   node scripts/bench-check.js --update-baseline < bench-output.txt
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BASELINE_PATH = resolve(__dirname, '../benchmarks/baseline.json');
+const THRESHOLD = 0.15; // 15% regression threshold
+
+// Read stdin
+let input = '';
+process.stdin.setEncoding('utf-8');
+for await (const chunk of process.stdin) {
+    input += chunk;
+}
+
+// Parse benchmark table from vitest output
+const lines = input.split('\n').filter(l => l.startsWith('|') && !l.includes('---') && !l.includes('Benchmark'));
+const results = {};
+for (const line of lines) {
+    const cols = line.split('|').map(c => c.trim()).filter(Boolean);
+    if (cols.length < 3) continue;
+    const name = cols[0];
+    const median = parseFloat(cols[2]);
+    if (!isNaN(median)) results[name] = median;
+}
+
+if (Object.keys(results).length === 0) {
+    console.log('No benchmark results found in input.');
+    process.exit(0);
+}
+
+console.log(`Parsed ${Object.keys(results).length} benchmarks:`);
+for (const [name, median] of Object.entries(results)) {
+    console.log(`  ${name}: ${median.toFixed(1)}ms`);
+}
+
+// Update baseline mode
+if (process.argv.includes('--update-baseline')) {
+    writeFileSync(BASELINE_PATH, JSON.stringify(results, null, 2) + '\n');
+    console.log(`\nBaseline updated at ${BASELINE_PATH}`);
+    process.exit(0);
+}
+
+// Compare against baseline
+if (!existsSync(BASELINE_PATH)) {
+    console.log('\nNo baseline found. Run with --update-baseline to create one.');
+    process.exit(0);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8'));
+let regressions = 0;
+
+console.log('\nRegression check (threshold: 15%):');
+for (const [name, median] of Object.entries(results)) {
+    const base = baseline[name];
+    if (base === undefined) {
+        console.log(`  ${name}: NEW (no baseline)`);
+        continue;
+    }
+    const change = (median - base) / base;
+    if (change > THRESHOLD) {
+        console.log(`  REGRESSION: ${name} ${base.toFixed(1)}ms → ${median.toFixed(1)}ms (+${(change * 100).toFixed(0)}%)`);
+        regressions++;
+    } else if (change < -THRESHOLD) {
+        console.log(`  IMPROVED: ${name} ${base.toFixed(1)}ms → ${median.toFixed(1)}ms (${(change * 100).toFixed(0)}%)`);
+    } else {
+        console.log(`  OK: ${name} ${base.toFixed(1)}ms → ${median.toFixed(1)}ms (${(change * 100).toFixed(0)}%)`);
+    }
+}
+
+if (regressions > 0) {
+    console.log(`\n${regressions} benchmark(s) regressed >15%. Failing.`);
+    process.exit(1);
+} else {
+    console.log('\nNo performance regressions detected.');
+}

--- a/test/bench.test.ts
+++ b/test/bench.test.ts
@@ -176,6 +176,19 @@ describe("Core 5 — raw facade benchmarks", () => {
         expect(r.median).toBeLessThan(500);
     });
 
+    it("meshBatch ×10 spheres (single call)", () => {
+        const ids = new Module.VectorUint32();
+        for (let i = 0; i < 10; i++) {
+            ids.push_back(kernel.translate(kernel.makeSphere(5), i * 15, 0, 0));
+        }
+        const r = bench("meshBatch ×10 spheres", () => {
+            kernel.meshBatch(ids, 0.1, 0.5);
+        });
+        ids.delete();
+        record(r);
+        expect(r.median).toBeLessThan(200);
+    });
+
     it("print results", () => {
         console.log(
             "\n| Benchmark | Min (ms) | Median (ms) | Mean (ms) | Max (ms) |"

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -171,7 +171,7 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
 
 /// OCCT static libraries not used by the facade — excluded from linking.
 const EXCLUDED_LIBS: &[&str] = &[
-    // IGES exchange
+    // IGES exchange (deliberately excluded — STEP is the modern standard, saves ~1-2 MB)
     "libTKDEIGES.a",
     // Persistence / serialization
     "libTKStd.a",


### PR DESCRIPTION
## Summary
- **meshBatch**: tessellate N shapes in a single WASM call with concatenated buffers and per-shape offsets
- **MeshBatchData** struct: positions, normals, indices + shapeOffsets `[posStart, posCount, idxStart, idxCount]`
- **bench-check.js**: CI regression script — parses bench output, compares against baseline, fails at >15%
- New bench test for meshBatch ×10 spheres

## Benchmark results (Docker)
| Benchmark | Median (ms) |
|-----------|-------------|
| makeBox ×100 | 1.7 |
| fuse ×10 | 42.3 |
| translate ×1000 | 30.1 |
| mesh sphere (tol=0.01) | 33.7 |
| exportSTEP ×10 | 14.3 |
| translateBatch ×1000 | 46.6 |
| booleanPipeline ×3 | 8.4 |
| meshBatch ×10 spheres | 0.5 |

## Test plan
- [x] Docker build: 54/54 tests pass
- [x] brepjs suite: 2556/2556 passing