### PR TITLE
feat(ci): add benchmark baseline and regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,8 @@ jobs:
       - name: Run tests
         run: cd ts && npx vitest run
 
-      - name: Run benchmarks
-        run: cd ts && npx vitest run ../test/bench.test.ts
+      - name: Run benchmarks & check for regressions
+        run: cd ts && npx vitest run ../test/bench.test.ts 2>&1 | node ../scripts/bench-check.js
 
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -1,0 +1,10 @@
+{
+  "makeBox ×100": 2.8,
+  "fuse ×10": 42.9,
+  "translate ×1000": 39.2,
+  "mesh sphere (tol=0.01)": 0.3,
+  "exportSTEP ×10": 13.3,
+  "translateBatch ×1000": 38.8,
+  "booleanPipeline ×3": 8,
+  "meshBatch ×10 spheres": 0.5
+}


### PR DESCRIPTION
## Summary
- Add initial `benchmarks/baseline.json` with Core 5 + batch benchmark medians
- Wire CI to pipe benchmark output through `bench-check.js`, failing on >15% regression

## Test plan
- [x] `bench-check.js --update-baseline` captures 8 benchmarks
- [x] `bench-check.js` (without flag) compares and reports OK against baseline
- [x] Pre-push hook passes (9 xtask tests + 46 vitest tests)