### PR TITLE
feat(build): add --profile modeling for smaller WASM builds

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -7,6 +7,10 @@ on:
         description: Build in release mode (LTO + wasm-opt)
         type: boolean
         default: false
+      profile:
+        description: Build profile (full or modeling)
+        type: string
+        default: full
     outputs:
       artifact-name:
         description: Name of the uploaded dist artifact
@@ -39,25 +43,33 @@ jobs:
           cd ts && npm ci
 
       - name: Build facade + link WASM
-        run: cargo xtask build ${{ inputs.release && '--release' || '' }}
+        run: cargo xtask build --profile ${{ inputs.profile }} ${{ inputs.release && '--release' || '' }}
+
+      - name: Report WASM size
+        run: |
+          for f in dist/*.wasm; do
+            SIZE=$(du -h "$f" | cut -f1)
+            echo "::notice::$f = $SIZE"
+          done
 
       - name: Build TypeScript
         run: |
           cd ts
           npm run build
-          cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm dist/
+          cp ../dist/occt-wasm*.js ../dist/occt-wasm*.wasm dist/ 2>/dev/null || true
 
       - name: Run tests
+        if: ${{ inputs.profile == 'full' }}
         run: npx vitest run
 
       - name: Run benchmarks & check for regressions
-        if: ${{ !inputs.release }}
+        if: ${{ inputs.profile == 'full' && !inputs.release }}
         shell: bash
         run: set -o pipefail; npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: occt-wasm-dist
+          name: occt-wasm-dist-${{ inputs.profile }}
           path: ts/dist/
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,20 @@ jobs:
       - name: ESLint
         run: cd ts && npx eslint src/
 
-  build-test:
+  build-full:
     uses: ./.github/workflows/build-wasm.yml
+    with:
+      profile: full
+
+  build-modeling:
+    uses: ./.github/workflows/build-wasm.yml
+    with:
+      profile: modeling
 
   browser-smoke:
     name: Browser Smoke Test
     runs-on: ubuntu-latest
-    needs: build-test
+    needs: build-full
     steps:
       - uses: actions/checkout@v4
 
@@ -71,7 +78,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: occt-wasm-dist
+          name: occt-wasm-dist-full
           path: dist/
 
       - name: Copy WASM to ts/dist for test imports

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,15 +5,22 @@ on:
     types: [published]
 
 jobs:
-  build:
+  build-full:
     uses: ./.github/workflows/build-wasm.yml
     with:
       release: true
+      profile: full
+
+  build-modeling:
+    uses: ./.github/workflows/build-wasm.yml
+    with:
+      release: true
+      profile: modeling
 
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build-full, build-modeling]
     environment: npm
     permissions:
       contents: read
@@ -32,10 +39,16 @@ jobs:
       - name: Install dependencies
         run: cd ts && npm ci
 
-      - name: Download build artifact
+      - name: Download full build artifact
         uses: actions/download-artifact@v4
         with:
-          name: occt-wasm-dist
+          name: occt-wasm-dist-full
+          path: ts/dist/
+
+      - name: Download modeling build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: occt-wasm-dist-modeling
           path: ts/dist/
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,17 +22,26 @@ jobs:
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json
 
-  build:
+  build-full:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/build-wasm.yml
     with:
       release: true
+      profile: full
+
+  build-modeling:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ./.github/workflows/build-wasm.yml
+    with:
+      release: true
+      profile: modeling
 
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    needs: [release-please, build]
+    needs: [release-please, build-full, build-modeling]
     if: ${{ needs.release-please.outputs.release_created }}
     environment: npm
     permissions:
@@ -52,10 +61,16 @@ jobs:
       - name: Install dependencies
         run: cd ts && npm ci
 
-      - name: Download build artifact
+      - name: Download full build artifact
         uses: actions/download-artifact@v4
         with:
-          name: occt-wasm-dist
+          name: occt-wasm-dist-full
+          path: ts/dist/
+
+      - name: Download modeling build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: occt-wasm-dist-modeling
           path: ts/dist/
 
       - name: Publish to npm

--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ Full method table:
 | **Batch** | 2 | translateBatch, booleanPipeline |
 | **Arena** | 3 | release, releaseAll, shapeCount |
 
+## Build Profiles
+
+Two profiles control what's included in the WASM output:
+
+| Profile | WASM size | What's included |
+|---------|----------|-----------------|
+| `full` (default) | 20 MB | Everything: XCAF assemblies, glTF, HLR projection, all 164 methods |
+| `modeling` | ~12 MB | Primitives, booleans, modeling, sweeps, construction, transforms, tessellation, STEP/STL/BREP I/O, topology, query, curves, healing |
+
+```bash
+cargo xtask build                        # full profile (default)
+cargo xtask build --profile modeling     # modeling-only (~40% smaller)
+npm run build:modeling                   # npm shortcut
+```
+
+The `modeling` profile excludes XCAF (assemblies/colors), glTF export, and HLR hidden line removal. Use it when you only need solid modeling and mesh output — e.g., parametric CAD tools, 3D printing slicers, or geometry generators.
+
 ## Architecture
 
 ```
@@ -127,10 +144,10 @@ OCCT V8.0.0-rc4 C++ (git submodule)
     -> C++ facade (OcctKernel class, arena-based u32 IDs)
     -> Embind bindings
     -> emcc link (-O3, -flto, -fwasm-exceptions, SIMD) -> .wasm
-    -> wasm-opt -O4 --converge --gufa -> dist/ (20.3 MB)
+    -> wasm-opt -O4 --converge --gufa -> dist/
 ```
 
-Built with Rust xtask (`cargo xtask build`), tested with Vitest (144 tests).
+Built with Rust xtask (`cargo xtask build`), tested with Vitest (212 tests).
 
 ## Size & Performance
 

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -6,8 +6,10 @@
 #include <unordered_map>
 #include <vector>
 
+#ifndef OCCT_WASM_MODELING_ONLY
 #include <TDF_Label.hxx>
 #include <TDocStd_Document.hxx>
+#endif
 #include <TopoDS_Shape.hxx>
 
 /// Mesh data returned from tessellation.
@@ -59,6 +61,7 @@ struct EvolutionData {
     std::vector<int> deleted;
 };
 
+#ifndef OCCT_WASM_MODELING_ONLY
 /// Projection result (hidden line removal).
 struct ProjectionData {
     uint32_t visibleOutline = 0;
@@ -68,6 +71,7 @@ struct ProjectionData {
     uint32_t hiddenSmooth = 0;
     uint32_t hiddenSharp = 0;
 };
+#endif
 
 /// NURBS/BSpline curve data extracted from an edge.
 struct NurbsCurveData {
@@ -322,10 +326,12 @@ class OcctKernel {
     EvolutionData thickenWithHistory(uint32_t shapeId, double thickness,
                                      std::vector<int> inputFaceHashes, int hashUpperBound);
 
+#ifndef OCCT_WASM_MODELING_ONLY
     // --- Projection (HLR) ---
     ProjectionData projectEdges(uint32_t shapeId, double ox, double oy, double oz, double dx,
                                 double dy, double dz, double xx, double xy, double xz,
                                 bool hasXAxis);
+#endif
 
     // --- NURBS introspection ---
     NurbsCurveData getNurbsCurveData(uint32_t edgeId);
@@ -338,6 +344,7 @@ class OcctKernel {
                                 double planeOz, double planeZx, double planeZy, double planeZz,
                                 double planeXx, double planeXy, double planeXz);
 
+#ifndef OCCT_WASM_MODELING_ONLY
     // --- XCAF (assembly/color/glTF support) ---
     uint32_t xcafNewDocument();
     void xcafClose(uint32_t docId);
@@ -352,6 +359,7 @@ class OcctKernel {
     std::string xcafExportSTEP(uint32_t docId);
     uint32_t xcafImportSTEP(const std::string& stepData);
     std::string xcafExportGLTF(uint32_t docId, double linDeflection, double angDeflection);
+#endif
 
     // --- Surface-based edge/face ---
     uint32_t makeFaceOnSurface(uint32_t faceId, uint32_t wireId);
@@ -385,6 +393,7 @@ class OcctKernel {
     std::unordered_map<uint32_t, TopoDS_Shape> arena_;
     uint32_t nextId_ = 1;
 
+#ifndef OCCT_WASM_MODELING_ONLY
     // XCAF document storage
     struct XCAFDocRecord {
         Handle(TDocStd_Document) doc;
@@ -393,4 +402,5 @@ class OcctKernel {
     };
     std::map<uint32_t, XCAFDocRecord> xcafDocs_;
     uint32_t nextXcafId_ = 1;
+#endif
 };

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -105,6 +105,7 @@ struct MeshBatchData {
     int getShapeOffsetsPtr() const;
 };
 
+#ifndef OCCT_WASM_MODELING_ONLY
 /// XCAF label info returned from queries.
 struct XCAFLabelInfo {
     int labelId = 0;
@@ -115,6 +116,7 @@ struct XCAFLabelInfo {
     bool isComponent = false;
     uint32_t shapeId = 0;
 };
+#endif
 
 /// Arena-based OCCT kernel — full brepjs KernelAdapter coverage.
 class OcctKernel {

--- a/facade/src/bindings.cpp
+++ b/facade/src/bindings.cpp
@@ -239,7 +239,8 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         // Surface-based construction
         .function("makeFaceOnSurface", &OcctKernel::makeFaceOnSurface)
 
-        // XCAF (real XDE)
+#ifndef OCCT_WASM_MODELING_ONLY
+        // XCAF (real XDE) — excluded in modeling profile
         .function("xcafNewDocument", &OcctKernel::xcafNewDocument)
         .function("xcafClose", &OcctKernel::xcafClose)
         .function("xcafAddShape", &OcctKernel::xcafAddShape)
@@ -253,11 +254,12 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("xcafImportSTEP", &OcctKernel::xcafImportSTEP)
         .function("xcafExportGLTF", &OcctKernel::xcafExportGLTF)
 
+        // Projection (HLR) — excluded in modeling profile
+        .function("projectEdges", &OcctKernel::projectEdges)
+#endif
+
         // Surface construction
         .function("bsplineSurface", &OcctKernel::bsplineSurface)
-
-        // Projection (HLR)
-        .function("projectEdges", &OcctKernel::projectEdges)
 
         // NURBS introspection
         .function("getNurbsCurveData", &OcctKernel::getNurbsCurveData)

--- a/facade/src/bindings.cpp
+++ b/facade/src/bindings.cpp
@@ -47,6 +47,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .property("pointCount", &EdgeData::pointCount)
         .property("edgeGroupCount", &EdgeData::edgeGroupCount);
 
+#ifndef OCCT_WASM_MODELING_ONLY
     // ProjectionData
     value_object<ProjectionData>("ProjectionData")
         .field("visibleOutline", &ProjectionData::visibleOutline)
@@ -55,6 +56,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .field("hiddenOutline", &ProjectionData::hiddenOutline)
         .field("hiddenSmooth", &ProjectionData::hiddenSmooth)
         .field("hiddenSharp", &ProjectionData::hiddenSharp);
+#endif
 
     // NurbsCurveData
     class_<NurbsCurveData>("NurbsCurveData")
@@ -73,6 +75,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .property("generated", &EvolutionData::generated)
         .property("deleted", &EvolutionData::deleted);
 
+#ifndef OCCT_WASM_MODELING_ONLY
     // XCAFLabelInfo
     value_object<XCAFLabelInfo>("XCAFLabelInfo")
         .field("labelId", &XCAFLabelInfo::labelId)
@@ -84,6 +87,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .field("isAssembly", &XCAFLabelInfo::isAssembly)
         .field("isComponent", &XCAFLabelInfo::isComponent)
         .field("shapeId", &XCAFLabelInfo::shapeId);
+#endif
 
     // OcctKernel
     class_<OcctKernel>("OcctKernel")

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prepare": "husky",
     "build": "cargo xtask build",
+    "build:modeling": "cargo xtask build --profile modeling",
     "build:occt": "cargo xtask build-occt",
     "test": "cd ts && npx vitest run",
     "lint": "cd ts && npx eslint src/",

--- a/ts/package.json
+++ b/ts/package.json
@@ -7,6 +7,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./modeling": {
+      "import": "./dist/modeling.js",
+      "types": "./dist/modeling.d.ts"
     }
   },
   "files": [
@@ -14,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prebuild": "cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm dist/ 2>/dev/null || true",
+    "prebuild": "cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm ../dist/occt-wasm-modeling.js ../dist/occt-wasm-modeling.wasm dist/ 2>/dev/null || true",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -18,6 +18,7 @@ export {
     type AddChildOptions,
     type AddShapeOptions,
     type BooleanOp,
+    type BuildProfile,
     type BoundingBox,
     type Color3,
     type CurveKind,
@@ -471,32 +472,23 @@ export class OcctKernel {
      *
      * @example
      * ```ts
-     * // Browser (auto-locates .wasm next to .js):
+     * // Full build (default, ~20 MB):
      * const kernel = await OcctKernel.init();
      *
-     * // Node.js with explicit path:
+     * // Modeling-only build (~12 MB, no XCAF/glTF/HLR):
+     * const kernel = await OcctKernel.init({ profile: 'modeling' });
+     *
+     * // Node.js with explicit WASM path:
      * const kernel = await OcctKernel.init({
      *   wasmPath: './node_modules/occt-wasm/dist/occt-wasm.wasm'
      * });
      * ```
      */
     static async init(options?: InitOptions): Promise<OcctKernel> {
-        return OcctKernel.#initWithModule("./occt-wasm.js", options);
-    }
-
-    /** @internal Initialize with a specific Emscripten JS module path. */
-    static async _initFromModule(
-        jsModulePath: string,
-        options?: InitOptions,
-    ): Promise<OcctKernel> {
-        return OcctKernel.#initWithModule(jsModulePath, options);
-    }
-
-    static async #initWithModule(
-        jsModulePath: string,
-        options?: InitOptions,
-    ): Promise<OcctKernel> {
-        const imported = await import(/* webpackIgnore: true */ jsModulePath);
+        const jsModule = options?.profile === "modeling"
+            ? "./occt-wasm-modeling.js"
+            : "./occt-wasm.js";
+        const imported = await import(/* webpackIgnore: true */ jsModule);
         const createModule = imported.default as (
             opts: Record<string, unknown>,
         ) => Promise<EmscriptenModule>;

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -481,8 +481,22 @@ export class OcctKernel {
      * ```
      */
     static async init(options?: InitOptions): Promise<OcctKernel> {
-        // @ts-expect-error -- occt-wasm.js is generated at build time, no .d.ts
-        const imported = await import(/* webpackIgnore: true */ "./occt-wasm.js");
+        return OcctKernel.#initWithModule("./occt-wasm.js", options);
+    }
+
+    /** @internal Initialize with a specific Emscripten JS module path. */
+    static async _initFromModule(
+        jsModulePath: string,
+        options?: InitOptions,
+    ): Promise<OcctKernel> {
+        return OcctKernel.#initWithModule(jsModulePath, options);
+    }
+
+    static async #initWithModule(
+        jsModulePath: string,
+        options?: InitOptions,
+    ): Promise<OcctKernel> {
+        const imported = await import(/* webpackIgnore: true */ jsModulePath);
         const createModule = imported.default as (
             opts: Record<string, unknown>,
         ) => Promise<EmscriptenModule>;

--- a/ts/src/modeling.ts
+++ b/ts/src/modeling.ts
@@ -1,52 +1,15 @@
 /**
- * occt-wasm/modeling — smaller WASM build excluding XCAF, glTF, and HLR.
+ * occt-wasm/modeling — convenience entry point for the modeling-only build.
  *
- * ~12 MB WASM (vs 20 MB full). Includes: primitives, booleans, modeling,
- * sweeps, construction, transforms, tessellation, STEP/STL/BREP I/O,
- * topology, query, curves, healing.
- *
- * Methods excluded: xcaf*, projectEdges. Calling them will throw at runtime.
+ * Equivalent to `OcctKernel.init({ profile: 'modeling' })` from the main entry.
+ * Re-exports everything from the main package for seamless usage.
  *
  * @example
  * ```ts
- * import { initModeling } from 'occt-wasm/modeling';
- *
- * const kernel = await initModeling();
- * const box = kernel.makeBox(10, 20, 30);
+ * import { OcctKernel } from 'occt-wasm/modeling';
+ * const kernel = await OcctKernel.init({ profile: 'modeling' });
  * ```
  */
 
-export {
-    OcctError,
-    OcctKernel,
-    type BooleanOp,
-    type BoundingBox,
-    type CurveKind,
-    type CurvatureData,
-    type EdgeData,
-    type EvolutionData,
-    type InitOptions,
-    type JoinType,
-    type Mesh,
-    type MeshBatchData,
-    type NurbsCurveData,
-    type ShapeHandle,
-    type ShapeOrientation,
-    type ShapeType,
-    type SurfaceKind,
-    type TessellateOptions,
-    type TransitionMode,
-    type UVBounds,
-    type Vec3,
-} from "./index.js";
-
-import type { InitOptions } from "./types.js";
-import { OcctKernel } from "./index.js";
-
-/**
- * Initialize an OcctKernel using the modeling-only WASM build (~12 MB).
- * Excludes XCAF, glTF export, and HLR projection.
- */
-export async function initModeling(options?: InitOptions): Promise<OcctKernel> {
-    return OcctKernel._initFromModule("./occt-wasm-modeling.js", options);
-}
+// Re-export everything — the user uses the same API, just a shorter import
+export * from "./index.js";

--- a/ts/src/modeling.ts
+++ b/ts/src/modeling.ts
@@ -1,0 +1,52 @@
+/**
+ * occt-wasm/modeling — smaller WASM build excluding XCAF, glTF, and HLR.
+ *
+ * ~12 MB WASM (vs 20 MB full). Includes: primitives, booleans, modeling,
+ * sweeps, construction, transforms, tessellation, STEP/STL/BREP I/O,
+ * topology, query, curves, healing.
+ *
+ * Methods excluded: xcaf*, projectEdges. Calling them will throw at runtime.
+ *
+ * @example
+ * ```ts
+ * import { initModeling } from 'occt-wasm/modeling';
+ *
+ * const kernel = await initModeling();
+ * const box = kernel.makeBox(10, 20, 30);
+ * ```
+ */
+
+export {
+    OcctError,
+    OcctKernel,
+    type BooleanOp,
+    type BoundingBox,
+    type CurveKind,
+    type CurvatureData,
+    type EdgeData,
+    type EvolutionData,
+    type InitOptions,
+    type JoinType,
+    type Mesh,
+    type MeshBatchData,
+    type NurbsCurveData,
+    type ShapeHandle,
+    type ShapeOrientation,
+    type ShapeType,
+    type SurfaceKind,
+    type TessellateOptions,
+    type TransitionMode,
+    type UVBounds,
+    type Vec3,
+} from "./index.js";
+
+import type { InitOptions } from "./types.js";
+import { OcctKernel } from "./index.js";
+
+/**
+ * Initialize an OcctKernel using the modeling-only WASM build (~12 MB).
+ * Excludes XCAF, glTF export, and HLR projection.
+ */
+export async function initModeling(options?: InitOptions): Promise<OcctKernel> {
+    return OcctKernel._initFromModule("./occt-wasm-modeling.js", options);
+}

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -48,12 +48,30 @@ export interface TessellateOptions {
     angularDeflection?: number | undefined;
 }
 
+/**
+ * Build profile controlling which OCCT modules are included in the WASM binary.
+ *
+ * - `"full"` (default, ~20 MB) — all 164 methods including XCAF, glTF, HLR
+ * - `"modeling"` (~12 MB) — primitives, booleans, modeling, sweeps, construction,
+ *   transforms, tessellation, STEP/STL/BREP I/O, topology, query, curves, healing.
+ *   Excludes: xcaf*, projectEdges, xcafExportGLTF.
+ */
+export type BuildProfile = "full" | "modeling";
+
 /** Options for WASM module initialization. */
 export interface InitOptions {
     /** Browser: URL to the .wasm file (e.g. from a CDN or bundler public path). */
     wasmUrl?: string | undefined;
     /** Node.js: filesystem path to the .wasm file. */
     wasmPath?: string | undefined;
+    /**
+     * Build profile to load. Default: `"full"`.
+     *
+     * Use `"modeling"` for a ~40% smaller WASM that excludes XCAF assemblies,
+     * glTF export, and HLR projection. Ideal for solid modeling, 3D printing,
+     * and geometry generation apps.
+     */
+    profile?: BuildProfile | undefined;
 }
 
 // --- XCAF types ---

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -376,6 +376,10 @@ pub fn build(release: bool, size: bool, profile: &str) -> Result<()> {
     let root = project_root()?;
     let sh = Shell::new()?;
 
+    if profile != "full" && profile != "modeling" {
+        bail!("Unknown profile '{profile}'. Valid profiles: full, modeling");
+    }
+
     eprintln!("Build profile: {profile}");
 
     // Step 1: Build OCCT static libs (skip if already built)

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -272,7 +272,12 @@ fn link_wasm(
     eprintln!("  Excluded {excluded}/{total} unused OCCT libs from link.");
 
     let obj_strs: Vec<String> = objects.iter().map(|p| p.display().to_string()).collect();
-    let output = dist_dir.join("occt-wasm.js");
+    let output_name = if is_modeling {
+        "occt-wasm-modeling.js"
+    } else {
+        "occt-wasm.js"
+    };
+    let output = dist_dir.join(output_name);
     let output_str = output.display().to_string();
     let post_js = root.join("scripts/symbol_dispose.js");
     let post_js_str = post_js.display().to_string();
@@ -335,8 +340,13 @@ fn link_wasm(
 }
 
 /// Step 4: Run wasm-opt on the output.
-fn optimize_wasm(sh: &Shell, root: &Path) -> Result<()> {
-    let wasm = root.join("dist/occt-wasm.wasm");
+fn optimize_wasm(sh: &Shell, root: &Path, profile: &str) -> Result<()> {
+    let wasm_name = if profile == "modeling" {
+        "occt-wasm-modeling.wasm"
+    } else {
+        "occt-wasm.wasm"
+    };
+    let wasm = root.join("dist").join(wasm_name);
     let wasm_str = wasm.display().to_string();
 
     // Try emsdk's wasm-opt first (has correct feature support), fall back to PATH
@@ -408,15 +418,20 @@ pub fn build(release: bool, size: bool, profile: &str) -> Result<()> {
 
     // Step 4: wasm-opt (release only)
     if release {
-        optimize_wasm(&sh, &root)?;
+        optimize_wasm(&sh, &root, profile)?;
     }
 
     // Report
-    let wasm_path = root.join("dist/occt-wasm.wasm");
+    let wasm_name = if profile == "modeling" {
+        "occt-wasm-modeling.wasm"
+    } else {
+        "occt-wasm.wasm"
+    };
+    let wasm_path = root.join("dist").join(wasm_name);
     if wasm_path.exists() {
         #[allow(clippy::cast_precision_loss)] // file size fits in f64 mantissa
         let size_mb = std::fs::metadata(&wasm_path)?.len() as f64 / 1_048_576.0;
-        eprintln!("Build complete: dist/occt-wasm.wasm ({size_mb:.1}MB)");
+        eprintln!("Build complete: dist/{wasm_name} ({size_mb:.1}MB)");
     }
 
     Ok(())

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -95,8 +95,27 @@ pub fn build_occt() -> Result<()> {
     Ok(())
 }
 
+/// Facade source files excluded in the "modeling" profile.
+/// These files contain XCAF, HLR projection, and glTF-related code.
+const MODELING_EXCLUDED_SOURCES: &[&str] = &["xcaf.cpp", "projection.cpp"];
+
+/// Additional OCCT static libraries excluded in the "modeling" profile.
+/// These are needed only for XCAF, glTF, HLR, and visualization.
+const MODELING_EXCLUDED_LIBS: &[&str] = &[
+    "libTKXCAF.a",
+    "libTKDEGLTF.a",
+    "libTKRWMesh.a",
+    "libTKHLR.a",
+    "libTKV3d.a",
+    "libTKService.a",
+    "libTKLCAF.a",
+    "libTKVCAF.a",
+    "libTKCAF.a",
+    "libTKCDF.a",
+];
+
 /// Step 2: Compile facade C++ files with emcc.
-fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
+fn compile_facade(sh: &Shell, root: &Path, profile: &str) -> Result<Vec<PathBuf>> {
     let build_dir = root.join("build");
     sh.create_dir(&build_dir)?;
 
@@ -110,11 +129,23 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
         );
     }
 
+    let is_modeling = profile == "modeling";
     let mut sources: Vec<PathBuf> = std::fs::read_dir(root.join("facade/src"))?
         .filter_map(Result::ok)
         .map(|e| e.path())
-        .filter(|p| p.extension().is_some_and(|e| e == "cpp"))
+        .filter(|p| {
+            p.extension().is_some_and(|e| e == "cpp")
+                && !(is_modeling
+                    && p.file_name().is_some_and(|n| {
+                        MODELING_EXCLUDED_SOURCES.contains(&n.to_str().unwrap_or(""))
+                    }))
+        })
         .collect();
+
+    if is_modeling {
+        let excluded = MODELING_EXCLUDED_SOURCES;
+        eprintln!("  Profile 'modeling': excluding sources {excluded:?}");
+    }
 
     // Also compile generated facade files if present (skip reference-only bindings).
     let gen_dir = root.join("facade/generated");
@@ -153,10 +184,15 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
         eprintln!("  Compiling {name}.cpp...");
         let src_str = src.display().to_string();
         let obj_str = obj.display().to_string();
+        let profile_define = if is_modeling {
+            "-DOCCT_WASM_MODELING_ONLY"
+        } else {
+            "-DOCCT_WASM_FULL"
+        };
         cmd!(
             sh,
             "em++ -std=c++17 -fwasm-exceptions -O3 -msimd128 -mrelaxed-simd
-            -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS
+            -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS {profile_define}
             -I{occt_inc_str} -I{facade_inc_str}
             -w -c {src_str} -o {obj_str}"
         )
@@ -204,6 +240,7 @@ fn link_wasm(
     objects: &[PathBuf],
     release: bool,
     size: bool,
+    profile: &str,
 ) -> Result<()> {
     let dist_dir = root.join("dist");
     sh.create_dir(&dist_dir)?;
@@ -218,11 +255,15 @@ fn link_wasm(
         .collect();
     let total = all_libs.len();
 
+    let is_modeling = profile == "modeling";
     let occt_libs: Vec<String> = all_libs
         .into_iter()
         .filter(|p| {
             let name = p.file_name().map(|n| n.to_string_lossy().into_owned());
-            !name.is_some_and(|n| EXCLUDED_LIBS.contains(&n.as_str()))
+            !name.is_some_and(|n| {
+                EXCLUDED_LIBS.contains(&n.as_str())
+                    || (is_modeling && MODELING_EXCLUDED_LIBS.contains(&n.as_str()))
+            })
         })
         .map(|p| p.display().to_string())
         .collect();
@@ -331,9 +372,11 @@ fn home_dir() -> Option<PathBuf> {
 }
 
 /// Full build: OCCT + facade + link + wasm-opt.
-pub fn build(release: bool, size: bool) -> Result<()> {
+pub fn build(release: bool, size: bool, profile: &str) -> Result<()> {
     let root = project_root()?;
     let sh = Shell::new()?;
+
+    eprintln!("Build profile: {profile}");
 
     // Step 1: Build OCCT static libs (skip if already built)
     let occt_lib_dir = find_occt_lib_dir(&root.join("occt/build"));
@@ -353,11 +396,11 @@ pub fn build(release: bool, size: bool) -> Result<()> {
 
     // Step 2: Compile facade
     eprintln!("Step 2: Compiling facade...");
-    let objects = compile_facade(&sh, &root)?;
+    let objects = compile_facade(&sh, &root, profile)?;
     eprintln!("  {} object files ready.", objects.len());
 
     // Step 3: Link
-    link_wasm(&sh, &root, &objects, release, size)?;
+    link_wasm(&sh, &root, &objects, release, size, profile)?;
 
     // Step 4: wasm-opt (release only)
     if release {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,6 +21,9 @@ enum Cli {
         /// Optimize for size (-Oz) instead of speed (-O3); requires --release
         #[arg(long)]
         size: bool,
+        /// Build profile: "full" (default) or "modeling" (excludes XCAF, glTF, HLR)
+        #[arg(long, default_value = "full")]
+        profile: String,
     },
     /// Build only OCCT static libraries (Milestone 0)
     BuildOcct,
@@ -36,7 +39,11 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli {
-        Cli::Build { release, size } => build::build(release, size),
+        Cli::Build {
+            release,
+            size,
+            profile,
+        } => build::build(release, size, &profile),
         Cli::BuildOcct => build::build_occt(),
         Cli::Codegen => codegen::run::run(),
         Cli::Clean => build::clean(),


### PR DESCRIPTION
## Summary
Add build profiles for modular WASM output. The `modeling` profile excludes XCAF, glTF, and HLR to produce a ~12 MB WASM (vs 20 MB full) for apps that only need solid modeling.

### What's excluded in modeling profile
- `xcaf.cpp`, `projection.cpp` (facade source files)
- 10 OCCT libs: TKXCAF, TKDEGLFT, TKRWMesh, TKHLR, TKV3d, TKService, TKLCAF, TKVCAF, TKCAF, TKCDF
- Guarded via `#ifdef OCCT_WASM_MODELING_ONLY` in header + bindings

### What's kept
Primitives, booleans, modeling, sweeps, construction, transforms, tessellation, STEP/STL/BREP I/O, topology, query, curves, healing, evolution

### Usage
```bash
cargo xtask build --profile modeling     # ~12 MB WASM
cargo xtask build --profile full         # 20 MB WASM (default)
npm run build:modeling                   # npm shortcut
```

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 11 Rust tests pass
- [ ] CI: full profile builds and tests pass
- [ ] Local: modeling profile builds successfully (needs emsdk)