### PR TITLE
refactor(xtask): code review improvements + structural tests

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -326,7 +326,8 @@ fn home_dir() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
 }
 
-/// Find the newest mtime among all `.h` and `.hxx` files in a directory.
+/// Find the newest mtime among all `.h`, `.hxx`, and `.hpp` files in a
+/// directory tree (recursive).
 ///
 /// Returns `None` if the directory doesn't exist or contains no headers.
 fn newest_header_mtime(include_dir: &Path) -> Result<Option<std::time::SystemTime>> {
@@ -334,14 +335,21 @@ fn newest_header_mtime(include_dir: &Path) -> Result<Option<std::time::SystemTim
         return Ok(None);
     }
     let mut newest = None;
-    for entry in std::fs::read_dir(include_dir)?.filter_map(Result::ok) {
-        let path = entry.path();
-        let is_header = path
-            .extension()
-            .is_some_and(|e| e == "h" || e == "hxx" || e == "hpp");
-        if is_header {
-            let mtime = std::fs::metadata(&path)?.modified()?;
-            newest = Some(newest.map_or(mtime, |prev: std::time::SystemTime| prev.max(mtime)));
+    let mut stack = vec![include_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)?.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let is_header = path
+                .extension()
+                .is_some_and(|e| e == "h" || e == "hxx" || e == "hpp");
+            if is_header {
+                let mtime = std::fs::metadata(&path)?.modified()?;
+                newest = Some(newest.map_or(mtime, |prev: std::time::SystemTime| prev.max(mtime)));
+            }
         }
     }
     Ok(newest)

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -4,16 +4,7 @@ use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
 use xshell::{Shell, cmd};
 
-/// Project root (parent of xtask/).
-fn project_root() -> Result<PathBuf> {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string());
-    let root = Path::new(&manifest_dir)
-        .parent()
-        .context("xtask must be inside the workspace")?
-        .to_path_buf();
-    Ok(root)
-}
+use crate::util::project_root;
 
 /// Locate OCCT static lib directory (varies by platform detection).
 fn find_occt_lib_dir(occt_build: &Path) -> Result<PathBuf> {
@@ -127,6 +118,12 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
         sources.extend(gen_sources);
     }
 
+    // Sort for deterministic compilation order across platforms.
+    sources.sort();
+
+    // Track header mtimes: if any header changed, all objects are stale.
+    let newest_header = newest_header_mtime(&facade_inc)?;
+
     let mut objects = Vec::new();
     let occt_inc_str = occt_inc.display().to_string();
     let facade_inc_str = facade_inc.display().to_string();
@@ -137,11 +134,12 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
         let prefix = if is_generated { "gen_" } else { "" };
         let obj = build_dir.join(format!("{prefix}{name}.o"));
 
-        // Skip if .o is newer than .cpp
+        // Skip if .o is newer than both the .cpp and all facade headers.
         if obj.exists() {
             let src_modified = std::fs::metadata(src)?.modified()?;
+            let newest_dep = newest_header.map_or(src_modified, |h| h.max(src_modified));
             let obj_modified = std::fs::metadata(&obj)?.modified()?;
-            if obj_modified >= src_modified {
+            if obj_modified >= newest_dep {
                 objects.push(obj);
                 continue;
             }
@@ -207,12 +205,13 @@ fn link_wasm(
 
     let occt_lib_dir = find_occt_lib_dir(&root.join("occt/build"))?;
 
-    // Collect all OCCT static lib paths, filtering out unused libraries
-    let all_libs: Vec<PathBuf> = std::fs::read_dir(&occt_lib_dir)?
+    // Collect all OCCT static lib paths, filtering out unused libraries.
+    let mut all_libs: Vec<PathBuf> = std::fs::read_dir(&occt_lib_dir)?
         .filter_map(Result::ok)
         .map(|e| e.path())
         .filter(|p| p.extension().is_some_and(|e| e == "a"))
         .collect();
+    all_libs.sort(); // Deterministic link order across platforms.
     let total = all_libs.len();
 
     let occt_libs: Vec<String> = all_libs
@@ -327,6 +326,27 @@ fn home_dir() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
 }
 
+/// Find the newest mtime among all `.h` and `.hxx` files in a directory.
+///
+/// Returns `None` if the directory doesn't exist or contains no headers.
+fn newest_header_mtime(include_dir: &Path) -> Result<Option<std::time::SystemTime>> {
+    if !include_dir.is_dir() {
+        return Ok(None);
+    }
+    let mut newest = None;
+    for entry in std::fs::read_dir(include_dir)?.filter_map(Result::ok) {
+        let path = entry.path();
+        let is_header = path
+            .extension()
+            .is_some_and(|e| e == "h" || e == "hxx" || e == "hpp");
+        if is_header {
+            let mtime = std::fs::metadata(&path)?.modified()?;
+            newest = Some(newest.map_or(mtime, |prev: std::time::SystemTime| prev.max(mtime)));
+        }
+    }
+    Ok(newest)
+}
+
 /// Full build: OCCT + facade + link + wasm-opt.
 pub fn build(release: bool, size: bool) -> Result<()> {
     let root = project_root()?;
@@ -373,16 +393,18 @@ pub fn build(release: bool, size: bool) -> Result<()> {
 }
 
 /// Remove all build artifacts.
-pub fn clean() -> Result<()> {
+pub fn clean(keep_generated: bool) -> Result<()> {
     let root = project_root()?;
     let sh = Shell::new()?;
 
-    let dirs_to_clean = [
+    let mut dirs_to_clean = vec![
         root.join("occt/build"),
         root.join("build"),
         root.join("dist"),
-        root.join("facade/generated"),
     ];
+    if !keep_generated {
+        dirs_to_clean.push(root.join("facade/generated"));
+    }
 
     for dir in &dirs_to_clean {
         if dir.exists() {
@@ -396,7 +418,7 @@ pub fn clean() -> Result<()> {
 }
 
 /// Run integration tests.
-pub fn test() -> Result<()> {
+pub fn test(watch: bool) -> Result<()> {
     let root = project_root()?;
     let sh = Shell::new()?;
 
@@ -405,7 +427,11 @@ pub fn test() -> Result<()> {
     }
 
     sh.change_dir(root.join("ts"));
-    cmd!(sh, "npx vitest run").run()?;
+    if watch {
+        cmd!(sh, "npx vitest --watch").run()?;
+    } else {
+        cmd!(sh, "npx vitest run").run()?;
+    }
 
     Ok(())
 }

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -506,7 +506,7 @@ if (!maker.IsDone()) {
     throw std::runtime_error(\"draft: operation failed\");
 }
 return store(maker.Shape());",
-        includes: &["BRepOffsetAPI_DraftAngle.hxx", "TopoDS.hxx", "gp_Dir.hxx"],
+        includes: &["BRepOffsetAPI_DraftAngle.hxx", "TopoDS.hxx", "gp_Dir.hxx", "gp_Pln.hxx"],
         category: "modeling",
         return_type: ReturnType::ShapeId,
     },
@@ -3449,6 +3449,7 @@ return result;",
             "BRep_Tool.hxx", "NCollection_Vec3.hxx", "Poly_Triangulation.hxx",
             "TopAbs_Orientation.hxx", "TopExp_Explorer.hxx", "TopLoc_Location.hxx",
             "TopTools_ShapeMapHasher.hxx", "TopoDS.hxx", "TopoDS_Face.hxx",
+            "gp_Dir.hxx", "gp_Pnt.hxx",
         ],
         category: "tessellate",
         return_type: ReturnType::MeshData,
@@ -3598,6 +3599,7 @@ return result;",
             "BRep_Tool.hxx", "NCollection_Vec3.hxx", "Poly_Triangulation.hxx",
             "TopAbs_Orientation.hxx", "TopExp_Explorer.hxx", "TopLoc_Location.hxx",
             "TopoDS.hxx", "TopoDS_Face.hxx",
+            "gp_Dir.hxx", "gp_Pnt.hxx",
         ],
         category: "tessellate",
         return_type: ReturnType::MeshBatchData,
@@ -3670,6 +3672,7 @@ return result;",
             "BRepAdaptor_Curve.hxx", "GCPnts_TangentialDeflection.hxx",
             "NCollection_IndexedMap.hxx", "TopExp.hxx",
             "TopTools_ShapeMapHasher.hxx", "TopoDS.hxx",
+            "gp_Pnt.hxx",
         ],
         category: "tessellate",
         return_type: ReturnType::EdgeData,
@@ -4250,6 +4253,41 @@ mod tests {
                 assert!(
                     m.params.is_empty(),
                     "skipped method '{}' should have empty params",
+                    m.name,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_duplicate_method_names() {
+        let methods = target_methods();
+        let mut seen = std::collections::HashSet::new();
+        for m in methods {
+            assert!(seen.insert(m.name), "duplicate method name: '{}'", m.name,);
+        }
+    }
+
+    #[test]
+    fn categories_are_lowercase() {
+        for m in target_methods() {
+            assert_eq!(
+                m.category,
+                m.category.to_ascii_lowercase(),
+                "method '{}' has non-lowercase category '{}'",
+                m.name,
+                m.category,
+            );
+        }
+    }
+
+    #[test]
+    fn custom_body_methods_have_setup_code() {
+        for m in target_methods() {
+            if m.kind == MethodKind::CustomBody {
+                assert!(
+                    !m.setup_code.is_empty(),
+                    "CustomBody method '{}' has empty setup_code",
                     m.name,
                 );
             }

--- a/xtask/src/codegen/emitter.rs
+++ b/xtask/src/codegen/emitter.rs
@@ -422,6 +422,7 @@ pub fn emit_kernel(methods: &[&MethodSpec]) -> String {
     let _ = writeln!(buf, "#include <cmath>");
     let _ = writeln!(buf, "#include <cstdio>");
     let _ = writeln!(buf, "#include <cstdlib>");
+    let _ = writeln!(buf, "#include <fstream>");
     let _ = writeln!(buf, "#include <iomanip>");
     let _ = writeln!(buf, "#include <set>");
     let _ = writeln!(buf, "#include <sstream>");

--- a/xtask/src/codegen/run.rs
+++ b/xtask/src/codegen/run.rs
@@ -4,22 +4,12 @@
 //! writes the generated C++ files to `facade/generated/`.
 
 use anyhow::{Context, Result};
-use std::path::{Path, PathBuf};
 
 use super::config;
 use super::emitter;
 use super::types::MethodKind;
 
-/// Project root (parent of xtask/).
-fn project_root() -> Result<PathBuf> {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string());
-    let root = Path::new(&manifest_dir)
-        .parent()
-        .context("xtask must be inside the workspace")?
-        .to_path_buf();
-    Ok(root)
-}
+use crate::util::project_root;
 
 /// Run the facade code generator.
 ///

--- a/xtask/src/codegen/types.rs
+++ b/xtask/src/codegen/types.rs
@@ -36,7 +36,6 @@ pub enum MethodKind {
 
 /// A single facade method parameter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // Variants used as codegen expands to more method patterns.
 pub enum FacadeParam {
     /// `uint32_t` shape ID resolved via `get(id)`.
     ShapeId(&'static str),
@@ -154,6 +153,5 @@ pub struct MethodSpec {
     pub category: &'static str,
 
     /// Return type of the method.
-    #[allow(dead_code)] // Will be used when TS wrapper generation is added.
     pub return_type: ReturnType,
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@ use clap::Parser;
 
 mod build;
 mod codegen;
+mod util;
 
 /// occt-wasm build tool.
 #[derive(Parser)]
@@ -27,9 +28,17 @@ enum Cli {
     /// Run the facade code generator (v0.1.1)
     Codegen,
     /// Remove all build artifacts
-    Clean,
+    Clean {
+        /// Keep facade/generated/ (avoid re-running codegen)
+        #[arg(long)]
+        keep_generated: bool,
+    },
     /// Run integration tests (requires built WASM)
-    Test,
+    Test {
+        /// Run in watch mode (re-runs on file changes)
+        #[arg(long)]
+        watch: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -39,7 +48,7 @@ fn main() -> Result<()> {
         Cli::Build { release, size } => build::build(release, size),
         Cli::BuildOcct => build::build_occt(),
         Cli::Codegen => codegen::run::run(),
-        Cli::Clean => build::clean(),
-        Cli::Test => build::test(),
+        Cli::Clean { keep_generated } => build::clean(keep_generated),
+        Cli::Test { watch } => build::test(watch),
     }
 }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,0 +1,15 @@
+//! Shared utilities for the xtask build tool.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Project root (parent of xtask/).
+pub fn project_root() -> Result<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string());
+    let root = Path::new(&manifest_dir)
+        .parent()
+        .context("xtask must be inside the workspace")?
+        .to_path_buf();
+    Ok(root)
+}


### PR DESCRIPTION
## Summary

Comprehensive xtask code review: quality improvements, feature additions, and bug fixes.

- **DRY**: Extract shared `project_root()` into `util.rs`
- **Determinism**: Sort `.cpp` sources and `.a` libs after `read_dir` for reproducible builds across platforms
- **Incremental correctness**: Track `facade/include/*.h` mtimes — header changes now trigger recompilation
- **DX**: `cargo xtask test --watch` and `cargo xtask clean --keep-generated`
- **Build robustness**: Add missing `<fstream>` to emitter C++ includes; fix 4 methods with fragile transitive includes (`gp_Pln.hxx`, `gp_Dir.hxx`, `gp_Pnt.hxx`)
- **Test coverage**: 3 new structural tests (duplicate names, category casing, CustomBody invariant) — 14 total (was 11)
- **Cleanup**: Remove 2 stale `#[allow(dead_code)]` attributes

## Known issues flagged (not in scope)

- `draftPrism` silently ignores its `angleDeg` parameter (published API bug, needs design decision)
- `hasTriangulation` miscategorized as "curve" (should be "query" or "tessellate")

## Test plan

- [x] `cargo clippy` — clean
- [x] `cargo test` — 14/14 pass
- [x] Pre-commit hook (fmt + clippy) — pass
- [x] Pre-push hook (cargo test + vitest 168 tests) — pass
- [ ] CI: lint + codegen drift check
- [ ] CI: WASM build + integration tests