### PR TITLE
Fix Docker crate workspace + exclude wasi_exports from npm build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ TS wrapper (ts/) → tsc → occt-wasm
 - `facade/` — C++ facade (OcctKernel class + Embind bindings)
 - `ts/` — TypeScript wrapper (occt-wasm npm package)
 - `xtask/` — Rust build orchestration (clap + anyhow + xshell)
-- `occt/` — OCCT V8.0.0-rc5 (git submodule)
+- `occt/` — OCCT V8.0.0-rc5 + 2 WASM patches (git submodule from andymai/OCCT fork)
 - `3rdparty/` — Isolated third-party headers (RapidJSON for glTF, gitignored)
 - `scripts/` — build.sh, symbol_dispose.js, publish.sh, fetch-rapidjson.sh, bench-check.js
 - `test/` — Vitest integration tests (integration, expanded, xcaf, bench) + benchmark.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,12 @@ WORKDIR /workspace
 COPY .cargo/ .cargo/
 COPY Cargo.toml Cargo.lock* ./
 COPY xtask/Cargo.toml xtask/
-RUN mkdir -p xtask/src && echo 'fn main() {}' > xtask/src/main.rs \
+COPY crate/Cargo.toml crate/
+RUN mkdir -p xtask/src crate/src \
+    && echo 'fn main() {}' > xtask/src/main.rs \
+    && echo 'pub fn placeholder() {}' > crate/src/lib.rs \
     && cargo build --release 2>/dev/null || true \
-    && rm -rf xtask/src
+    && rm -rf xtask/src crate/src
 
 # --- Layer 4: Node dependency cache (changes only when package.json changes) ---
 COPY package.json package-lock.json* ./
@@ -68,8 +71,12 @@ RUN --mount=type=cache,target=/cache/ccache \
     && cmake --build . --parallel \
     && echo "OCCT build complete: $(ls -1 lin32/clang/lib/*.a 2>/dev/null | wc -l) static libs"
 
-# --- Layer 7: xtask source (changes when build logic changes) ---
+# --- Layer 7: xtask + crate source (changes when build logic changes) ---
+# crate/ is a workspace member; cargo parses all member manifests even for `-p xtask`,
+# so its src must be present (a stub lib.rs would also work, but keeping real source
+# avoids a second placeholder dance).
 COPY xtask/ xtask/
+COPY crate/ crate/
 RUN cargo build --release -p xtask
 
 # --- Layer 8: Facade + scripts + TS (changes frequently) ---

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -108,12 +108,21 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
         .collect();
 
     // Also compile generated facade files (kernel.cpp + bindings.cpp).
+    // Exclude wasi_exports.cpp — that's the C-ABI export layer for the standalone
+    // WASI build (cargo xtask build-wasi), not the Embind/npm path. Linking it here
+    // adds ~60 KB of dead code and, with -O3 -flto on top of newer OCCT objects, can
+    // produce invalid wasm at the linker output.
     let gen_dir = root.join("facade/generated");
     if gen_dir.is_dir() {
         let gen_sources: Vec<PathBuf> = std::fs::read_dir(&gen_dir)?
             .filter_map(Result::ok)
             .map(|e| e.path())
             .filter(|p| p.extension().is_some_and(|e| e == "cpp"))
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| !n.starts_with("wasi_"))
+            })
             .collect();
         sources.extend(gen_sources);
     }


### PR DESCRIPTION
## Summary

Three independent build-pipeline fixes that surfaced during a 2026-05-04 OCCT V8.0.0-beta2 bump attempt. The bump itself was reverted (emcc produces invalid wasm linking beta1+ OCCT objects, prime suspect upstream PR #1212), but these three issues are real and unrelated to the OCCT version.

- **`fix(docker)`**: PR #82 added the `crate/` workspace member but never updated the Dockerfile dep-cache layer. The error was masked by `2>/dev/null || true` on the cache-warming `cargo build`, then surfaced as a hard failure on the real `cargo build -p xtask` step. `npm run docker:build` had been silently broken since #82 merged in April.
- **`fix(xtask)`**: PR #82 also added `facade/generated/wasi_exports.cpp` (60 KB of C-ABI exports for the standalone WASI build). The npm/Embind build's `compile_facade` blindly globbed `*.cpp` from `facade/generated/`, so wasi_exports has been silently linked into the npm WASM since #82 — dead code in that context, plus an LTO risk surface.
- **`docs(claude)`**: Sharpens the OCCT submodule line. The previous "V8.0.0-rc5 (git submodule)" wording obscured that the pin is rc5 + 2 WASM-compat patches via the andymai/OCCT fork. The beta2 attempt revealed this ambiguity (a stale `git describe` reported "rc4-66" because rc5 hadn't been fetched into the fork yet).

Each fix is bisectable on its own; bundling for review convenience.

## Test plan

- [x] `npm run docker:build` green on rc5+patches baseline with the kept fixes applied
- [x] **Tests: 259 passed | 1 skipped | 0 failed** (was 257/1/0 in the prior decision log; +2 reflects tests added in PRs #84/#85)
- [x] WASM size: 21 MB uncompressed, consistent with prior
- [x] Build now uses **3 facade objects** (was 4) — confirms `wasi_exports.cpp` is excluded
- [x] All 4 build steps clean: OCCT cached, facade compile, `-O3` link, explicit `wasm-opt -O4 --converge --gufa`
- [x] Pre-commit + pre-push hooks pass on each commit (cargo fmt + clippy + clang-format + eslint + tsc + vitest)