### PR TITLE
chore(deps): bump Rust toolchain to 1.95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.95"
           components: rustfmt, clippy
 
       - name: Rust cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "git+https://github.com/andymai/occt-wasm.git"
-rust-version = "1.93"
+rust-version = "1.95"
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crate/src/kernel.rs
+++ b/crate/src/kernel.rs
@@ -282,12 +282,14 @@ impl OcctKernel {
     pub(crate) fn write_bytes(&mut self, data: &[u8]) -> OcctResult<u32> {
         let ptr = self.fn_alloc.call(&mut self.store, data.len() as u32)?;
         if ptr == 0 {
+            core::hint::cold_path();
             return Err(OcctError::Memory("allocation failed".to_owned()));
         }
         let mem = self.memory.data_mut(&mut self.store);
         let start = ptr as usize;
         let end = start + data.len();
         if end > mem.len() {
+            core::hint::cold_path();
             return Err(OcctError::Memory("write out of bounds".to_owned()));
         }
         mem[start..end].copy_from_slice(data);
@@ -306,6 +308,7 @@ impl OcctKernel {
         let start = ptr as usize;
         let end = start + len as usize;
         if end > mem.len() {
+            core::hint::cold_path();
             return Err(OcctError::Memory("read out of bounds".to_owned()));
         }
         Ok(mem[start..end].to_vec())
@@ -353,12 +356,17 @@ impl OcctKernel {
     pub(crate) fn check_error(&mut self, operation: &str) -> OcctResult<()> {
         let has_error = self.fn_has_error.call(&mut self.store, ())?;
         if has_error != 0 {
+            // Errors are the exception, not the norm — this branch runs after
+            // every facade call. Hint to LLVM that it's cold so the happy path
+            // stays tight in the instruction cache. (stabilized in Rust 1.95)
+            core::hint::cold_path();
             return Err(self.read_last_error(operation));
         }
         Ok(())
     }
 
     /// Read the last error message from the WASM module.
+    #[cold]
     pub(crate) fn read_last_error(&mut self, operation: &str) -> OcctError {
         let ptr = self.fn_get_error.call(&mut self.store, ()).unwrap_or(0);
         let len = self.fn_get_error_len.call(&mut self.store, ()).unwrap_or(0);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93"
+channel = "1.95"

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -4478,7 +4478,7 @@ mod tests {
         let methods = target_methods();
         let mut seen = std::collections::HashSet::new();
         for m in methods {
-            assert!(seen.insert(m.name), "duplicate method name: '{}'", m.name,);
+            assert!(seen.insert(m.name), "duplicate method name: '{}'", m.name);
         }
     }
 


### PR DESCRIPTION
## Summary
- Bumps pinned Rust toolchain + workspace MSRV + CI pin from **1.93 → 1.95** (released 2026-04-14).
- Adopts `core::hint::cold_path()` (stabilized in 1.95) for error branches in `check_error`, `write_bytes`, and `read_bytes`; marks the whole `read_last_error` function `#[cold]`.
- Drops a trailing comma inside `assert!(…)` in `xtask/src/codegen/config.rs` to satisfy the new `clippy::unnecessary_trailing_comma` lint in 1.95.

## Why
`check_error` runs after every facade call. The error branch is almost never taken, so hinting it as cold lets LLVM push the error-handling machinery out of the hot path.

## MSRV note
Raising `rust-version` from 1.93 to 1.95 is a breaking MSRV bump for downstream `occt-wasm` crate users. A minor version bump (1.5.0 → 1.6.0) may be appropriate on the next release.

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test -p xtask\` (26/26)
- [x] \`cargo doc -p occt-wasm --no-deps\`
- [ ] Full CI (build-test + browser smoke) on GitHub Actions