### PR TITLE
feat(facade): add getFaceCylinderData for cylinder radius + direct flag

### DIFF
--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -123,6 +123,7 @@ pub(crate) struct GeneratedFuncs {
     fn_get_linear_center_of_mass: TypedFunc<(u32,), i32>,
     fn_surface_curvature: TypedFunc<(u32, f64, f64), i32>,
     fn_uv_bounds: TypedFunc<(u32,), i32>,
+    fn_get_face_cylinder_data: TypedFunc<(u32,), i32>,
     fn_uv_from_point: TypedFunc<(u32, f64, f64, f64), i32>,
     fn_project_point_on_face: TypedFunc<(u32, f64, f64, f64), i32>,
     fn_classify_point_on_face: TypedFunc<(u32, f64, f64), i32>,
@@ -312,6 +313,8 @@ impl GeneratedFuncs {
                 .get_typed_func(&mut store, "occt_get_linear_center_of_mass")?,
             fn_surface_curvature: instance.get_typed_func(&mut store, "occt_surface_curvature")?,
             fn_uv_bounds: instance.get_typed_func(&mut store, "occt_uv_bounds")?,
+            fn_get_face_cylinder_data: instance
+                .get_typed_func(&mut store, "occt_get_face_cylinder_data")?,
             fn_uv_from_point: instance.get_typed_func(&mut store, "occt_uv_from_point")?,
             fn_project_point_on_face: instance
                 .get_typed_func(&mut store, "occt_project_point_on_face")?,
@@ -2146,6 +2149,17 @@ impl crate::kernel::OcctKernel {
             .call(&mut self.store, (face_id.0,))?;
         if len < 0 {
             return Err(self.read_last_error("uv_bounds"));
+        }
+        self.read_vec_f64_result()
+    }
+
+    pub fn get_face_cylinder_data(&mut self, face_id: ShapeHandle) -> OcctResult<Vec<f64>> {
+        let len = self
+            .generated
+            .fn_get_face_cylinder_data
+            .call(&mut self.store, (face_id.0,))?;
+        if len < 0 {
+            return Err(self.read_last_error("get_face_cylinder_data"));
         }
         self.read_vec_f64_result()
     }

--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -203,6 +203,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("getLinearCenterOfMass", &OcctKernel::getLinearCenterOfMass)
         .function("surfaceCurvature", &OcctKernel::surfaceCurvature)
         .function("uvBounds", &OcctKernel::uvBounds)
+        .function("getFaceCylinderData", &OcctKernel::getFaceCylinderData)
         .function("uvFromPoint", &OcctKernel::uvFromPoint)
         .function("projectPointOnFace", &OcctKernel::projectPointOnFace)
         .function("classifyPointOnFace", &OcctKernel::classifyPointOnFace)

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -136,6 +136,7 @@
 #include <gp_Ax2.hxx>
 #include <gp_Ax3.hxx>
 #include <gp_Circ.hxx>
+#include <gp_Cylinder.hxx>
 #include <gp_Dir.hxx>
 #include <gp_Dir2d.hxx>
 #include <gp_Elips.hxx>
@@ -1917,6 +1918,19 @@ std::vector<double> OcctKernel::uvBounds(uint32_t faceId) {
                 surf.LastVParameter()};
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("uvBounds: ") + e.what());
+    }
+}
+
+std::vector<double> OcctKernel::getFaceCylinderData(uint32_t faceId) {
+    try {
+        BRepAdaptor_Surface surf(TopoDS::Face(get(faceId)));
+        if (surf.GetType() != GeomAbs_Cylinder) {
+            return {};
+        }
+        gp_Cylinder cyl = surf.Cylinder();
+        return {cyl.Radius(), cyl.Direct() ? 1.0 : 0.0};
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("getFaceCylinderData: ") + e.what());
     }
 }
 

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -281,6 +281,7 @@ class OcctKernel {
     uint32_t outerWire(uint32_t faceId);
     std::vector<double> uvBounds(uint32_t faceId);
     std::vector<double> uvFromPoint(uint32_t faceId, double x, double y, double z);
+    std::vector<double> getFaceCylinderData(uint32_t faceId);
     std::vector<double> projectPointOnFace(uint32_t faceId, double x, double y, double z);
     std::string classifyPointOnFace(uint32_t faceId, double u, double v);
 

--- a/test/ts-wrapper.test.ts
+++ b/test/ts-wrapper.test.ts
@@ -104,7 +104,7 @@ describe("TS wrapper patterns: structured returns (uvBounds → UVBounds)", () =
         // The cylinder has 3 faces (top, bottom, lateral). Find the lateral one.
         let cylinderFaceIdx = -1;
         for (let i = 0; i < faces.size(); i++) {
-            if (kernel.surfaceType(faces.get(i)) === "CYLINDER") {
+            if (kernel.surfaceType(faces.get(i)) === "cylinder") {
                 cylinderFaceIdx = i;
                 break;
             }

--- a/test/ts-wrapper.test.ts
+++ b/test/ts-wrapper.test.ts
@@ -98,6 +98,35 @@ describe("TS wrapper patterns: structured returns (uvBounds → UVBounds)", () =
         edges.delete();
     });
 
+    it("getFaceCylinderData returns [radius, isDirect] for a cylindrical face", () => {
+        const cyl = kernel.makeCylinder(7, 20);
+        const faces = kernel.getSubShapes(cyl, "face");
+        // The cylinder has 3 faces (top, bottom, lateral). Find the lateral one.
+        let cylinderFaceIdx = -1;
+        for (let i = 0; i < faces.size(); i++) {
+            if (kernel.surfaceType(faces.get(i)) === "CYLINDER") {
+                cylinderFaceIdx = i;
+                break;
+            }
+        }
+        expect(cylinderFaceIdx).toBeGreaterThanOrEqual(0);
+        const raw = kernel.getFaceCylinderData(faces.get(cylinderFaceIdx));
+        expect(raw.size()).toBe(2);
+        expect(raw.get(0)).toBeCloseTo(7, 6); // radius
+        expect(raw.get(1)).toBe(1); // isDirect = true
+        raw.delete();
+        faces.delete();
+    });
+
+    it("getFaceCylinderData returns empty vector for a non-cylindrical face", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const faces = kernel.getSubShapes(box, "face");
+        const raw = kernel.getFaceCylinderData(faces.get(0)); // planar
+        expect(raw.size()).toBe(0);
+        raw.delete();
+        faces.delete();
+    });
+
     it("getCenterOfMass raw data can be destructured into Vec3", () => {
         const box = kernel.makeBox(10, 20, 30);
         const raw = kernel.getCenterOfMass(box);

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -309,6 +309,7 @@ interface RawKernel {
     outerWire(faceId: number): number;
     uvBounds(faceId: number): EmbindVectorF64;
     uvFromPoint(faceId: number, x: number, y: number, z: number): EmbindVectorF64;
+    getFaceCylinderData(faceId: number): EmbindVectorF64;
     projectPointOnFace(faceId: number, x: number, y: number, z: number): EmbindVectorF64;
     classifyPointOnFace(faceId: number, u: number, v: number): string;
     bsplineSurface(flatPoints: EmbindVectorF64, rows: number, cols: number): number;
@@ -1473,6 +1474,25 @@ export class OcctKernel {
         return wrap("uvFromPoint", () =>
             this.#vec2FromEmbind(this.#raw.uvFromPoint(face, point.x, point.y, point.z)),
         );
+    }
+
+    /**
+     * Extract cylinder data from a cylindrical face.
+     *
+     * Returns `null` when the face's underlying surface is not a cylinder,
+     * otherwise `{ radius, isDirect }` where `isDirect` mirrors
+     * `gp_Cylinder::Direct()` (i.e. whether U and V form a right-handed pair).
+     */
+    getFaceCylinderData(face: ShapeHandle): { radius: number; isDirect: boolean } | null {
+        return wrap("getFaceCylinderData", () => {
+            const vec = this.#raw.getFaceCylinderData(face);
+            try {
+                if (vec.size() === 0) return null;
+                return { radius: vec.get(0), isDirect: vec.get(1) !== 0 };
+            } finally {
+                vec.delete();
+            }
+        });
     }
 
     /** Project a 3D point onto a face, returning the closest point as Vec3. */

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -2162,6 +2162,23 @@ return {surf.FirstUParameter(), surf.LastUParameter(), surf.FirstVParameter(),
         return_type: ReturnType::VectorDouble,
     },
     MethodSpec {
+        name: "getFaceCylinderData",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("faceId")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+BRepAdaptor_Surface surf(TopoDS::Face(get(faceId)));
+if (surf.GetType() != GeomAbs_Cylinder) {
+    return {};
+}
+gp_Cylinder cyl = surf.Cylinder();
+return {cyl.Radius(), cyl.Direct() ? 1.0 : 0.0};",
+        includes: &["BRepAdaptor_Surface.hxx", "GeomAbs_SurfaceType.hxx", "TopoDS.hxx", "gp_Cylinder.hxx"],
+        category: "query",
+        return_type: ReturnType::VectorDouble,
+    },
+    MethodSpec {
         name: "uvFromPoint",
         kind: MethodKind::CustomBody,
         params: &[
@@ -4444,7 +4461,7 @@ mod tests {
             .iter()
             .filter(|m| m.kind != MethodKind::Skip)
             .count();
-        assert_eq!(count, 171, "expected 171 generable methods");
+        assert_eq!(count, 172, "expected 172 generable methods");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a facade method to extract `gp_Cylinder` data (radius + direct flag) from a face whose underlying surface is cylindrical. Wraps `BRepAdaptor_Surface::Cylinder()` behind a standard `std::vector<double>` return.

**Return contract:**
- Cylindrical face → `[radius, isDirect ? 1.0 : 0.0]`
- Non-cylindrical face → empty vector (signals null)

**TS wrapper** returns `{ radius, isDirect } | null`.

## Motivation

This unblocks [`brepjs`](https://github.com/andymai/brepjs) — its `KernelIOOps.getSurfaceCylinderData` interface has been `notImplemented` on the `occt-wasm` adapter since inception. brepjs uses face handles as surface proxies (see `extractSurfaceFromFace` in its occt-wasm adapter), so a face-keyed facade method is the natural binding — no new handle type needed.

Once this lands + a minor release goes out, brepjs' occt-wasm adapter closes one more stub and the `nurbsFns.cylindricalFaceSurface` divergence in its conformance matrix flips from ❌ to ✅.

## Changes

| File | Change |
|---|---|
| `xtask/src/codegen/config.rs` | Add `MethodSpec` for `getFaceCylinderData` (CustomBody, 10 lines of C++) |
| `xtask/src/codegen/config.rs` | Bump generable method count assertion `171 → 172` |
| `facade/include/occt_kernel.h` | Add class-level method declaration |
| `facade/generated/{bindings,kernel}.cpp` | Regenerated via `cargo xtask codegen` |
| `crate/src/kernel_generated.rs` | Regenerated typed-func binding |
| `ts/src/index.ts` | Add raw interface decl + typed wrapper method returning `{ radius, isDirect } \| null` |
| `test/ts-wrapper.test.ts` | Two tests: cylindrical face returns `[7, 1]`, planar face returns empty |

## Test plan

- [x] Rust `cargo test` codegen config unit tests pass (6/6)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] WASM rebuild produces `dist/occt-wasm.wasm` (21 MB) with no new compile errors
- [x] Full test suite: `259 passed | 1 skipped` (the skip is a pre-existing unrelated case)
- [x] TS `npm run typecheck` and `npm run lint` clean
- [ ] CI passes

## Downstream

Once merged + published, brepjs PR will be small (~5 lines in `occtWasmAdapter.ts`):

```ts
getSurfaceCylinderData(surface: KernelType): { radius: number; isDirect: boolean } | null {
  const vec = this.k.getFaceCylinderData(unwrap(surface as unknown as KernelShape));
  try {
    return vec.size() === 0 ? null : { radius: vec.get(0), isDirect: vec.get(1) !== 0 };
  } finally {
    vec.delete();
  }
}
```