### PR TITLE
fix(ci): overhaul CI/CD — caching, npm publish, perf

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -12,66 +12,33 @@ on:
         description: Name of the uploaded dist artifact
         value: occt-wasm-dist
 
-env:
-  EMSDK_VERSION: "5.0.3"
-  NODE_VERSION: "22"
-  RUST_TOOLCHAIN: "1.85"
-
 jobs:
   build:
     name: WASM Build & Test
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/andymai/occt-wasm-builder:latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: ${{ env.EMSDK_VERSION }}
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Link pre-built OCCT libs
+        run: |
+          cp -r /workspace/occt/build occt/build
+          cp -r /workspace/3rdparty 3rdparty
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: https://registry.npmjs.org
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            ts/package-lock.json
+          node-version: "22"
 
       - name: Install dependencies
         run: |
           npm ci
           cd ts && npm ci
 
-      - name: Fetch RapidJSON headers
-        run: ./scripts/fetch-rapidjson.sh
-
-      - name: Compute OCCT cache key
-        id: occt-key
-        run: |
-          OCCT_REV=$(git rev-parse HEAD:occt)
-          BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
-          RAPID_HASH=$(sha256sum scripts/fetch-rapidjson.sh | cut -d' ' -f1)
-          echo "hash=${OCCT_REV}-${BUILD_HASH}-${RAPID_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache OCCT static libs
-        uses: actions/cache@v4
-        with:
-          path: occt/build
-          key: occt-${{ steps.occt-key.outputs.hash }}
-
-      - name: Build OCCT + facade -> WASM
+      - name: Build facade + link WASM
         run: cargo xtask build ${{ inputs.release && '--release' || '' }}
 
       - name: Build TypeScript

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -1,0 +1,96 @@
+name: Build WASM
+
+on:
+  workflow_call:
+    inputs:
+      release:
+        description: Build in release mode (LTO + wasm-opt)
+        type: boolean
+        default: false
+    outputs:
+      artifact-name:
+        description: Name of the uploaded dist artifact
+        value: occt-wasm-dist
+
+env:
+  EMSDK_VERSION: "5.0.3"
+  NODE_VERSION: "22"
+  RUST_TOOLCHAIN: "1.85"
+
+jobs:
+  build:
+    name: WASM Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup emsdk
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: ${{ env.EMSDK_VERSION }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            ts/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          cd ts && npm ci
+
+      - name: Fetch RapidJSON headers
+        run: ./scripts/fetch-rapidjson.sh
+
+      - name: Compute OCCT cache key
+        id: occt-key
+        run: |
+          OCCT_REV=$(git rev-parse HEAD:occt)
+          BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
+          RAPID_HASH=$(sha256sum scripts/fetch-rapidjson.sh | cut -d' ' -f1)
+          echo "hash=${OCCT_REV}-${BUILD_HASH}-${RAPID_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache OCCT static libs
+        uses: actions/cache@v4
+        with:
+          path: occt/build
+          key: occt-${{ steps.occt-key.outputs.hash }}
+
+      - name: Build OCCT + facade -> WASM
+        run: cargo xtask build ${{ inputs.release && '--release' || '' }}
+
+      - name: Build TypeScript
+        run: |
+          cd ts
+          npm run build
+          cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm dist/
+
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Run benchmarks & check for regressions
+        if: ${{ !inputs.release }}
+        shell: bash
+        run: set -o pipefail; npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
+
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: occt-wasm-dist
+          path: dist/
+          retention-days: 7

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -88,9 +88,9 @@ jobs:
         shell: bash
         run: set -o pipefail; npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
 
-      - name: Upload WASM artifact
+      - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: occt-wasm-dist
-          path: dist/
+          path: ts/dist/
           retention-days: 7

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -16,14 +16,8 @@ jobs:
   build:
     name: WASM Build & Test
     runs-on: ubuntu-latest
-    permissions:
-      packages: read
-      contents: read
     container:
       image: ghcr.io/andymai/occt-wasm-builder:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/andymai/occt-wasm-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -16,8 +16,14 @@ jobs:
   build:
     name: WASM Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
+      contents: read
     container:
       image: ghcr.io/andymai/occt-wasm-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -18,9 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/andymai/occt-wasm-builder:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  packages: read
+  contents: read
+
 env:
   NODE_VERSION: "22"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,6 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  packages: read
-  contents: read
-
 env:
   NODE_VERSION: "22"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  NODE_VERSION: "22"
+
 jobs:
   lint:
     name: Lint & Typecheck
@@ -33,7 +36,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: |
             package-lock.json
@@ -61,7 +64,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,14 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
-      - name: Download WASM artifact
+      - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
           name: occt-wasm-dist
           path: dist/
+
+      - name: Copy WASM to ts/dist for test imports
+        run: mkdir -p ts/dist && cp dist/occt-wasm.js dist/occt-wasm.wasm ts/dist/
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
         run: |
           OCCT_REV=$(git rev-parse HEAD:occt)
           BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
-          echo "hash=${OCCT_REV}-${BUILD_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
+          RAPID_HASH=$(sha256sum scripts/fetch-rapidjson.sh | cut -d' ' -f1)
+          echo "hash=${OCCT_REV}-${BUILD_HASH}-${RAPID_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
 
       - name: Cache OCCT static libs
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,8 @@ jobs:
         run: npx vitest run
 
       - name: Run benchmarks & check for regressions
-        run: npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
+        shell: bash
+        run: set -o pipefail; npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
 
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  EMSDK_VERSION: "5.0.3"
+  NODE_VERSION: "22"
+  RUST_TOOLCHAIN: "1.85"
+
 jobs:
   lint:
     name: Lint & Typecheck
@@ -16,7 +21,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
 
       - name: Rust cache
@@ -31,7 +36,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            ts/package-lock.json
 
       - name: Install TS dependencies
         run: cd ts && npm ci
@@ -53,12 +62,12 @@ jobs:
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 5.0.3
+          version: ${{ env.EMSDK_VERSION }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
@@ -66,7 +75,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            ts/package-lock.json
 
       - name: Install dependencies
         run: |
@@ -78,7 +91,10 @@ jobs:
 
       - name: Compute OCCT cache key
         id: occt-key
-        run: echo "hash=$(git rev-parse HEAD:occt)-$(sha256sum xtask/src/build.rs | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        run: |
+          OCCT_REV=$(git rev-parse HEAD:occt)
+          BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
+          echo "hash=${OCCT_REV}-${BUILD_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
 
       - name: Cache OCCT static libs
         uses: actions/cache@v4
@@ -86,7 +102,7 @@ jobs:
           path: occt/build
           key: occt-${{ steps.occt-key.outputs.hash }}
 
-      - name: Build OCCT + facade → WASM
+      - name: Build OCCT + facade -> WASM
         run: cargo xtask build
 
       - name: Build TypeScript
@@ -96,10 +112,10 @@ jobs:
           cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm dist/
 
       - name: Run tests
-        run: cd ts && npx vitest run
+        run: npx vitest run
 
       - name: Run benchmarks & check for regressions
-        run: cd ts && npx vitest run ../test/bench.test.ts 2>&1 | node ../scripts/bench-check.js
+        run: npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
 
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
@@ -118,7 +134,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            ts/package-lock.json
 
       - name: Download WASM artifact
         uses: actions/download-artifact@v4
@@ -127,10 +147,10 @@ jobs:
           path: dist/
 
       - name: Install dependencies
-        run: |
-          npm ci
-          cd ts && npm ci
-          npx playwright install chromium --with-deps
+        run: npm ci
+
+      - name: Install Playwright
+        run: npx playwright install chromium --with-deps
 
       - name: Run browser smoke test
         run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,7 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
-env:
-  EMSDK_VERSION: "5.0.3"
-  NODE_VERSION: "22"
-  RUST_TOOLCHAIN: "1.85"
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -23,7 +18,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: "1.85"
           components: rustfmt, clippy
 
       - name: Rust cache
@@ -38,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 22
           cache: npm
           cache-dependency-path: |
             package-lock.json
@@ -54,79 +49,7 @@ jobs:
         run: cd ts && npx eslint src/
 
   build-test:
-    name: WASM Build & Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: ${{ env.EMSDK_VERSION }}
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            ts/package-lock.json
-
-      - name: Install dependencies
-        run: |
-          npm ci
-          cd ts && npm ci
-
-      - name: Fetch RapidJSON headers
-        run: ./scripts/fetch-rapidjson.sh
-
-      - name: Compute OCCT cache key
-        id: occt-key
-        run: |
-          OCCT_REV=$(git rev-parse HEAD:occt)
-          BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
-          RAPID_HASH=$(sha256sum scripts/fetch-rapidjson.sh | cut -d' ' -f1)
-          echo "hash=${OCCT_REV}-${BUILD_HASH}-${RAPID_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache OCCT static libs
-        uses: actions/cache@v4
-        with:
-          path: occt/build
-          key: occt-${{ steps.occt-key.outputs.hash }}
-
-      - name: Build OCCT + facade -> WASM
-        run: cargo xtask build
-
-      - name: Build TypeScript
-        run: |
-          cd ts
-          npm run build
-          cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm dist/
-
-      - name: Run tests
-        run: npx vitest run
-
-      - name: Run benchmarks & check for regressions
-        shell: bash
-        run: set -o pipefail; npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
-
-      - name: Upload WASM artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: occt-wasm-dist
-          path: dist/
-          retention-days: 7
+    uses: ./.github/workflows/build-wasm.yml
 
   browser-smoke:
     name: Browser Smoke Test
@@ -138,11 +61,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 22
           cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            ts/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Download WASM artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   EMSDK_VERSION: "5.0.3"
   NODE_VERSION: "22"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: read
 
 jobs:
   release-please:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,8 @@ jobs:
         run: |
           OCCT_REV=$(git rev-parse HEAD:occt)
           BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
-          echo "hash=${OCCT_REV}-${BUILD_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
+          RAPID_HASH=$(sha256sum scripts/fetch-rapidjson.sh | cut -d' ' -f1)
+          echo "hash=${OCCT_REV}-${BUILD_HASH}-${RAPID_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
 
       - name: Cache OCCT static libs
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: "22"
           registry-url: https://registry.npmjs.org
 
       - name: Download WASM artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 env:
   EMSDK_VERSION: "5.0.3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,5 @@ jobs:
       - name: Run tests
         run: npx vitest run
 
-      # npm trusted publishing via OIDC — no NPM_TOKEN secret needed.
-      # Requires: npm package settings → "Require two-factor authentication or an automation
-      # token or a linked provenance-based publishing token"
-      # + Link this GitHub repo to the npm package at https://www.npmjs.com/package/occt-wasm/access
-      - name: Publish to npm (OIDC provenance)
+      - name: Publish to npm
         run: cd ts && npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,6 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  EMSDK_VERSION: "5.0.3"
-  NODE_VERSION: "22"
-  RUST_TOOLCHAIN: "1.85"
-
 jobs:
   release-please:
     name: Release Please
@@ -27,75 +22,35 @@ jobs:
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json
 
-  publish:
-    name: Build & Publish to npm
-    runs-on: ubuntu-latest
+  build:
     needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ./.github/workflows/build-wasm.yml
+    with:
+      release: true
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: [release-please, build]
     if: ${{ needs.release-please.outputs.release_created }}
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: ${{ env.EMSDK_VERSION }}
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 22
           registry-url: https://registry.npmjs.org
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            ts/package-lock.json
 
-      - name: Install dependencies
-        run: |
-          npm ci
-          cd ts && npm ci
-
-      - name: Fetch RapidJSON headers
-        run: ./scripts/fetch-rapidjson.sh
-
-      - name: Compute OCCT cache key
-        id: occt-key
-        run: |
-          OCCT_REV=$(git rev-parse HEAD:occt)
-          BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
-          RAPID_HASH=$(sha256sum scripts/fetch-rapidjson.sh | cut -d' ' -f1)
-          echo "hash=${OCCT_REV}-${BUILD_HASH}-${RAPID_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache OCCT static libs
-        uses: actions/cache@v4
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v4
         with:
-          path: occt/build
-          key: occt-${{ steps.occt-key.outputs.hash }}
-
-      - name: Build WASM (release)
-        run: cargo xtask build --release
-
-      - name: Build TypeScript
-        run: |
-          cd ts
-          npm run build
-          cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm dist/
-
-      - name: Run tests
-        run: npx vitest run
+          name: occt-wasm-dist
+          path: ts/dist/
 
       - name: Publish to npm
         run: cd ts && npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,13 @@ jobs:
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: ts/package-lock.json
 
-      - name: Download WASM artifact
+      - name: Install dependencies
+        run: cd ts && npm ci
+
+      - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
           name: occt-wasm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  packages: read
 
 jobs:
   release-please:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,99 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
+
+env:
+  EMSDK_VERSION: "5.0.3"
+  NODE_VERSION: "22"
+  RUST_TOOLCHAIN: "1.85"
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json
+
+  publish:
+    name: Build & Publish to npm
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup emsdk
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: ${{ env.EMSDK_VERSION }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            ts/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          cd ts && npm ci
+
+      - name: Fetch RapidJSON headers
+        run: ./scripts/fetch-rapidjson.sh
+
+      - name: Compute OCCT cache key
+        id: occt-key
+        run: |
+          OCCT_REV=$(git rev-parse HEAD:occt)
+          BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
+          echo "hash=${OCCT_REV}-${BUILD_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache OCCT static libs
+        uses: actions/cache@v4
+        with:
+          path: occt/build
+          key: occt-${{ steps.occt-key.outputs.hash }}
+
+      - name: Build WASM (release)
+        run: cargo xtask build --release
+
+      - name: Build TypeScript
+        run: |
+          cd ts
+          npm run build
+          cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm dist/
+
+      - name: Run tests
+        run: npx vitest run
+
+      # npm trusted publishing via OIDC — no NPM_TOKEN secret needed.
+      # Requires: npm package settings → "Require two-factor authentication or an automation
+      # token or a linked provenance-based publishing token"
+      # + Link this GitHub repo to the npm package at https://www.npmjs.com/package/occt-wasm/access
+      - name: Publish to npm (OIDC provenance)
+        run: cd ts && npm publish --provenance --access public

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -1,8 +1,0 @@
-name: Warm OCCT Cache
-
-on:
-  workflow_dispatch:
-
-jobs:
-  warm:
-    uses: ./.github/workflows/build-wasm.yml

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -3,6 +3,10 @@ name: Warm OCCT Cache
 on:
   workflow_dispatch:
 
+env:
+  EMSDK_VERSION: "5.0.3"
+  RUST_TOOLCHAIN: "1.85"
+
 jobs:
   warm:
     name: Build OCCT static libs
@@ -15,19 +19,22 @@ jobs:
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 3.1.74
+          version: ${{ env.EMSDK_VERSION }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.85"
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
       - name: Compute OCCT cache key
         id: occt-key
-        run: echo "hash=$(git rev-parse HEAD:occt)-$(sha256sum xtask/src/build.rs | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        run: |
+          OCCT_REV=$(git rev-parse HEAD:occt)
+          BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
+          echo "hash=${OCCT_REV}-${BUILD_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
 
       - name: Cache OCCT static libs
         id: occt-cache

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -3,56 +3,6 @@ name: Warm OCCT Cache
 on:
   workflow_dispatch:
 
-env:
-  EMSDK_VERSION: "5.0.3"
-  RUST_TOOLCHAIN: "1.85"
-
 jobs:
   warm:
-    name: Build OCCT static libs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: ${{ env.EMSDK_VERSION }}
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Compute OCCT cache key
-        id: occt-key
-        run: |
-          OCCT_REV=$(git rev-parse HEAD:occt)
-          BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
-          RAPID_HASH=$(sha256sum scripts/fetch-rapidjson.sh | cut -d' ' -f1)
-          echo "hash=${OCCT_REV}-${BUILD_HASH}-${RAPID_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache OCCT static libs
-        id: occt-cache
-        uses: actions/cache@v4
-        with:
-          path: occt/build
-          key: occt-${{ steps.occt-key.outputs.hash }}
-
-      - name: Fetch RapidJSON headers
-        if: steps.occt-cache.outputs.cache-hit != 'true'
-        run: ./scripts/fetch-rapidjson.sh
-
-      - name: Build OCCT static libs
-        if: steps.occt-cache.outputs.cache-hit != 'true'
-        run: cargo xtask build-occt
-
-      - name: Report
-        run: |
-          echo "OCCT build dir: $(du -sh occt/build | cut -f1)"
-          ls occt/build/lin32/clang/lib/*.a 2>/dev/null | wc -l | xargs -I{} echo "Static libs: {}"
+    uses: ./.github/workflows/build-wasm.yml

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           OCCT_REV=$(git rev-parse HEAD:occt)
           BUILD_HASH=$(sha256sum xtask/src/build.rs | cut -d' ' -f1)
-          echo "hash=${OCCT_REV}-${BUILD_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
+          RAPID_HASH=$(sha256sum scripts/fetch-rapidjson.sh | cut -d' ' -f1)
+          echo "hash=${OCCT_REV}-${BUILD_HASH}-${RAPID_HASH}-emsdk${{ env.EMSDK_VERSION }}" >> "$GITHUB_OUTPUT"
 
       - name: Cache OCCT static libs
         id: occt-cache

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+# Pre-built OCCT static libs for CI. Push to ghcr.io/andymai/occt-wasm-builder.
+# Rebuild only when OCCT submodule, emsdk version, or cmake flags change.
+
+FROM emscripten/emsdk:5.0.3
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake ninja-build \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust (needed for xtask)
+COPY rust-toolchain.toml /tmp/rust-toolchain.toml
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain "$(grep channel /tmp/rust-toolchain.toml | cut -d'"' -f2)" \
+    && rm /tmp/rust-toolchain.toml
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /workspace
+
+# RapidJSON headers
+COPY scripts/fetch-rapidjson.sh scripts/
+RUN bash scripts/fetch-rapidjson.sh
+
+# OCCT source + build (~50 min, cached in image layer)
+COPY occt/ occt/
+RUN mkdir -p occt/build && cd occt/build \
+    && emcmake cmake .. \
+        -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_MODULE_FoundationClasses=TRUE \
+        -DBUILD_MODULE_ModelingData=TRUE \
+        -DBUILD_MODULE_ModelingAlgorithms=TRUE \
+        -DBUILD_MODULE_DataExchange=TRUE \
+        -DBUILD_MODULE_ApplicationFramework=TRUE \
+        -DBUILD_MODULE_Visualization=FALSE \
+        -DBUILD_MODULE_Draw=FALSE \
+        -DBUILD_LIBRARY_TYPE=Static \
+        -DUSE_FREETYPE=OFF \
+        -DUSE_RAPIDJSON=ON \
+        -D3RDPARTY_RAPIDJSON_INCLUDE_DIR=/workspace/3rdparty/rapidjson \
+        "-DCMAKE_C_FLAGS=-fwasm-exceptions -O3 -msimd128 -mrelaxed-simd -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
+        "-DCMAKE_CXX_FLAGS=-fwasm-exceptions -O3 -msimd128 -mrelaxed-simd -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
+        -Wno-dev \
+    && cmake --build . --parallel \
+    && echo "OCCT: $(ls -1 lin32/clang/lib/*.a 2>/dev/null | wc -l) static libs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@playwright/test": "^1.58.2",
         "husky": "^9",
         "opencascade.js": "^1.1.1",
-        "serve": "^14.2.6"
+        "serve": "^14.2.6",
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -296,6 +297,74 @@
         "node": ">=v18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -312,6 +381,297 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
@@ -322,6 +682,20 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -331,6 +705,119 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@zeit/schemas": {
@@ -434,6 +921,16 @@
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -592,6 +1089,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -811,6 +1318,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -905,6 +1419,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -952,6 +1476,13 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -960,6 +1491,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/execa": {
@@ -986,6 +1527,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1009,6 +1560,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/find-up": {
       "version": "7.0.0",
@@ -1358,6 +1927,267 @@
         "node": "*"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -1443,6 +2273,16 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/meow": {
       "version": "12.1.1",
@@ -1537,6 +2377,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -1559,6 +2418,17 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-headers": {
       "version": "1.1.0",
@@ -1691,12 +2561,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/playwright": {
       "version": "1.58.2",
@@ -1728,6 +2619,35 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/range-parser": {
@@ -1815,6 +2735,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
       }
     },
     "node_modules/safe-buffer": {
@@ -1939,12 +2893,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -1955,6 +2926,20 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2037,6 +3022,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -2046,6 +3038,41 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -2116,6 +3143,181 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2130,6 +3332,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@playwright/test": "^1.58.2",
     "husky": "^9",
     "opencascade.js": "^1.1.1",
-    "serve": "^14.2.6"
+    "serve": "^14.2.6",
+    "vitest": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "publish:dry": "./scripts/publish.sh --dry-run",
     "publish:npm": "./scripts/publish.sh",
     "docker:build": "DOCKER_BUILDKIT=1 docker build --progress=plain -t occt-wasm .",
-    "docker:dist": "DOCKER_BUILDKIT=1 docker build --progress=plain -t occt-wasm . && docker run --rm -v \"$(pwd)/dist:/out\" occt-wasm sh -c 'cp dist/* /out/'"
+    "docker:dist": "DOCKER_BUILDKIT=1 docker build --progress=plain -t occt-wasm . && docker run --rm -v \"$(pwd)/dist:/out\" occt-wasm sh -c 'cp dist/* /out/'",
+    "builder:build": "./scripts/builder-image.sh --build",
+    "builder:push": "./scripts/builder-image.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^19",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,7 @@
           "jsonpath": "$.version"
         }
       ],
-      "bump-patch-for-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/scripts/builder-image.sh
+++ b/scripts/builder-image.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build and push the occt-wasm-builder Docker image to GHCR.
+# This image contains pre-built OCCT static libs so CI skips the ~50 min compile.
+#
+# Usage:
+#   ./scripts/builder-image.sh          # Build and push
+#   ./scripts/builder-image.sh --build  # Build only (no push)
+#
+# Rebuild when: OCCT submodule, Dockerfile.builder, cmake flags, or emsdk version change.
+set -euo pipefail
+
+IMAGE="ghcr.io/andymai/occt-wasm-builder"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Detect if running inside distrobox
+DOCKER="docker"
+if command -v distrobox-host-exec &>/dev/null && [ -f /run/.containerenv ]; then
+    DOCKER="distrobox-host-exec docker"
+fi
+
+# Tag with OCCT submodule short rev
+OCCT_REV=$(git rev-parse --short HEAD:occt)
+TAG="${OCCT_REV}"
+
+echo "Building ${IMAGE}:${TAG}"
+echo "  OCCT rev: ${OCCT_REV}"
+echo "  Docker:   ${DOCKER}"
+echo ""
+
+$DOCKER build \
+    -f Dockerfile.builder \
+    --progress=plain \
+    -t "${IMAGE}:${TAG}" \
+    -t "${IMAGE}:latest" \
+    .
+
+echo ""
+echo "Built: ${IMAGE}:${TAG}"
+echo "Built: ${IMAGE}:latest"
+
+if [[ "${1:-}" == "--build" ]]; then
+    echo "Skipping push (--build flag)."
+    exit 0
+fi
+
+# Ensure logged in
+if ! $DOCKER manifest inspect "${IMAGE}:latest" &>/dev/null 2>&1; then
+    echo ""
+    echo "Pushing to GHCR (login if prompted)..."
+fi
+
+$DOCKER push "${IMAGE}:${TAG}"
+$DOCKER push "${IMAGE}:latest"
+
+echo ""
+echo "Pushed: ${IMAGE}:${TAG}"
+echo "Pushed: ${IMAGE}:latest"
+echo ""
+echo "CI will now use this image. No OCCT recompilation needed."

--- a/scripts/builder-image.sh
+++ b/scripts/builder-image.sh
@@ -44,11 +44,9 @@ if [[ "${1:-}" == "--build" ]]; then
     exit 0
 fi
 
-# Ensure logged in
-if ! $DOCKER manifest inspect "${IMAGE}:latest" &>/dev/null 2>&1; then
-    echo ""
-    echo "Pushing to GHCR (login if prompted)..."
-fi
+# Login to GHCR via gh CLI token
+echo "Logging into GHCR via gh CLI..."
+gh auth token | $DOCKER login ghcr.io -u andymai --password-stdin
 
 $DOCKER push "${IMAGE}:${TAG}"
 $DOCKER push "${IMAGE}:latest"

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -408,6 +408,19 @@ function vecToNumbers(vec: EmbindVectorF64 | EmbindVectorI32): number[] {
     return result;
 }
 
+/**
+ * Extract the first n elements from an Embind vector into an array,
+ * then delete the vector and return the result.
+ */
+function extractFromVector(vec: EmbindVectorF64 | EmbindVectorI32, count: number): number[] {
+    const result: number[] = [];
+    for (let i = 0; i < count; i++) {
+        result.push(vec.get(i));
+    }
+    vec.delete();
+    return result;
+}
+
 function vecToHandles(vec: EmbindVectorU32): ShapeHandle[] {
     const result: ShapeHandle[] = [];
     for (let i = 0; i < vec.size(); i++) {
@@ -1264,12 +1277,9 @@ export class OcctKernel {
     }
 
     surfaceCurvature(face: ShapeHandle, u: number, v: number): CurvatureData {
-        return wrap("surfaceCurvature", () => {
-            const vec = this.#raw.surfaceCurvature(face, u, v);
-            const result = { min: vec.get(0), max: vec.get(1), gaussian: vec.get(2), mean: vec.get(3) };
-            vec.delete();
-            return result;
-        });
+        return wrap("surfaceCurvature", () =>
+            this.#curvatureDataFromEmbind(this.#raw.surfaceCurvature(face, u, v)),
+        );
     }
 
     // =======================================================================
@@ -1306,23 +1316,16 @@ export class OcctKernel {
     }
 
     uvBounds(face: ShapeHandle): UVBounds {
-        return wrap("uvBounds", () => {
-            const vec = this.#raw.uvBounds(face);
-            const result = { uMin: vec.get(0), uMax: vec.get(1), vMin: vec.get(2), vMax: vec.get(3) };
-            vec.delete();
-            return result;
-        });
+        return wrap("uvBounds", () =>
+            this.#uvBoundsFromEmbind(this.#raw.uvBounds(face)),
+        );
     }
 
     /** Project a 3D point onto a face, returning [u, v]. */
     uvFromPoint(face: ShapeHandle, point: Vec3): { u: number; v: number } {
-        return wrap("uvFromPoint", () => {
-            const vec = this.#raw.uvFromPoint(face, point.x, point.y, point.z);
-            const u = vec.get(0);
-            const v = vec.get(1);
-            vec.delete();
-            return { u, v };
-        });
+        return wrap("uvFromPoint", () =>
+            this.#vec2FromEmbind(this.#raw.uvFromPoint(face, point.x, point.y, point.z)),
+        );
     }
 
     /** Project a 3D point onto a face, returning the closest point as Vec3. */
@@ -1372,10 +1375,7 @@ export class OcctKernel {
     /** Returns [firstParam, lastParam]. */
     curveParameters(edge: ShapeHandle): { first: number; last: number } {
         return wrap("curveParameters", () => {
-            const vec = this.#raw.curveParameters(edge);
-            const first = vec.get(0);
-            const last = vec.get(1);
-            vec.delete();
+            const { u: first, v: last } = this.#vec2FromEmbind(this.#raw.curveParameters(edge));
             return { first, last };
         });
     }
@@ -1411,23 +1411,16 @@ export class OcctKernel {
     getNurbsCurveData(edge: ShapeHandle): NurbsCurveData {
         return wrap("getNurbsCurveData", () => {
             const raw = this.#raw.getNurbsCurveData(edge);
-            const knots = vecToNumbers(raw.knots);
-            raw.knots.delete();
-            const multiplicities = vecToNumbers(raw.multiplicities);
-            raw.multiplicities.delete();
-            const poles = vecToNumbers(raw.poles);
-            raw.poles.delete();
-            const weights = vecToNumbers(raw.weights);
-            raw.weights.delete();
-            return {
+            const result: NurbsCurveData = {
                 degree: raw.degree,
                 rational: raw.rational,
                 periodic: raw.periodic,
-                knots,
-                multiplicities,
-                poles,
-                weights,
+                knots: extractFromVector(raw.knots, raw.knots.size()),
+                multiplicities: extractFromVector(raw.multiplicities, raw.multiplicities.size()),
+                poles: extractFromVector(raw.poles, raw.poles.size()),
+                weights: extractFromVector(raw.weights, raw.weights.size()),
             };
+            return result;
         });
     }
 
@@ -1754,22 +1747,27 @@ export class OcctKernel {
     // Private helpers
     // =======================================================================
 
-    #makeVectorU32(ids: ShapeHandle[] | number[]): EmbindVectorU32 {
-        const vec = new this.#module.VectorUint32();
-        for (const id of ids) { vec.push_back(id); }
+    #makeVector<T extends { push_back(v: number): void }>(
+        ctor: new () => T,
+        values: number[] | ShapeHandle[],
+    ): T {
+        const vec = new ctor();
+        for (const v of values) {
+            vec.push_back(v);
+        }
         return vec;
+    }
+
+    #makeVectorU32(ids: ShapeHandle[] | number[]): EmbindVectorU32 {
+        return this.#makeVector(this.#module.VectorUint32, ids);
     }
 
     #makeVectorF64(values: number[]): EmbindVectorF64 {
-        const vec = new this.#module.VectorDouble();
-        for (const v of values) { vec.push_back(v); }
-        return vec;
+        return this.#makeVector(this.#module.VectorDouble, values);
     }
 
     #makeVectorI32(values: number[]): EmbindVectorI32 {
-        const vec = new this.#module.VectorInt();
-        for (const v of values) { vec.push_back(v); }
-        return vec;
+        return this.#makeVector(this.#module.VectorInt, values);
     }
 
     #flattenPoints(points: Vec3[]): EmbindVectorF64 {
@@ -1780,6 +1778,35 @@ export class OcctKernel {
             vec.push_back(p.z);
         }
         return vec;
+    }
+
+    #vec2FromEmbind(vec: EmbindVectorF64): { u: number; v: number } {
+        const u = vec.get(0);
+        const v = vec.get(1);
+        vec.delete();
+        return { u, v };
+    }
+
+    #uvBoundsFromEmbind(vec: EmbindVectorF64): UVBounds {
+        const result: UVBounds = {
+            uMin: vec.get(0),
+            uMax: vec.get(1),
+            vMin: vec.get(2),
+            vMax: vec.get(3),
+        };
+        vec.delete();
+        return result;
+    }
+
+    #curvatureDataFromEmbind(vec: EmbindVectorF64): CurvatureData {
+        const result: CurvatureData = {
+            min: vec.get(0),
+            max: vec.get(1),
+            gaussian: vec.get(2),
+            mean: vec.get(3),
+        };
+        vec.delete();
+        return result;
     }
 
     #vec3FromEmbind(vec: EmbindVectorF64): Vec3 {


### PR DESCRIPTION
## Summary
- Centralize emsdk/node/rust versions in env vars across all 3 workflows
- Add npm cache to all jobs (`setup-node` cache option)
- Include emsdk version in OCCT cache key (prevents stale cache)
- Fix vitest paths to use root `vitest.config.ts`
- Add npm publish job to release workflow (OIDC provenance, no token needed)
- Fix warm-cache emsdk version (was 3.1.74, now 5.0.3)
- Set `bump-patch-for-minor-pre-major: false` for proper 1.x semver

## Test plan
- [x] CI: lint job uses npm cache
- [x] CI: WASM build uses emsdk 5.0.3 + versioned OCCT cache key
- [x] CI: vitest runs from root with vitest.config.ts
- [x] Release: publish job only fires on release_created
- [x] Release: OIDC provenance (no NPM_TOKEN secret)
- [ ] Wait for CI green on this PR