### PR TITLE
chore(occt): bump OCCT submodule to V8.0.0-rc5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ TS wrapper (ts/) → tsc → occt-wasm
 - `facade/` — C++ facade (OcctKernel class + Embind bindings)
 - `ts/` — TypeScript wrapper (occt-wasm npm package)
 - `xtask/` — Rust build orchestration (clap + anyhow + xshell)
-- `occt/` — OCCT V8.0.0-rc4 (git submodule)
+- `occt/` — OCCT V8.0.0-rc5 (git submodule)
 - `3rdparty/` — Isolated third-party headers (RapidJSON for glTF, gitignored)
 - `scripts/` — build.sh, symbol_dispose.js, publish.sh, fetch-rapidjson.sh, bench-check.js
 - `test/` — Vitest integration tests (integration, expanded, xcaf, bench) + benchmark.ts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # occt-wasm
 
-[OpenCascade](https://www.opencascade.com/) V8 compiled to WebAssembly with a clean TypeScript API. Smaller bundles, branded types, arena-based memory, and modern tooling.
+[OpenCascade](https://github.com/Open-Cascade-SAS/OCCT) V8 compiled to WebAssembly with a clean TypeScript API. Smaller bundles, branded types, arena-based memory, and modern tooling.
 
 > **Looking for a higher-level CAD library?** [brepjs](https://github.com/nicholasgasior/brepjs) builds on occt-wasm with a friendlier API for parametric modeling, sketching, and production CAD applications. Use occt-wasm directly when you need full control over OCCT operations.
 
@@ -265,7 +265,7 @@ Generate full docs locally: `cd ts && npm run docs` (TypeDoc output).
 ## Architecture
 
 ```
-OCCT V8.0.0-rc4 C++ (git submodule)
+OCCT V8.0.0-rc5 C++ (git submodule)
     -> emcmake cmake (48 static libs)
     -> C++ facade (OcctKernel class, arena-based u32 IDs)
     -> Embind bindings
@@ -327,7 +327,7 @@ Node.js 22+ is recommended (tail calls via V8). Node.js 18+ works if your V8 ver
 
 ## Known Limitations
 
-These are upstream OCCT V8.0.0-rc4 issues, not occt-wasm bugs:
+These are upstream OCCT V8.0.0-rc5 issues, not occt-wasm bugs:
 
 - **IGES** -- TKDEIGES excluded from link; no IGES import/export
 - **Zero-length extrusion** -- WASM exception escapes JS catch boundary (1 test skip)


### PR DESCRIPTION
## Summary
- Rebased the `wasm-patches` branch on the `andymai/OCCT` fork onto upstream `V8_0_0_rc5` — 65 upstream commits, clean rebase.
- Added a second patch commit on `wasm-patches` for WASM32 compatibility: `BRepGraph_VersionStamp::ToGUID` (new in rc5) packs two `size_t` hashes into a 128-bit UUID via `memcpy(..., 8)` and asserts `sizeof(size_t) >= 8`. Patch copies `sizeof(size_t)` bytes from each hash into a value-initialized UUID — byte-identical to upstream on 64-bit, functional on WASM32.
- Fixed the OpenCascade link in `README.md` to point at the official [`Open-Cascade-SAS/OCCT`](https://github.com/Open-Cascade-SAS/OCCT) GitHub repo instead of the corporate marketing site.
- Bumped version references in `README.md` (architecture block + Known Limitations) and `CLAUDE.md` (repo layout).

## Upstream rc5 highlights
- **New BRepGraph representation** (#1166, #1190) — parallel topology graph with iterators, ref caching, mutation APIs, layer events. Additive.
- **Eval geometry unification** — new `GeomProp`/`Geom2dProp`/`BRepProp`/`GeomBndLib`/`PointSetLib`/`ExtremaPC` packages; old `LProp_AnalyticCurInf`, `TColGeom`, `TColGeom2d`, and legacy `GeomProp` removed.
- **Handle API modernization** (#1185) — deprecates out-parameter overloads.
- **Bug fixes**: `ChFi3d_Builder::IntersectMoreCorner` segfault (#1163), `TKGeomAlgo` robustness (#1182), concurrent-op data races (#1180), `BOPAlgo_PaveFiller::MakeBlocks` memory (#1044).
- **New features**: Gordon surface construction (#1131), configurable `GeomHash` tolerances (#1169), derivative caching in evaluators (#1152).
- **ARM64** Windows build/test support (#1135, #1149).

Full diff: https://github.com/Open-Cascade-SAS/OCCT/compare/V8_0_0_rc4...V8_0_0_rc5

## Verification — all green ✅

**Facade impact check:** Grepped the entire `facade/` tree for references to removed/relocated packages (`TColGeom`, `TColGeom2d`, `LProp`, `GeomLProp`, `BRepLProp`, old `GeomProp`, `BRepProp_`, `Geom2dProp_`). Zero hits. The facade's high-level API surface insulated it from the Eval-geometry refactor.

**Docker build (`npm run docker:build`):**
- All 5522 ninja compile targets clean
- No deprecation warnings surfaced through `-Werror`
- `-fwasm-exceptions` path intact (still using the `OCC_CONVERT_SIGNALS` removal patch from the existing `wasm-patches` commit)

**Full Vitest suite (in-container):**
- ✅ **257 passed / 1 skipped / 0 failed** (258 total)
- Skipped test is the pre-existing zero-length-extrusion WASM exception escape — unchanged from rc4 baseline
- The 7 `batch-apis.test.ts` failures reported against stale local `dist/` were a red herring (pre-dated commit 1be6e1f which added the batch APIs); they pass cleanly against the freshly-built rc5 artifact.

**Bundle size (`occt-wasm.wasm`):**
- Uncompressed: **21.55 MB** (roughly flat vs rc4)
- Brotli quality 11: **4.39 MB** — still within the "~4 MB brotli" README claim

**Benchmarks** (flat vs rc4 baseline, no regression on the headless CAD subset we exercise):

| Benchmark | Mean (ms) |
|-----------|-----------|
| `makeBox ×100` | 3.8 |
| `fuse ×10` | 47.3 |
| `translate ×1000` | 46.9 |
| `exportSTEP ×10` | 14.1 |
| `translateBatch ×1000` | 47.3 |
| `booleanPipeline ×3` | 8.7 |
| `meshBatch ×10 spheres` | 0.5 |

## Test plan
- [x] `npm run docker:build` completes cleanly against rc5
- [x] Full Vitest suite (258 tests) passes against freshly-built `dist/`
- [x] Bundle size check — `dist/occt-wasm.wasm` brotli stays within ~4 MB target
- [x] Facade grep for removed/relocated OCCT packages
- [x] Spot-check the Three.js example — CI `Browser Smoke Test` runs Playwright/Chromium against the freshly-built WASM artifact, passed
