### PR TITLE
fix(package): add deep path exports for Emscripten module and WASM binary

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -7,7 +7,9 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./dist/occt-wasm.js": "./dist/occt-wasm.js",
+    "./dist/occt-wasm.wasm": "./dist/occt-wasm.wasm"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
## Summary
- Adds deep path exports (`./occt.js` and `./occt.wasm`) to `ts/package.json` so consumers can directly import the Emscripten module and WASM binary

## Test plan
- [x] Pre-push hooks pass (14 xtask tests + integration tests)