### PR TITLE
fix(package): add deep path exports for WASM module

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -7,7 +7,9 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./dist/occt-wasm.js": "./dist/occt-wasm.js",
+    "./dist/occt-wasm.wasm": "./dist/occt-wasm.wasm"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
## Summary
- Add `./dist/occt-wasm.js` and `./dist/occt-wasm.wasm` to the package.json `exports` map
- Enables bundlers like Vite (which enforce strict `exports` resolution) to import the raw Emscripten module and WASM binary directly
- Required for brepjs's `OcctWasmAdapter` integration, which needs the raw module rather than the high-level `OcctKernel` wrapper

## Test plan
- [x] Pre-commit hooks pass (cargo fmt, clippy, clang-format, eslint, tsc)
- [ ] Verify `import occtWasmInit from 'occt-wasm/dist/occt-wasm.js'` resolves in a Vite project
- [ ] Verify `import wasmUrl from 'occt-wasm/dist/occt-wasm.wasm?url'` resolves in a Vite project