### PR TITLE
feat(ts): structured error codes, named enums, and DX improvements

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prebuild": "cp ../dist/occt-wasm.js ../dist/occt-wasm.wasm dist/ 2>/dev/null || true",
+    "prebuild": "bash scripts/copy-wasm.sh",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/ts/scripts/copy-wasm.sh
+++ b/ts/scripts/copy-wasm.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copy WASM build artifacts into ts/dist/ before TypeScript compilation.
+# Fails fast if the WASM build hasn't been run yet.
+set -euo pipefail
+
+SRC="../dist"
+DST="dist"
+
+mkdir -p "$DST"
+
+missing=()
+for f in occt-wasm.js occt-wasm.wasm; do
+    if [[ ! -f "$SRC/$f" ]]; then
+        missing+=("$f")
+    fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "error: WASM artifacts not found in $SRC/: ${missing[*]}" >&2
+    echo "       Run 'cargo xtask build' first to compile the WASM module." >&2
+    exit 1
+fi
+
+for f in occt-wasm.js occt-wasm.wasm; do
+    cp "$SRC/$f" "$DST/$f"
+done
+
+echo "prebuild: copied occt-wasm.{js,wasm} → $DST/"

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -14,10 +14,13 @@
  */
 
 export {
+    BooleanOp,
+    JoinType,
     OcctError,
+    OcctErrorCode,
+    TransitionMode,
     type AddChildOptions,
     type AddShapeOptions,
-    type BooleanOp,
     type BoundingBox,
     type Color3,
     type CurveKind,
@@ -26,7 +29,6 @@ export {
     type EvolutionData,
     type GLTFExportOptions,
     type InitOptions,
-    type JoinType,
     type LabelInfo,
     type LabelTag,
     type Location,
@@ -40,22 +42,20 @@ export {
     type ShapeType,
     type SurfaceKind,
     type TessellateOptions,
-    type TransitionMode,
     type UVBounds,
     type Vec3,
 } from "./types.js";
 
 export { XCAFDocument, type EmscriptenFS } from "./xcaf-document.js";
+import { XCAFDocument as XCAFDocumentImpl, type EmscriptenFS } from "./xcaf-document.js";
 
 import type {
-    BooleanOp,
     BoundingBox,
     CurveKind,
     CurvatureData,
     EdgeData,
     EvolutionData,
     InitOptions,
-    JoinType,
     Mesh,
     MeshBatchData,
     NurbsCurveData,
@@ -66,11 +66,11 @@ import type {
     ShapeType,
     SurfaceKind,
     TessellateOptions,
-    TransitionMode,
+    BooleanOp,
     UVBounds,
     Vec3,
 } from "./types.js";
-import { OcctError } from "./types.js";
+import { JoinType, OcctError, TransitionMode } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Internal Embind types
@@ -84,6 +84,7 @@ interface EmscriptenModule {
     HEAPF32: Float32Array;
     HEAPU32: Uint32Array;
     HEAP32: Int32Array;
+    FS: EmscriptenFS;
 }
 
 interface RawMeshData {
@@ -733,7 +734,7 @@ export class OcctKernel {
         });
     }
 
-    sweep(wire: ShapeHandle, spine: ShapeHandle, transitionMode: TransitionMode = 0): ShapeHandle {
+    sweep(wire: ShapeHandle, spine: ShapeHandle, transitionMode: TransitionMode = TransitionMode.Transformed): ShapeHandle {
         return wrap("sweep", () => handle(this.#raw.sweep(wire, spine, transitionMode)));
     }
 
@@ -1051,6 +1052,30 @@ export class OcctKernel {
     getShapeType(shape: ShapeHandle): ShapeType {
         return wrap("getShapeType", () => this.#raw.getShapeType(shape) as ShapeType);
     }
+
+    /** True if the shape is a compound. */
+    isCompound(shape: ShapeHandle): boolean { return this.getShapeType(shape) === "compound"; }
+
+    /** True if the shape is a comp-solid. */
+    isCompSolid(shape: ShapeHandle): boolean { return this.getShapeType(shape) === "compsolid"; }
+
+    /** True if the shape is a solid. */
+    isSolid(shape: ShapeHandle): boolean { return this.getShapeType(shape) === "solid"; }
+
+    /** True if the shape is a shell. */
+    isShell(shape: ShapeHandle): boolean { return this.getShapeType(shape) === "shell"; }
+
+    /** True if the shape is a face. */
+    isFace(shape: ShapeHandle): boolean { return this.getShapeType(shape) === "face"; }
+
+    /** True if the shape is a wire. */
+    isWire(shape: ShapeHandle): boolean { return this.getShapeType(shape) === "wire"; }
+
+    /** True if the shape is an edge. */
+    isEdge(shape: ShapeHandle): boolean { return this.getShapeType(shape) === "edge"; }
+
+    /** True if the shape is a vertex. */
+    isVertex(shape: ShapeHandle): boolean { return this.getShapeType(shape) === "vertex"; }
 
     getSubShapes(shape: ShapeHandle, type: "vertex" | "edge" | "wire" | "face" | "shell" | "solid"): ShapeHandle[] {
         return wrap("getSubShapes", () => vecToHandles(this.#raw.getSubShapes(shape, type)));
@@ -1511,7 +1536,7 @@ export class OcctKernel {
     }
 
     /** Offset a 2D wire. */
-    offsetWire2D(wire: ShapeHandle, offset: number, joinType: JoinType = 0): ShapeHandle {
+    offsetWire2D(wire: ShapeHandle, offset: number, joinType: JoinType = JoinType.Arc): ShapeHandle {
         return wrap("offsetWire2D", () => handle(this.#raw.offsetWire2D(wire, offset, joinType)));
     }
 
@@ -1695,6 +1720,26 @@ export class OcctKernel {
 
     fixWireOnFace(wire: ShapeHandle, face: ShapeHandle, tolerance = 1e-6): ShapeHandle {
         return wrap("fixWireOnFace", () => handle(this.#raw.fixWireOnFace(wire, face, tolerance)));
+    }
+
+    // =======================================================================
+    // XCAF Document Factories
+    // =======================================================================
+
+    /**
+     * Create a new XCAF document with the Emscripten FS pre-injected.
+     * This allows `doc.exportGLTF()` to work without passing FS explicitly.
+     */
+    createXCAFDocument(): XCAFDocumentImpl {
+        return XCAFDocumentImpl.create(this.#raw, this.#module.FS);
+    }
+
+    /**
+     * Import a STEP file into a new XCAF document with the Emscripten FS pre-injected.
+     * Preserves colors, names, and assembly structure from the STEP file.
+     */
+    importXCAFFromSTEP(stepData: string): XCAFDocumentImpl {
+        return XCAFDocumentImpl.fromSTEP(this.#raw, stepData, this.#module.FS);
     }
 
     // =======================================================================

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -139,14 +139,35 @@ export type SurfaceKind = "plane" | "cylinder" | "cone" | "sphere" | "torus" | "
 /** Geom_Curve subclass identifier returned by curveType. */
 export type CurveKind = "line" | "circle" | "ellipse" | "hyperbola" | "parabola" | "bspline" | "bezier" | "offset" | (string & {});
 
-/** Transition mode for BRepBuilderAPI_MakeSweep. 0=transformed, 1=right-corner, 2=round-corner. */
-export type TransitionMode = 0 | 1 | 2;
+/** Transition mode for sweep operations (BRepBuilderAPI_MakeSweep). */
+export enum TransitionMode {
+    /** Transform the profile along the spine (default). */
+    Transformed = 0,
+    /** Apply right-corner transitions at spine vertices. */
+    RightCorner = 1,
+    /** Apply round-corner transitions at spine vertices. */
+    RoundCorner = 2,
+}
 
-/** Join type for BRepOffsetAPI_MakeOffset. 0=arc, 1=tangent, 2=intersection. */
-export type JoinType = 0 | 1 | 2;
+/** Join type for offset/fillet operations (BRepOffsetAPI_MakeOffset). */
+export enum JoinType {
+    /** Arc interpolation at joints (default). */
+    Arc = 0,
+    /** Tangent extension at joints. */
+    Tangent = 1,
+    /** Intersection extension at joints. */
+    Intersection = 2,
+}
 
-/** Boolean operation code for booleanPipeline. 0=fuse, 1=cut, 2=common. */
-export type BooleanOp = 0 | 1 | 2;
+/** Boolean operation code for booleanPipeline. */
+export enum BooleanOp {
+    /** Union: combine volumes. */
+    Fuse = 0,
+    /** Subtraction: remove tool from base. */
+    Cut = 1,
+    /** Intersection: keep only overlapping volume. */
+    Common = 2,
+}
 
 /** UV parameter bounds of a face surface. */
 export interface UVBounds {
@@ -248,16 +269,97 @@ export interface MeshBatchData {
 }
 
 /**
+ * Structured error codes for programmatic error handling.
+ * Use `switch (error.code)` instead of parsing error message strings.
+ */
+export enum OcctErrorCode {
+    /** Shape construction failed (Build()/IsDone() returned false). */
+    ConstructionFailed = "CONSTRUCTION_FAILED",
+    /** Boolean operation failed (fuse/cut/common/intersect/section). */
+    BooleanFailed = "BOOLEAN_FAILED",
+    /** Referenced shape ID does not exist in the arena. */
+    InvalidShapeId = "INVALID_SHAPE_ID",
+    /** Referenced XCAF label ID does not exist. */
+    InvalidLabelId = "INVALID_LABEL_ID",
+    /** Tessellation or meshing operation failed. */
+    TessellationFailed = "TESSELLATION_FAILED",
+    /** STEP/STL/BREP import or export failed. */
+    ImportExportFailed = "IMPORT_EXPORT_FAILED",
+    /** Shape healing or repair operation failed. */
+    HealingFailed = "HEALING_FAILED",
+    /** Operation attempted on a closed XCAF document. */
+    DocumentClosed = "DOCUMENT_CLOSED",
+    /** OCCT kernel raised an internal error (Standard_Failure). */
+    KernelError = "KERNEL_ERROR",
+    /** Error does not match any known pattern. */
+    Unknown = "UNKNOWN",
+}
+
+/**
  * Typed error thrown when an OCCT operation fails.
  * The `operation` field identifies which kernel method raised the error.
+ * The `code` field enables programmatic error handling via `switch`.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   kernel.fuse(a, b);
+ * } catch (e) {
+ *   if (e instanceof OcctError) {
+ *     switch (e.code) {
+ *       case OcctErrorCode.BooleanFailed:
+ *         // retry with simpler geometry
+ *         break;
+ *       case OcctErrorCode.InvalidShapeId:
+ *         // shape was already released
+ *         break;
+ *     }
+ *   }
+ * }
+ * ```
  */
 export class OcctError extends Error {
     /** Name of the kernel method that failed. */
     readonly operation: string;
+    /** Structured error code for programmatic handling. */
+    readonly code: OcctErrorCode;
 
-    constructor(operation: string, message: string) {
+    constructor(operation: string, message: string, code?: OcctErrorCode) {
         super(`${operation}: ${message}`);
         this.name = "OcctError";
         this.operation = operation;
+        this.code = code ?? classifyError(operation, message);
     }
+}
+
+/** Operation categories used to infer error codes from context. */
+const BOOLEAN_OPS = new Set(["fuse", "cut", "common", "intersect", "section", "fuseAll", "cutAll", "split", "booleanPipeline", "fuseWithHistory", "cutWithHistory", "intersectWithHistory"]);
+const TESSELLATION_OPS = new Set(["tessellate", "wireframe", "meshShape", "meshBatch"]);
+const IO_OPS = new Set(["importStep", "exportStep", "importStl", "exportStl", "toBREP", "fromBREP", "xcafExportSTEP", "xcafImportSTEP", "xcafExportGLTF"]);
+const HEALING_OPS = new Set(["fixShape", "unifySameDomain", "healSolid", "healFace", "healWire", "fixFaceOrientations", "removeDegenerateEdges", "fixWireOnFace", "buildCurves3d"]);
+
+/**
+ * Classify an error into a structured code by matching known C++ error patterns
+ * and operation context.
+ */
+function classifyError(operation: string, message: string): OcctErrorCode {
+    const msg = message.toLowerCase();
+
+    // Exact pattern matches from C++ facade
+    if (msg.includes("invalid shape id")) return OcctErrorCode.InvalidShapeId;
+    if (msg.includes("invalid label id")) return OcctErrorCode.InvalidLabelId;
+    if (msg.includes("document is closed")) return OcctErrorCode.DocumentClosed;
+    if (msg.includes("boolean operation failed")) return OcctErrorCode.BooleanFailed;
+    if (msg.includes("construction failed")) return OcctErrorCode.ConstructionFailed;
+
+    // Operation-category fallback
+    if (BOOLEAN_OPS.has(operation)) return OcctErrorCode.BooleanFailed;
+    if (TESSELLATION_OPS.has(operation)) return OcctErrorCode.TessellationFailed;
+    if (IO_OPS.has(operation)) return OcctErrorCode.ImportExportFailed;
+    if (HEALING_OPS.has(operation)) return OcctErrorCode.HealingFailed;
+
+    // "operation failed" is the generic SetupShape/FilletLike pattern
+    if (msg.includes("operation failed")) return OcctErrorCode.ConstructionFailed;
+
+    return OcctErrorCode.Unknown;
 }

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -361,5 +361,8 @@ function classifyError(operation: string, message: string): OcctErrorCode {
     // "operation failed" is the generic SetupShape/FilletLike pattern
     if (msg.includes("operation failed")) return OcctErrorCode.ConstructionFailed;
 
+    // Unmatched errors from known OCCT operations are Standard_Failure propagations
+    if (operation && operation !== "XCAFDocument") return OcctErrorCode.KernelError;
+
     return OcctErrorCode.Unknown;
 }

--- a/ts/src/xcaf-document.ts
+++ b/ts/src/xcaf-document.ts
@@ -25,7 +25,7 @@ import type {
     AddChildOptions,
     GLTFExportOptions,
 } from "./types.js";
-import { OcctError } from "./types.js";
+import { OcctError, OcctErrorCode } from "./types.js";
 
 /** Raw XCAF methods on the Embind kernel (internal). */
 export interface RawXCAFKernel {
@@ -90,23 +90,25 @@ function wrap<T>(op: string, fn: () => T): T {
 export class XCAFDocument {
     readonly #raw: RawXCAFKernel;
     readonly #docId: number;
+    readonly #fs: EmscriptenFS | undefined;
     #closed = false;
 
-    private constructor(raw: RawXCAFKernel, docId: number) {
+    private constructor(raw: RawXCAFKernel, docId: number, fs?: EmscriptenFS) {
         this.#raw = raw;
         this.#docId = docId;
+        this.#fs = fs;
     }
 
     /** Create a new empty XCAF document. */
-    static create(raw: RawXCAFKernel): XCAFDocument {
+    static create(raw: RawXCAFKernel, fs?: EmscriptenFS): XCAFDocument {
         const docId = wrap("xcafNewDocument", () => raw.xcafNewDocument());
-        return new XCAFDocument(raw, docId);
+        return new XCAFDocument(raw, docId, fs);
     }
 
     /** Import a STEP file into a new XCAF document (preserves colors/names/assemblies). */
-    static fromSTEP(raw: RawXCAFKernel, stepData: string): XCAFDocument {
+    static fromSTEP(raw: RawXCAFKernel, stepData: string, fs?: EmscriptenFS): XCAFDocument {
         const docId = wrap("xcafImportSTEP", () => raw.xcafImportSTEP(stepData));
-        return new XCAFDocument(raw, docId);
+        return new XCAFDocument(raw, docId, fs);
     }
 
     /** Add a shape as a root label. */
@@ -195,13 +197,42 @@ export class XCAFDocument {
 
     /**
      * Export as glTF binary (.glb). Returns raw bytes as Uint8Array.
-     * Requires the Emscripten FS for binary file reading.
+     *
+     * When the document was created via `OcctKernel.createXCAFDocument()`,
+     * the Emscripten FS is injected automatically. Otherwise, pass it
+     * explicitly or via the options object.
      */
+    exportGLTF(options?: GLTFExportOptions & { fs?: EmscriptenFS }): Uint8Array;
+    /** @deprecated Pass `fs` via options instead: `exportGLTF({ fs })` */
+    exportGLTF(fs: EmscriptenFS, options?: GLTFExportOptions): Uint8Array;
     exportGLTF(
-        fs: EmscriptenFS,
-        options?: GLTFExportOptions,
+        fsOrOptions?: EmscriptenFS | (GLTFExportOptions & { fs?: EmscriptenFS }),
+        maybeOptions?: GLTFExportOptions,
     ): Uint8Array {
         this.#ensureOpen();
+
+        // Resolve overloads: exportGLTF(fs, opts) vs exportGLTF(opts)
+        let fs: EmscriptenFS | undefined;
+        let options: GLTFExportOptions | undefined;
+        if (fsOrOptions && typeof fsOrOptions === "object" && "readFile" in fsOrOptions) {
+            // Legacy: exportGLTF(fs, options?)
+            fs = fsOrOptions as EmscriptenFS;
+            options = maybeOptions;
+        } else {
+            // New: exportGLTF(options?)
+            const opts = fsOrOptions as (GLTFExportOptions & { fs?: EmscriptenFS }) | undefined;
+            fs = opts?.fs;
+            options = opts;
+        }
+
+        fs ??= this.#fs;
+        if (!fs) {
+            throw new OcctError(
+                "xcafExportGLTF",
+                "No Emscripten FS available. Either create the document via OcctKernel.createXCAFDocument(), or pass { fs } in options.",
+            );
+        }
+
         const linDefl = options?.linearDeflection ?? 0.1;
         const angDefl = options?.angularDeflection ?? 0.5;
         const glbPath = wrap("xcafExportGLTF", () =>
@@ -248,7 +279,7 @@ export class XCAFDocument {
 
     #ensureOpen(): void {
         if (this.#closed) {
-            throw new OcctError("XCAFDocument", "Document is closed");
+            throw new OcctError("XCAFDocument", "Document is closed", OcctErrorCode.DocumentClosed);
         }
     }
 }

--- a/ts/src/xcaf-document.ts
+++ b/ts/src/xcaf-document.ts
@@ -214,7 +214,7 @@ export class XCAFDocument {
         // Resolve overloads: exportGLTF(fs, opts) vs exportGLTF(opts)
         let fs: EmscriptenFS | undefined;
         let options: GLTFExportOptions | undefined;
-        if (fsOrOptions && typeof fsOrOptions === "object" && "readFile" in fsOrOptions) {
+        if (fsOrOptions && typeof fsOrOptions === "object" && "readFile" in fsOrOptions && "unlink" in fsOrOptions) {
             // Legacy: exportGLTF(fs, options?)
             fs = fsOrOptions as EmscriptenFS;
             options = maybeOptions;


### PR DESCRIPTION
## Summary

Improve the TypeScript public API for open-source consumers with structured error handling, self-documenting enums, and a cleaner XCAF export surface. All changes are backwards-compatible with existing code.

## Changes

- **Structured error codes**: Add `OcctErrorCode` enum (10 codes) and `code` field on `OcctError` — enables `switch(e.code)` instead of string parsing. Two-layer classification: matches C++ facade error patterns first, then falls back to operation-category inference.
- **Type predicate methods**: Add `isSolid()`, `isFace()`, `isEdge()`, `isWire()`, `isVertex()`, `isShell()`, `isCompound()`, `isCompSolid()` convenience methods on `OcctKernel`.
- **Named enums**: Replace opaque `0 | 1 | 2` unions with proper enums: `TransitionMode` (Transformed/RightCorner/RoundCorner), `JoinType` (Arc/Tangent/Intersection), `BooleanOp` (Fuse/Cut/Common). Numeric values unchanged — fully backwards-compatible.
- **XCAF factory methods**: Add `OcctKernel.createXCAFDocument()` and `importXCAFFromSTEP()` that auto-inject Emscripten FS, so `exportGLTF()` works without passing the FS module explicitly. Old signature deprecated but still supported.
- **Fix silent prebuild failure**: Replace `cp ... 2>/dev/null || true` with a fail-fast script that errors with a clear message when WASM artifacts are missing.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] ESLint passes (`npx eslint src/`)
- [x] All 212 existing tests pass (pre-push hook verified)
- [x] All changes are backwards-compatible: existing `new OcctError(op, msg)` auto-classifies, numeric enum values still accepted, old `exportGLTF(fs)` signature still works

## Notes

- `OcctErrorCode` uses string enum values (`"CONSTRUCTION_FAILED"`) for debuggability; `TransitionMode`/`JoinType`/`BooleanOp` use numeric values (`0, 1, 2`) to match C++ Embind expectations with zero marshaling overhead
- The error classification covers all known C++ facade patterns from `emitter.rs` plus operation-category fallback for unpredictable OCCT exceptions