### PR TITLE
fix(test): repair benchmark.ts getSubShapes call after API change

### DIFF
--- a/test/benchmark.ts
+++ b/test/benchmark.ts
@@ -157,7 +157,7 @@ await bench("tessellate(fused, 0.1)", () => {
 
 await bench("fillet(box, 1.0)", () => {
   const box = kernel.makeBox(10, 10, 10);
-  const edges = kernel.getSubShapes(box, 6); // TopAbs_EDGE
+  const edges = kernel.getSubShapes(box, "edge");
   const edgeVec = new occtModule.VectorUint32();
   const edgeCount = edges.size();
   for (let i = 0; i < edgeCount; i++) {


### PR DESCRIPTION
## Summary
One-character fix: \`test/benchmark.ts:160\` was calling \`kernel.getSubShapes(box, 6)\` with the legacy numeric \`TopAbs_EDGE\` enum, but the facade signature has been \`getSubShapes(uint32_t, const std::string&)\` since #58 (codegen migration). The standalone \`npx tsx test/benchmark.ts\` harness has thrown \`BindingError: Cannot pass non-string to std::string\` at the fillet benchmark ever since — caught only today while running benchmarks after the rc5 bump (#80).

\`bench.test.ts\` (the vitest CI path) doesn't exercise \`getSubShapes\`, which is why \`bench-check.js\` and the CI gate never noticed.

## Why this is a small, safe fix
- **Scope**: 1 line changed in a test-only file. No facade, TypeScript wrapper, or WASM changes.
- **Root cause**: API drift between \`test/benchmark.ts\` (pinned to the pre-codegen numeric enum) and the facade (moved to lowercase strings). The fix matches what \`ts/src/index.ts\` does everywhere else (\`kernel.getSubShapes(shape, "edge")\`, line 1900).
- **Verification**: \`npx tsx test/benchmark.ts\` now completes end-to-end. Full output below.

## Benchmark output post-fix (rc5, native Node)

### WASM size comparison
| Build | Raw | gzip | brotli |
|-------|---:|---:|---:|
| **occt-wasm** (current build) | 20.6 MB | 6.5 MB | **4.4 MB** |
| opencascade.js 1.1.1 | 62.8 MB | 13.3 MB | 8.7 MB |
| brepjs-opencascade (single) | 24.8 MB | 7.6 MB | 5.0 MB |
| brepjs-opencascade (exceptions) | 18.4 MB | 5.7 MB | 4.0 MB |

### Core operations (median of 10)
- \`occt-wasm init\`: 36.5 ms (median of 5)
- \`makeBox\`: 0.0 ms
- \`makeSphere\`: 0.0 ms
- \`fuse(box, cylinder)\`: 10.4 ms
- \`cut(box, cylinder)\`: 7.6 ms
- \`tessellate(fused, 0.1)\`: 0.3 ms
- \`fillet(box, 1.0)\`: 6.6 ms  ← the previously-broken path
- \`exportStep(box)\`: 1.8 ms
- \`importStep(box)\`: 3.7 ms

## Follow-up to consider (not in this PR)
The standalone \`test/benchmark.ts\` harness calls the raw facade directly (bypasses \`ts/src/index.ts\`), so it's a second source of truth that can drift from the wrapper unchecked — exactly what happened here. Options to discuss separately:
1. Add \`test/benchmark.ts\` to the CI suite so rot is caught immediately
2. Route \`test/benchmark.ts\` through the TypeScript wrapper so the TS \`getSubShapes(handle, "edge")\` type-checks against drift at compile time
3. Delete \`test/benchmark.ts\` entirely in favour of the vitest-based \`bench.test.ts\` (which is what \`benchmarks/baseline.json\` and \`bench-check.js\` already target)

## Test plan
- [x] \`npx tsx test/benchmark.ts\` runs to completion locally against freshly-built rc5 \`dist/\`
- [x] All 258 tests in the vitest suite still pass (pre-push hook)
- [x] No code outside \`test/benchmark.ts\` touched