### PR TITLE
feat(ts): expose raw module + kernel for third-party adapters

### DIFF
--- a/test/raw-access.test.ts
+++ b/test/raw-access.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for getRawModule() / getRawKernel() — the escape hatch that lets
+ * third-party adapters (e.g. brepjs.OcctWasmAdapter) pair with the public
+ * OcctKernel class without bypassing OcctKernel.init().
+ *
+ * These tests import the *built* dist/index.js so that init()'s relative
+ * `import('./occt-wasm.js')` resolves correctly.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { resolve, dirname } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let OcctKernel: typeof import("../ts/dist/index.js").OcctKernel;
+let kernel: import("../ts/dist/index.js").OcctKernel;
+
+beforeAll(async () => {
+    const wasmPath = resolve(__dirname, "../ts/dist/occt-wasm.wasm");
+    const wasmBinary = readFileSync(wasmPath);
+    const mod = await import(resolve(__dirname, "../ts/dist/index.js"));
+    OcctKernel = mod.OcctKernel;
+    kernel = await OcctKernel.init({ wasm: wasmBinary });
+}, 30_000);
+
+afterAll(() => {
+    kernel?.[Symbol.dispose]();
+});
+
+describe("OcctKernel raw access", () => {
+    it("getRawModule() returns the Emscripten module with expected surface", () => {
+        const module = kernel.getRawModule();
+        expect(typeof module.OcctKernel).toBe("function");
+        expect(typeof module.VectorUint32).toBe("function");
+        expect(typeof module.VectorDouble).toBe("function");
+        expect(typeof module.VectorInt).toBe("function");
+        expect(module.HEAPF32).toBeInstanceOf(Float32Array);
+        expect(module.HEAPU32).toBeInstanceOf(Uint32Array);
+        expect(module.HEAP32).toBeInstanceOf(Int32Array);
+    });
+
+    it("getRawKernel() returns the same raw kernel that backs the wrapper", () => {
+        const raw = kernel.getRawKernel();
+        const boxId = raw.makeBox(10, 20, 30);
+        try {
+            // Wrapper-side observation of state mutated through the raw kernel.
+            expect(kernel.shapeCount).toBeGreaterThan(0);
+            expect(typeof boxId).toBe("number");
+            expect(raw.getShapeType(boxId)).toBe("solid");
+        } finally {
+            raw.release(boxId);
+        }
+    });
+
+    it("raw module + raw kernel are stable across calls (same identity)", () => {
+        expect(kernel.getRawModule()).toBe(kernel.getRawModule());
+        expect(kernel.getRawKernel()).toBe(kernel.getRawKernel());
+    });
+
+    it("simulates a brepjs-style adapter handoff", () => {
+        const module = kernel.getRawModule();
+        const raw = kernel.getRawKernel();
+        // brepjs.OcctWasmAdapter expects (module, kernel) — verify both are
+        // typed and structurally compatible (no `as any` needed).
+        const adapter = { module, kernel: raw };
+        const id = adapter.kernel.makeSphere(5);
+        try {
+            expect(adapter.kernel.getVolume(id)).toBeGreaterThan(0);
+        } finally {
+            adapter.kernel.release(id);
+        }
+    });
+});

--- a/test/raw-access.test.ts
+++ b/test/raw-access.test.ts
@@ -58,6 +58,20 @@ describe("OcctKernel raw access", () => {
         expect(kernel.getRawKernel()).toBe(kernel.getRawKernel());
     });
 
+    it("dispose is idempotent if the raw kernel is deleted externally first", async () => {
+        // An integrator following Embind teardown conventions might call
+        // raw.delete() when tearing down their adapter. The wrapper's
+        // [Symbol.dispose]() must not crash when it later runs releaseAll() /
+        // delete() on the already-deleted Embind object.
+        const wasmPath = resolve(__dirname, "../ts/dist/occt-wasm.wasm");
+        const wasmBinary = readFileSync(wasmPath);
+        const ephemeral = await OcctKernel.init({ wasm: wasmBinary });
+        ephemeral.getRawKernel().delete();
+        // Should not throw — the catch in [Symbol.dispose]() absorbs the
+        // double-delete error from Embind.
+        expect(() => ephemeral[Symbol.dispose]()).not.toThrow();
+    });
+
     it("simulates a brepjs-style adapter handoff", () => {
         const module = kernel.getRawModule();
         const raw = kernel.getRawKernel();

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -75,11 +75,25 @@ import type {
 import { JoinType, OcctError, TransitionMode } from "./types.js";
 
 // ---------------------------------------------------------------------------
-// Internal Embind types
+// Raw Embind types
+//
+// These describe the WASM-level surface that sits beneath the public
+// `OcctKernel` class. They're exposed (via `getRawModule()` / `getRawKernel()`)
+// so that integrators — most notably brepjs's `OcctWasmAdapter` — can pair
+// the public class with adapters that take the raw module + Embind kernel
+// directly, without losing TypeScript types or bypassing `OcctKernel.init()`.
 // ---------------------------------------------------------------------------
 
-interface EmscriptenModule {
-    OcctKernel: new () => RawKernel;
+/**
+ * The Emscripten module exposed by `occt-wasm.js`. Provides Embind class
+ * constructors, std::vector wrappers, and typed-array views into WASM
+ * linear memory.
+ *
+ * Returned by {@link OcctKernel.getRawModule}. Structurally compatible with
+ * brepjs's `OcctWasmModule` interface.
+ */
+export interface OcctWasmModule {
+    OcctKernel: new () => OcctRawKernel;
     VectorUint32: new () => EmbindVectorU32;
     VectorDouble: new () => EmbindVectorF64;
     VectorInt: new () => EmbindVectorI32;
@@ -168,7 +182,18 @@ interface EmbindVectorI32 {
     delete(): void;
 }
 
-interface RawKernel {
+/**
+ * The raw Embind kernel — direct mirror of the C++ `OcctKernel` class
+ * compiled to WASM. Operates on `u32` arena handles instead of branded
+ * {@link ShapeHandle} values.
+ *
+ * Returned by {@link OcctKernel.getRawKernel}. Structurally compatible with
+ * brepjs's `OcctKernelWasm` interface. Prefer the public `OcctKernel` class
+ * unless you specifically need to hand the raw kernel to a third-party
+ * adapter — calling raw methods bypasses `OcctError` wrapping and the branded
+ * handle types.
+ */
+export interface OcctRawKernel {
     // Arena
     release(id: number): void;
     releaseAll(): void;
@@ -445,7 +470,7 @@ function vecToHandles(vec: EmbindVectorU32): ShapeHandle[] {
  * garbage-collected without being disposed. Prefer `using` or explicit
  * `kernel[Symbol.dispose]()` — the FinalizationRegistry is a last resort.
  */
-const kernelRegistry = new FinalizationRegistry<RawKernel>((raw) => {
+const kernelRegistry = new FinalizationRegistry<OcctRawKernel>((raw) => {
     try {
         raw.releaseAll();
         raw.delete();
@@ -467,10 +492,10 @@ const kernelRegistry = new FinalizationRegistry<RawKernel>((raw) => {
  * instances, but deterministic disposal is strongly preferred.
  */
 export class OcctKernel {
-    readonly #raw: RawKernel;
-    readonly #module: EmscriptenModule;
+    readonly #raw: OcctRawKernel;
+    readonly #module: OcctWasmModule;
 
-    private constructor(module: EmscriptenModule) {
+    private constructor(module: OcctWasmModule) {
         this.#module = module;
         this.#raw = new module.OcctKernel();
         kernelRegistry.register(this, this.#raw, this);
@@ -497,7 +522,7 @@ export class OcctKernel {
         const imported = await import(/* webpackIgnore: true */ "./occt-wasm.js");
         const createModule = imported.default as (
             opts: Record<string, unknown>,
-        ) => Promise<EmscriptenModule>;
+        ) => Promise<OcctWasmModule>;
 
         const moduleOpts: Record<string, unknown> = {};
 
@@ -1928,6 +1953,38 @@ export class OcctKernel {
         kernelRegistry.unregister(this);
         this.#raw.releaseAll();
         this.#raw.delete();
+    }
+
+    // =======================================================================
+    // Raw module / kernel access (for third-party adapters)
+    // =======================================================================
+
+    /**
+     * Return the underlying Emscripten module. Intended for integrators who
+     * need to hand the raw module to a third-party adapter (e.g.
+     * `brepjs.OcctWasmAdapter`) without bypassing {@link OcctKernel.init}.
+     *
+     * The module is owned by this `OcctKernel` instance — disposing the
+     * kernel does not invalidate the module reference, but the raw kernel
+     * obtained via {@link getRawKernel} *will* be deleted.
+     */
+    getRawModule(): OcctWasmModule {
+        return this.#module;
+    }
+
+    /**
+     * Return the underlying raw Embind kernel. Intended for integrators who
+     * need to hand the raw kernel to a third-party adapter (e.g.
+     * `brepjs.OcctWasmAdapter`).
+     *
+     * Lifecycle: the raw kernel is owned by this `OcctKernel`. Calling
+     * `kernel[Symbol.dispose]()` (or letting the FinalizationRegistry collect
+     * the wrapper) will `releaseAll()` and `delete()` the raw kernel — so the
+     * adapter must not outlive the `OcctKernel` it was constructed from.
+     * Do not call `delete()` or `releaseAll()` on the raw kernel directly.
+     */
+    getRawKernel(): OcctRawKernel {
+        return this.#raw;
     }
 
     // =======================================================================

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1951,8 +1951,14 @@ export class OcctKernel {
 
     [Symbol.dispose](): void {
         kernelRegistry.unregister(this);
-        this.#raw.releaseAll();
-        this.#raw.delete();
+        try {
+            this.#raw.releaseAll();
+            this.#raw.delete();
+        } catch {
+            // Raw kernel was already deleted externally (e.g. by an adapter
+            // following Embind teardown conventions) — ignore, matching the
+            // FinalizationRegistry callback's behavior.
+        }
     }
 
     // =======================================================================


### PR DESCRIPTION
## Summary

- Add `OcctKernel.getRawModule()` and `OcctKernel.getRawKernel()` accessors so integrators (e.g. `brepjs.OcctWasmAdapter`) can pair the public `OcctKernel` with adapters that take the raw Emscripten module + Embind kernel directly, without bypassing `OcctKernel.init()`.
- Rename internal `EmscriptenModule` → `OcctWasmModule` and `RawKernel` → `OcctRawKernel`, and export them. Both are structurally compatible with brepjs's `OcctWasmModule` / `OcctKernelWasm` interfaces — no `as any` casts needed at the integration boundary.
- New test file `test/raw-access.test.ts` exercises the accessors via `OcctKernel.init({ wasm })` against the built `dist/`.

Closes #91.

### Before
```ts
// What you had to write today (from issue #91):
import createModule from 'occt-wasm/dist/occt-wasm.js';
import wasmUrl from 'occt-wasm/dist/occt-wasm.wasm?url';

const module = await createModule({ locateFile: (p) => p.endsWith('.wasm') ? wasmUrl : p });
const rawKernel = new module.OcctKernel();
const adapter = new OcctWasmAdapter(module as any, rawKernel as any);
// — skips FinalizationRegistry safety net
// — re-implements wasm-source resolution
// — TS types lost
```

### After
```ts
import { OcctKernel } from 'occt-wasm';
import { OcctWasmAdapter, registerKernel } from 'brepjs';

const kernel = await OcctKernel.init({ wasm: url });
const adapter = new OcctWasmAdapter(kernel.getRawModule(), kernel.getRawKernel());
registerKernel('occt-wasm', adapter);
```

## Lifecycle note

The raw kernel is owned by the `OcctKernel` wrapper. `kernel[Symbol.dispose]()` will `releaseAll()` and `delete()` it, so the adapter must not outlive the wrapper. Documented inline on `getRawKernel()`.

## Test plan
- [x] `npx vitest run` — 263 passed | 1 skipped (unchanged from main)
- [x] `npx vitest run test/raw-access.test.ts` — 4 new tests pass
- [x] `tsc --noEmit` clean
- [x] Verified `dist/index.d.ts` exports `OcctWasmModule`, `OcctRawKernel`, `getRawModule()`, `getRawKernel()`