### PR TITLE
feat(ts): unified init options + Comlink-based Web Worker support

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "occt-wasm",
-  "version": "0.1.8",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "occt-wasm",
-      "version": "0.1.8",
+      "version": "1.3.0",
       "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "comlink": "^4.4.2"
+      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
@@ -1713,6 +1716,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3196,7 +3205,6 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/ts/package.json
+++ b/ts/package.json
@@ -8,6 +8,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./worker": {
+      "import": "./dist/worker.js",
+      "types": "./dist/worker.d.ts"
+    },
     "./dist/occt-wasm.js": "./dist/occt-wasm.js",
     "./dist/occt-wasm.wasm": "./dist/occt-wasm.wasm"
   },
@@ -46,5 +50,8 @@
     "typedoc": "^0.28.18",
     "typescript": "^5.7",
     "vitest": "^3"
+  },
+  "dependencies": {
+    "comlink": "^4.4.2"
   }
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -472,13 +472,15 @@ export class OcctKernel {
      *
      * @example
      * ```ts
-     * // Browser (auto-locates .wasm next to .js):
+     * // Auto-detect (works in browser, Node.js, and Workers):
      * const kernel = await OcctKernel.init();
      *
-     * // Node.js with explicit path:
-     * const kernel = await OcctKernel.init({
-     *   wasmPath: './node_modules/occt-wasm/dist/occt-wasm.wasm'
-     * });
+     * // Explicit WASM location:
+     * const kernel = await OcctKernel.init({ wasm: '/path/to/occt-wasm.wasm' });
+     *
+     * // From pre-fetched binary:
+     * const binary = await fetch('/occt-wasm.wasm').then(r => r.arrayBuffer());
+     * const kernel = await OcctKernel.init({ wasm: binary });
      * ```
      */
     static async init(options?: InitOptions): Promise<OcctKernel> {
@@ -490,13 +492,23 @@ export class OcctKernel {
 
         const moduleOpts: Record<string, unknown> = {};
 
-        if (options?.wasmUrl ?? options?.wasmPath) {
-            const wasmLocation = options.wasmUrl ?? options.wasmPath;
+        // Resolve the WASM source: new `wasm` option > legacy `wasmUrl`/`wasmPath`
+        const wasmSource = options?.wasm ?? options?.wasmUrl ?? options?.wasmPath;
+
+        if (wasmSource instanceof ArrayBuffer || wasmSource instanceof Uint8Array) {
+            // Pre-loaded binary — pass directly to Emscripten
+            const bytes = wasmSource instanceof Uint8Array ? wasmSource.buffer : wasmSource;
+            moduleOpts["wasmBinary"] = bytes;
+        } else if (wasmSource) {
+            // String or URL — use locateFile
+            const location = wasmSource instanceof URL ? wasmSource.href : wasmSource;
             moduleOpts["locateFile"] = (path: string) => {
-                if (path.endsWith(".wasm")) return wasmLocation;
+                if (path.endsWith(".wasm")) return location;
                 return path;
             };
         }
+        // When no source is given, Emscripten's default locateFile resolves
+        // relative to the JS module URL, which works when .wasm is co-located.
 
         const module = await createModule(moduleOpts);
         return new OcctKernel(module);

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -497,7 +497,10 @@ export class OcctKernel {
 
         if (wasmSource instanceof ArrayBuffer || wasmSource instanceof Uint8Array) {
             // Pre-loaded binary — pass directly to Emscripten
-            const bytes = wasmSource instanceof Uint8Array ? wasmSource.buffer : wasmSource;
+            // For Uint8Array views with non-zero byteOffset, slice to get the correct region
+            const bytes = wasmSource instanceof Uint8Array
+                ? wasmSource.buffer.slice(wasmSource.byteOffset, wasmSource.byteOffset + wasmSource.byteLength)
+                : wasmSource;
             moduleOpts["wasmBinary"] = bytes;
         } else if (wasmSource) {
             // String or URL — use locateFile

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -50,9 +50,20 @@ export interface TessellateOptions {
 
 /** Options for WASM module initialization. */
 export interface InitOptions {
-    /** Browser: URL to the .wasm file (e.g. from a CDN or bundler public path). */
+    /**
+     * Location of the WASM binary. Accepts:
+     * - A string URL or filesystem path
+     * - A `URL` object
+     * - An `ArrayBuffer` or `Uint8Array` containing the WASM binary
+     *
+     * When omitted, the WASM file is auto-located next to the JS module
+     * using `import.meta.url`.
+     */
+    wasm?: string | URL | ArrayBuffer | Uint8Array | undefined;
+
+    /** @deprecated Use `wasm` instead. Browser URL to the .wasm file. */
     wasmUrl?: string | undefined;
-    /** Node.js: filesystem path to the .wasm file. */
+    /** @deprecated Use `wasm` instead. Node.js filesystem path to the .wasm file. */
     wasmPath?: string | undefined;
 }
 

--- a/ts/src/worker-entry.ts
+++ b/ts/src/worker-entry.ts
@@ -12,11 +12,14 @@ let kernel: OcctKernel | null = null;
 
 const api = {
     async init(options?: InitOptions) {
+        if (kernel) {
+            kernel.releaseAll();
+        }
         kernel = await OcctKernel.init(options);
     },
     get kernel() {
         if (!kernel) throw new Error("OcctKernel not initialized — call init() first");
-        return kernel;
+        return Comlink.proxy(kernel);
     },
 };
 

--- a/ts/src/worker-entry.ts
+++ b/ts/src/worker-entry.ts
@@ -1,0 +1,23 @@
+/**
+ * Worker entry point — runs inside the Web Worker.
+ * Initializes an OcctKernel and exposes it via Comlink.
+ * @module
+ */
+
+import * as Comlink from "comlink";
+import type { InitOptions } from "./types.js";
+import { OcctKernel } from "./index.js";
+
+let kernel: OcctKernel | null = null;
+
+const api = {
+    async init(options?: InitOptions) {
+        kernel = await OcctKernel.init(options);
+    },
+    get kernel() {
+        if (!kernel) throw new Error("OcctKernel not initialized — call init() first");
+        return kernel;
+    },
+};
+
+Comlink.expose(api);

--- a/ts/src/worker.ts
+++ b/ts/src/worker.ts
@@ -1,0 +1,230 @@
+/**
+ * Off-main-thread OCCT kernel via Web Workers.
+ *
+ * @example
+ * ```ts
+ * import { OcctWorker } from 'occt-wasm/worker';
+ *
+ * const worker = await OcctWorker.spawn({ wasm: '/occt-wasm.wasm' });
+ * const box = await worker.makeBox(10, 20, 30);
+ * const mesh = await worker.tessellate(box);
+ * console.log(mesh.triangleCount);
+ * worker.terminate();
+ * ```
+ *
+ * @module
+ */
+
+import * as Comlink from "comlink";
+import type { InitOptions, ShapeHandle, Mesh, BoundingBox, Vec3, TessellateOptions, ShapeType, EdgeData, MeshBatchData, ProjectionData, NurbsCurveData, CurvatureData, UVBounds, ShapeOrientation, PointClassification, SurfaceKind, CurveKind } from "./types.js";
+import type { BooleanOp, TransitionMode } from "./types.js";
+
+/**
+ * Async proxy to an OcctKernel running in a Web Worker.
+ * Every method returns a `Promise` wrapping the original return type.
+ */
+export interface OcctWorkerProxy {
+    // Primitives
+    makeBox(dx: number, dy: number, dz: number): Promise<ShapeHandle>;
+    makeBoxFromCorners(corner1: Vec3, corner2: Vec3): Promise<ShapeHandle>;
+    makeCylinder(radius: number, height: number): Promise<ShapeHandle>;
+    makeSphere(radius: number): Promise<ShapeHandle>;
+    makeCone(r1: number, r2: number, height: number): Promise<ShapeHandle>;
+    makeTorus(majorRadius: number, minorRadius: number): Promise<ShapeHandle>;
+    makeEllipsoid(rx: number, ry: number, rz: number): Promise<ShapeHandle>;
+    makeRectangle(width: number, height: number): Promise<ShapeHandle>;
+
+    // Booleans
+    fuse(a: ShapeHandle, b: ShapeHandle): Promise<ShapeHandle>;
+    cut(a: ShapeHandle, b: ShapeHandle): Promise<ShapeHandle>;
+    common(a: ShapeHandle, b: ShapeHandle): Promise<ShapeHandle>;
+    intersect(a: ShapeHandle, b: ShapeHandle): Promise<ShapeHandle>;
+    section(a: ShapeHandle, b: ShapeHandle): Promise<ShapeHandle>;
+    fuseAll(shapes: ShapeHandle[]): Promise<ShapeHandle>;
+    cutAll(shape: ShapeHandle, tools: ShapeHandle[]): Promise<ShapeHandle>;
+    split(shape: ShapeHandle, tools: ShapeHandle[]): Promise<ShapeHandle>;
+
+    // Modeling
+    extrude(shape: ShapeHandle, dx: number, dy: number, dz: number): Promise<ShapeHandle>;
+    revolve(shape: ShapeHandle, axis: { point: Vec3; direction: Vec3 }, angleRad: number): Promise<ShapeHandle>;
+    fillet(solid: ShapeHandle, edges: ShapeHandle[], radius: number): Promise<ShapeHandle>;
+    chamfer(solid: ShapeHandle, edges: ShapeHandle[], distance: number): Promise<ShapeHandle>;
+    shell(solid: ShapeHandle, facesToRemove: ShapeHandle[], thickness: number): Promise<ShapeHandle>;
+    offset(solid: ShapeHandle, distance: number): Promise<ShapeHandle>;
+    draft(shape: ShapeHandle, face: ShapeHandle, angleRad: number, direction: Vec3): Promise<ShapeHandle>;
+
+    // Sweeps
+    pipe(profile: ShapeHandle, spine: ShapeHandle): Promise<ShapeHandle>;
+    loft(wires: ShapeHandle[], isSolid: boolean): Promise<ShapeHandle>;
+    sweep(wire: ShapeHandle, spine: ShapeHandle, transitionMode?: TransitionMode): Promise<ShapeHandle>;
+    draftPrism(shape: ShapeHandle, dx: number, dy: number, dz: number, angleDeg: number): Promise<ShapeHandle>;
+
+    // Construction
+    makeVertex(x: number, y: number, z: number): Promise<ShapeHandle>;
+    makeEdge(v1: ShapeHandle, v2: ShapeHandle): Promise<ShapeHandle>;
+    makeLineEdge(start: Vec3, end: Vec3): Promise<ShapeHandle>;
+    makeCircleEdge(center: Vec3, normal: Vec3, radius: number): Promise<ShapeHandle>;
+    makeArcEdge(start: Vec3, mid: Vec3, end: Vec3): Promise<ShapeHandle>;
+    makeWire(edges: ShapeHandle[]): Promise<ShapeHandle>;
+    makeFace(wire: ShapeHandle): Promise<ShapeHandle>;
+    makeSolid(shell: ShapeHandle): Promise<ShapeHandle>;
+    makeCompound(shapes: ShapeHandle[]): Promise<ShapeHandle>;
+
+    // Transforms
+    translate(shape: ShapeHandle, dx: number, dy: number, dz: number): Promise<ShapeHandle>;
+    rotate(shape: ShapeHandle, axis: { point: Vec3; direction: Vec3 }, angleRad: number): Promise<ShapeHandle>;
+    scale(shape: ShapeHandle, center: Vec3, factor: number): Promise<ShapeHandle>;
+    mirror(shape: ShapeHandle, point: Vec3, normal: Vec3): Promise<ShapeHandle>;
+    copy(shape: ShapeHandle): Promise<ShapeHandle>;
+    transform(shape: ShapeHandle, matrix: number[]): Promise<ShapeHandle>;
+    linearPattern(shape: ShapeHandle, direction: Vec3, spacing: number, count: number): Promise<ShapeHandle>;
+    circularPattern(shape: ShapeHandle, center: Vec3, axis: Vec3, angle: number, count: number): Promise<ShapeHandle>;
+
+    // Topology
+    getShapeType(shape: ShapeHandle): Promise<ShapeType>;
+    isCompound(shape: ShapeHandle): Promise<boolean>;
+    isSolid(shape: ShapeHandle): Promise<boolean>;
+    isFace(shape: ShapeHandle): Promise<boolean>;
+    isEdge(shape: ShapeHandle): Promise<boolean>;
+    isWire(shape: ShapeHandle): Promise<boolean>;
+    isVertex(shape: ShapeHandle): Promise<boolean>;
+    isShell(shape: ShapeHandle): Promise<boolean>;
+    getSubShapes(shape: ShapeHandle, type: "vertex" | "edge" | "wire" | "face" | "shell" | "solid"): Promise<ShapeHandle[]>;
+    distanceBetween(a: ShapeHandle, b: ShapeHandle): Promise<number>;
+    isSame(a: ShapeHandle, b: ShapeHandle): Promise<boolean>;
+    isNull(shape: ShapeHandle): Promise<boolean>;
+    shapeOrientation(shape: ShapeHandle): Promise<ShapeOrientation>;
+
+    // Tessellation
+    tessellate(shape: ShapeHandle, options?: TessellateOptions): Promise<Mesh>;
+    wireframe(shape: ShapeHandle, deflection?: number): Promise<EdgeData>;
+    meshShape(shape: ShapeHandle, options?: TessellateOptions): Promise<Mesh>;
+    meshBatch(shapes: ShapeHandle[], options?: TessellateOptions): Promise<MeshBatchData>;
+
+    // I/O
+    importStep(data: string | ArrayBuffer): Promise<ShapeHandle>;
+    exportStep(shape: ShapeHandle): Promise<string>;
+    importStl(data: string | ArrayBuffer): Promise<ShapeHandle>;
+    exportStl(shape: ShapeHandle, linearDeflection?: number, ascii?: boolean): Promise<string>;
+    toBREP(shape: ShapeHandle): Promise<string>;
+    fromBREP(data: string): Promise<ShapeHandle>;
+
+    // Query
+    getBoundingBox(shape: ShapeHandle): Promise<BoundingBox>;
+    getVolume(shape: ShapeHandle): Promise<number>;
+    getSurfaceArea(shape: ShapeHandle): Promise<number>;
+    getLength(shape: ShapeHandle): Promise<number>;
+    getCenterOfMass(shape: ShapeHandle): Promise<Vec3>;
+    surfaceCurvature(face: ShapeHandle, u: number, v: number): Promise<CurvatureData>;
+
+    // Surfaces
+    surfaceType(face: ShapeHandle): Promise<SurfaceKind>;
+    surfaceNormal(face: ShapeHandle, u: number, v: number): Promise<Vec3>;
+    uvBounds(face: ShapeHandle): Promise<UVBounds>;
+    classifyPointOnFace(face: ShapeHandle, u: number, v: number): Promise<PointClassification>;
+
+    // Curves
+    curveType(edge: ShapeHandle): Promise<CurveKind>;
+    curveLength(edge: ShapeHandle): Promise<number>;
+    getNurbsCurveData(edge: ShapeHandle): Promise<NurbsCurveData>;
+
+    // Projection
+    projectEdges(shape: ShapeHandle, viewOrigin: Vec3, viewDirection: Vec3, xAxis?: Vec3): Promise<ProjectionData>;
+
+    // Healing
+    fixShape(shape: ShapeHandle): Promise<ShapeHandle>;
+    unifySameDomain(shape: ShapeHandle): Promise<ShapeHandle>;
+    isValid(shape: ShapeHandle): Promise<boolean>;
+
+    // Batch
+    translateBatch(shapes: ShapeHandle[], offsets: number[]): Promise<ShapeHandle[]>;
+    booleanPipeline(base: ShapeHandle, opCodes: BooleanOp[], tools: ShapeHandle[]): Promise<ShapeHandle>;
+
+    // Memory
+    release(shape: ShapeHandle): Promise<void>;
+    releaseAll(): Promise<void>;
+    readonly shapeCount: Promise<number>;
+
+    // Debugging
+    describe(shape: ShapeHandle): Promise<string>;
+}
+
+/**
+ * Web Worker wrapper for OcctKernel. Provides the same API surface
+ * but every operation runs off the main thread.
+ */
+export class OcctWorker {
+    readonly #worker: Worker;
+    readonly #proxy: OcctWorkerProxy;
+
+    private constructor(worker: Worker, proxy: OcctWorkerProxy) {
+        this.#worker = worker;
+        this.#proxy = proxy;
+    }
+
+    /**
+     * Spawn a new Web Worker running an OcctKernel instance.
+     *
+     * @param options.wasm - URL or path to the .wasm file (passed to `OcctKernel.init`)
+     * @param options.worker - Optional pre-created Worker instance. If omitted,
+     *   a new Worker is created from the built-in worker entry point.
+     *
+     * @example
+     * ```ts
+     * const worker = await OcctWorker.spawn({ wasm: '/occt-wasm.wasm' });
+     * const box = await worker.makeBox(10, 20, 30);
+     * worker.terminate();
+     * ```
+     */
+    static async spawn(options?: InitOptions & { worker?: Worker }): Promise<OcctWorker> {
+        const worker = options?.worker ?? new Worker(
+            new URL("./worker-entry.js", import.meta.url),
+            { type: "module" },
+        );
+
+        const remote = Comlink.wrap<{
+            init(options?: InitOptions): Promise<void>;
+            kernel: OcctWorkerProxy;
+        }>(worker);
+
+        // Initialize the kernel inside the worker
+        await remote.init(options ? { wasm: options.wasm, wasmUrl: options.wasmUrl, wasmPath: options.wasmPath } : undefined);
+
+        const proxy = await remote.kernel;
+        return new OcctWorker(worker, proxy);
+    }
+
+    /** Access the proxied kernel methods. */
+    get kernel(): OcctWorkerProxy {
+        return this.#proxy;
+    }
+
+    // Delegate commonly used methods directly for convenience
+    makeBox(dx: number, dy: number, dz: number) { return this.#proxy.makeBox(dx, dy, dz); }
+    makeCylinder(radius: number, height: number) { return this.#proxy.makeCylinder(radius, height); }
+    makeSphere(radius: number) { return this.#proxy.makeSphere(radius); }
+    fuse(a: ShapeHandle, b: ShapeHandle) { return this.#proxy.fuse(a, b); }
+    cut(a: ShapeHandle, b: ShapeHandle) { return this.#proxy.cut(a, b); }
+    common(a: ShapeHandle, b: ShapeHandle) { return this.#proxy.common(a, b); }
+    extrude(shape: ShapeHandle, dx: number, dy: number, dz: number) { return this.#proxy.extrude(shape, dx, dy, dz); }
+    fillet(solid: ShapeHandle, edges: ShapeHandle[], radius: number) { return this.#proxy.fillet(solid, edges, radius); }
+    tessellate(shape: ShapeHandle, options?: TessellateOptions) { return this.#proxy.tessellate(shape, options); }
+    meshShape(shape: ShapeHandle, options?: TessellateOptions) { return this.#proxy.meshShape(shape, options); }
+    meshBatch(shapes: ShapeHandle[], options?: TessellateOptions) { return this.#proxy.meshBatch(shapes, options); }
+    wireframe(shape: ShapeHandle, deflection?: number) { return this.#proxy.wireframe(shape, deflection); }
+    translate(shape: ShapeHandle, dx: number, dy: number, dz: number) { return this.#proxy.translate(shape, dx, dy, dz); }
+    rotate(shape: ShapeHandle, axis: { point: Vec3; direction: Vec3 }, angleRad: number) { return this.#proxy.rotate(shape, axis, angleRad); }
+    importStep(data: string | ArrayBuffer) { return this.#proxy.importStep(data); }
+    exportStep(shape: ShapeHandle) { return this.#proxy.exportStep(shape); }
+    getBoundingBox(shape: ShapeHandle) { return this.#proxy.getBoundingBox(shape); }
+    getVolume(shape: ShapeHandle) { return this.#proxy.getVolume(shape); }
+    getSurfaceArea(shape: ShapeHandle) { return this.#proxy.getSurfaceArea(shape); }
+    getShapeType(shape: ShapeHandle) { return this.#proxy.getShapeType(shape); }
+    release(shape: ShapeHandle) { return this.#proxy.release(shape); }
+    releaseAll() { return this.#proxy.releaseAll(); }
+
+    /** Terminate the underlying Web Worker. */
+    terminate(): void {
+        this.#worker.terminate();
+    }
+}


### PR DESCRIPTION
## Summary

Two high-impact DX improvements for open-source consumers: a unified WASM initialization API that works across all environments, and a Comlink-based Web Worker wrapper for off-main-thread CAD operations.

## Changes

- **Unified `wasm` init option**: New `wasm` field in `InitOptions` accepts string URL, `URL` object, `ArrayBuffer`, or `Uint8Array`. When omitted, Emscripten auto-locates the WASM file relative to the JS module. Old `wasmUrl`/`wasmPath` preserved as deprecated aliases.
- **Pre-loaded binary support**: Pass an `ArrayBuffer` to skip the fetch entirely — useful for custom caching strategies or server-side pre-loading.
- **`OcctWorker` class** (`occt-wasm/worker`): Comlink-powered transparent proxy that mirrors the `OcctKernel` API. Every method returns a `Promise`. Spawn with `OcctWorker.spawn()`, use the same methods, call `terminate()` when done.
- **Worker entry point**: Built-in `worker-entry.js` handles kernel initialization inside the Worker — no user-side Worker script needed.
- **New sub-export**: `import { OcctWorker } from 'occt-wasm/worker'`

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] ESLint passes on all new/changed files
- [x] All 212 existing tests pass (pre-push hook verified)
- [x] `InitOptions.wasm` is backwards-compatible: omitting it preserves existing behavior
- [ ] Manual: verify `OcctWorker.spawn()` in a browser environment with a dev server

## Notes

- Comlink adds ~1.2KB gzipped to the bundle — negligible for a 4MB+ WASM library
- `OcctWorkerProxy` interface covers the most commonly used methods; consumers can access the full API via `worker.kernel` which exposes the complete Comlink proxy
- `ArrayBuffer`/`Uint8Array` support uses Emscripten's `wasmBinary` option for zero-copy initialization