### PR TITLE
feat(facade)!: expose ruled, tolerance, surfaceCenterOfMass for issue #90 parity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,14 @@ RUN --mount=type=cache,target=/cache/ccache \
     cargo xtask build --release \
     && echo "WASM size: $(du -h dist/occt-wasm.wasm | cut -f1)"
 
+# Copy ts/scripts/ here (after WASM build) so the build cache for the
+# expensive WASM link step isn't invalidated by edits to copy-wasm.sh.
+COPY ts/scripts/ ts/scripts/
+
+# Build TS package (prebuild copies dist/occt-wasm.{js,wasm} to ts/dist/,
+# which OcctKernel.init() resolves relative to its own location).
+RUN cd ts && npm run build
+
 # Test
 RUN cd ts && npx vitest run
 

--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -48,7 +48,7 @@ pub(crate) struct GeneratedFuncs {
     fn_chamfer: TypedFunc<(u32, i32, i32, f64), u32>,
     fn_chamfer_dist_angle: TypedFunc<(u32, i32, i32, f64, f64), u32>,
     fn_shell: TypedFunc<(u32, i32, i32, f64), u32>,
-    fn_offset: TypedFunc<(u32, f64), u32>,
+    fn_offset: TypedFunc<(u32, f64, f64), u32>,
     fn_draft: TypedFunc<(u32, u32, f64, f64, f64, f64), u32>,
     fn_thicken: TypedFunc<(u32, f64), u32>,
     fn_defeature: TypedFunc<(u32, i32, i32), u32>,
@@ -115,6 +115,7 @@ pub(crate) struct GeneratedFuncs {
     fn_get_surface_area: TypedFunc<(u32,), f64>,
     fn_get_length: TypedFunc<(u32,), f64>,
     fn_get_center_of_mass: TypedFunc<(u32,), i32>,
+    fn_get_surface_center_of_mass: TypedFunc<(u32,), i32>,
     fn_vertex_position: TypedFunc<(u32,), i32>,
     fn_surface_type: TypedFunc<(u32,), i32>,
     fn_surface_normal: TypedFunc<(u32, f64, f64), i32>,
@@ -144,8 +145,8 @@ pub(crate) struct GeneratedFuncs {
     fn_pipe: TypedFunc<(u32, u32), u32>,
     fn_simple_pipe: TypedFunc<(u32, u32), u32>,
     fn_revolve_vec: TypedFunc<(u32, f64, f64, f64, f64, f64, f64, f64), u32>,
-    fn_loft: TypedFunc<(i32, i32, i32), u32>,
-    fn_loft_with_vertices: TypedFunc<(i32, i32, i32, u32, u32), u32>,
+    fn_loft: TypedFunc<(i32, i32, i32, i32), u32>,
+    fn_loft_with_vertices: TypedFunc<(i32, i32, i32, i32, u32, u32), u32>,
     fn_sweep: TypedFunc<(u32, u32, i32), u32>,
     fn_sweep_pipe_shell: TypedFunc<(u32, u32, i32, i32), u32>,
     fn_draft_prism: TypedFunc<(u32, f64, f64, f64, f64), u32>,
@@ -304,6 +305,8 @@ impl GeneratedFuncs {
             fn_get_length: instance.get_typed_func(&mut store, "occt_get_length")?,
             fn_get_center_of_mass: instance
                 .get_typed_func(&mut store, "occt_get_center_of_mass")?,
+            fn_get_surface_center_of_mass: instance
+                .get_typed_func(&mut store, "occt_get_surface_center_of_mass")?,
             fn_vertex_position: instance.get_typed_func(&mut store, "occt_vertex_position")?,
             fn_surface_type: instance.get_typed_func(&mut store, "occt_surface_type")?,
             fn_surface_normal: instance.get_typed_func(&mut store, "occt_surface_normal")?,
@@ -818,11 +821,16 @@ impl crate::kernel::OcctKernel {
         Ok(ShapeHandle(result))
     }
 
-    pub fn offset(&mut self, solid_id: ShapeHandle, distance: f64) -> OcctResult<ShapeHandle> {
+    pub fn offset(
+        &mut self,
+        solid_id: ShapeHandle,
+        distance: f64,
+        tolerance: f64,
+    ) -> OcctResult<ShapeHandle> {
         let result = self
             .generated
             .fn_offset
-            .call(&mut self.store, (solid_id.0, distance))?;
+            .call(&mut self.store, (solid_id.0, distance, tolerance))?;
         self.check_error("offset")?;
         if result == 0 {
             return Err(self.read_last_error("offset"));
@@ -2054,6 +2062,17 @@ impl crate::kernel::OcctKernel {
         self.read_vec_f64_result()
     }
 
+    pub fn get_surface_center_of_mass(&mut self, face_id: ShapeHandle) -> OcctResult<Vec<f64>> {
+        let len = self
+            .generated
+            .fn_get_surface_center_of_mass
+            .call(&mut self.store, (face_id.0,))?;
+        if len < 0 {
+            return Err(self.read_last_error("get_surface_center_of_mass"));
+        }
+        self.read_vec_f64_result()
+    }
+
     pub fn vertex_position(&mut self, vertex_id: ShapeHandle) -> OcctResult<Vec<f64>> {
         let len = self
             .generated
@@ -2469,7 +2488,12 @@ impl crate::kernel::OcctKernel {
         Ok(ShapeHandle(result))
     }
 
-    pub fn loft(&mut self, wire_ids: &[ShapeHandle], is_solid: bool) -> OcctResult<ShapeHandle> {
+    pub fn loft(
+        &mut self,
+        wire_ids: &[ShapeHandle],
+        is_solid: bool,
+        ruled: bool,
+    ) -> OcctResult<ShapeHandle> {
         let wire_ids_bytes: Vec<u8> = wire_ids.iter().flat_map(|h| h.0.to_le_bytes()).collect();
         let wire_ids_ptr = self.write_bytes(&wire_ids_bytes)?;
         let wire_ids_len = wire_ids.len() as u32;
@@ -2479,6 +2503,7 @@ impl crate::kernel::OcctKernel {
                 wire_ids_ptr as i32,
                 wire_ids_len as i32,
                 i32::from(is_solid),
+                i32::from(ruled),
             ),
         );
         self.free_bytes(wire_ids_ptr)?;
@@ -2494,6 +2519,7 @@ impl crate::kernel::OcctKernel {
         &mut self,
         wire_ids: &[ShapeHandle],
         is_solid: bool,
+        ruled: bool,
         start_vertex_id: ShapeHandle,
         end_vertex_id: ShapeHandle,
     ) -> OcctResult<ShapeHandle> {
@@ -2506,6 +2532,7 @@ impl crate::kernel::OcctKernel {
                 wire_ids_ptr as i32,
                 wire_ids_len as i32,
                 i32::from(is_solid),
+                i32::from(ruled),
                 start_vertex_id.0,
                 end_vertex_id.0,
             ),

--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -195,6 +195,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("getSurfaceArea", &OcctKernel::getSurfaceArea)
         .function("getLength", &OcctKernel::getLength)
         .function("getCenterOfMass", &OcctKernel::getCenterOfMass)
+        .function("getSurfaceCenterOfMass", &OcctKernel::getSurfaceCenterOfMass)
         .function("vertexPosition", &OcctKernel::vertexPosition)
         .function("surfaceType", &OcctKernel::surfaceType)
         .function("surfaceNormal", &OcctKernel::surfaceNormal)

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -611,10 +611,10 @@ uint32_t OcctKernel::shell(uint32_t solidId, std::vector<uint32_t> faceIds, doub
     }
 }
 
-uint32_t OcctKernel::offset(uint32_t solidId, double distance) {
+uint32_t OcctKernel::offset(uint32_t solidId, double distance, double tolerance) {
     try {
         BRepOffsetAPI_MakeOffsetShape maker;
-        maker.PerformByJoin(get(solidId), distance, 1e-3);
+        maker.PerformByJoin(get(solidId), distance, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("offset: operation failed");
@@ -1798,6 +1798,18 @@ std::vector<double> OcctKernel::getCenterOfMass(uint32_t id) {
     }
 }
 
+std::vector<double> OcctKernel::getSurfaceCenterOfMass(uint32_t faceId) {
+    try {
+        const auto& face = get(faceId);
+        GProp_GProps props;
+        BRepGProp::SurfaceProperties(face, props);
+        gp_Pnt com = props.CentreOfMass();
+        return {com.X(), com.Y(), com.Z()};
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("getSurfaceCenterOfMass: ") + e.what());
+    }
+}
+
 std::vector<double> OcctKernel::vertexPosition(uint32_t vertexId) {
     try {
         gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(get(vertexId)));
@@ -2326,9 +2338,9 @@ uint32_t OcctKernel::revolveVec(uint32_t shapeId, double cx, double cy, double c
     }
 }
 
-uint32_t OcctKernel::loft(std::vector<uint32_t> wireIds, bool isSolid) {
+uint32_t OcctKernel::loft(std::vector<uint32_t> wireIds, bool isSolid, bool ruled) {
     try {
-        BRepOffsetAPI_ThruSections maker(isSolid);
+        BRepOffsetAPI_ThruSections maker(isSolid, ruled);
         for (uint32_t wid : wireIds) {
             maker.AddWire(TopoDS::Wire(get(wid)));
         }
@@ -2342,9 +2354,9 @@ uint32_t OcctKernel::loft(std::vector<uint32_t> wireIds, bool isSolid) {
     }
 }
 
-uint32_t OcctKernel::loftWithVertices(std::vector<uint32_t> wireIds, bool isSolid, uint32_t startVertexId, uint32_t endVertexId) {
+uint32_t OcctKernel::loftWithVertices(std::vector<uint32_t> wireIds, bool isSolid, bool ruled, uint32_t startVertexId, uint32_t endVertexId) {
     try {
-        BRepOffsetAPI_ThruSections maker(isSolid);
+        BRepOffsetAPI_ThruSections maker(isSolid, ruled);
         if (startVertexId != 0) {
             maker.AddVertex(TopoDS::Vertex(get(startVertexId)));
         }

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -157,16 +157,16 @@ class OcctKernel {
     uint32_t chamferDistAngle(uint32_t solidId, std::vector<uint32_t> edgeIds, double distance,
                               double angleDeg);
     uint32_t shell(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness);
-    uint32_t offset(uint32_t solidId, double distance);
+    uint32_t offset(uint32_t solidId, double distance, double tolerance);
     uint32_t draft(uint32_t shapeId, uint32_t faceId, double angleRad, double dx, double dy,
                    double dz);
 
     // --- Sweep operations ---
     uint32_t pipe(uint32_t profileId, uint32_t spineId);
     uint32_t simplePipe(uint32_t profileId, uint32_t spineId);
-    uint32_t loft(std::vector<uint32_t> wireIds, bool isSolid);
-    uint32_t loftWithVertices(std::vector<uint32_t> wireIds, bool isSolid, uint32_t startVertexId,
-                              uint32_t endVertexId);
+    uint32_t loft(std::vector<uint32_t> wireIds, bool isSolid, bool ruled);
+    uint32_t loftWithVertices(std::vector<uint32_t> wireIds, bool isSolid, bool ruled,
+                              uint32_t startVertexId, uint32_t endVertexId);
     uint32_t sweep(uint32_t wireId, uint32_t spineId, int transitionMode);
     uint32_t sweepPipeShell(uint32_t profileId, uint32_t spineId, bool freenet, bool smooth);
     uint32_t draftPrism(uint32_t shapeId, double dx, double dy, double dz, double angleDeg);
@@ -270,6 +270,7 @@ class OcctKernel {
     double getSurfaceArea(uint32_t id);
     double getLength(uint32_t id);
     std::vector<double> getCenterOfMass(uint32_t id);
+    std::vector<double> getSurfaceCenterOfMass(uint32_t faceId);
     std::vector<double> getLinearCenterOfMass(uint32_t id);
     std::vector<double> surfaceCurvature(uint32_t faceId, double u, double v);
 

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -270,7 +270,7 @@ describe("sweeps", () => {
         const wireVec = new Module.VectorUint32();
         wireVec.push_back(wire1);
         wireVec.push_back(wire2);
-        const result = kernel.loft(wireVec, true);
+        const result = kernel.loft(wireVec, true, false);
         expect(result).toBeGreaterThan(0);
         expect(kernel.getVolume(result)).toBeGreaterThan(0);
         wireVec.delete();

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -268,7 +268,7 @@ describe("degenerate geometry", () => {
         const box = kernel.makeBox(5, 5, 5);
         let result: number | undefined;
         try {
-            result = kernel.offset(box, -10);
+            result = kernel.offset(box, -10, 1e-6);
         } catch {
             return;
         }
@@ -302,7 +302,7 @@ describe("degenerate geometry", () => {
         const wireVec = new Module.VectorUint32();
         try {
             wireVec.push_back(wire);
-            expectThrows(() => kernel.loft(wireVec, true), "loft with 1 wire");
+            expectThrows(() => kernel.loft(wireVec, true, false), "loft with 1 wire");
         } finally {
             wireVec.delete();
         }
@@ -311,7 +311,7 @@ describe("degenerate geometry", () => {
     it("loft with an empty wire vector throws", () => {
         const wireVec = new Module.VectorUint32();
         try {
-            expectThrows(() => kernel.loft(wireVec, true), "loft with 0 wires");
+            expectThrows(() => kernel.loft(wireVec, true, false), "loft with 0 wires");
         } finally {
             wireVec.delete();
         }

--- a/test/expanded.test.ts
+++ b/test/expanded.test.ts
@@ -124,7 +124,7 @@ describe("modeling operations", () => {
 
     it("offsets a solid", () => {
         const box = kernel.makeBox(10, 10, 10);
-        const offset = kernel.offset(box, 1.0);
+        const offset = kernel.offset(box, 1.0, 1e-6);
         expect(offset).toBeGreaterThan(0);
         // Offset solid should have larger volume
         expect(kernel.getVolume(offset)).toBeGreaterThan(kernel.getVolume(box));

--- a/test/surface-center-of-mass.test.ts
+++ b/test/surface-center-of-mass.test.ts
@@ -88,19 +88,57 @@ describe("getSurfaceCenterOfMass", () => {
         faces.delete();
     });
 
-    it("differs from getCenterOfMass (which is volume-based) when called on a face", () => {
-        // Sanity check: the two methods are not aliases. For a face,
-        // getCenterOfMass(face) returns volume CoM (often (0,0,0) for a 2D
-        // shape with zero volume), while getSurfaceCenterOfMass returns the
-        // area-weighted point on the face.
+    it("differs from getCenterOfMass (volume-based) when called on the same face", () => {
+        // The two methods are not aliases. getCenterOfMass uses
+        // BRepGProp::VolumeProperties (returns origin for a 2D face with zero
+        // volume); getSurfaceCenterOfMass uses BRepGProp::SurfaceProperties
+        // (returns the area-weighted point on the face).
         const box = kernel.makeBox(10, 10, 10);
         const faces = kernel.getSubShapes(box, "face");
         const fid = faces.get(0);
         const surfaceCom = vecToArray(kernel.getSurfaceCenterOfMass(fid));
-        // surfaceCom should be on the face (one coord pinned to 0 or 10,
-        // the other two near 5).
-        const onPlane = surfaceCom.filter((c) => Math.abs(c) < 0.01 || Math.abs(c - 10) < 0.01);
-        expect(onPlane.length).toBeGreaterThanOrEqual(1);
+        const volumeCom = vecToArray(kernel.getCenterOfMass(fid));
+        // Volume CoM of a face should be at (or very near) the origin since
+        // a face has zero volume — OCCT returns the default-constructed gp_Pnt.
+        expect(volumeCom[0]).toBeCloseTo(0, 6);
+        expect(volumeCom[1]).toBeCloseTo(0, 6);
+        expect(volumeCom[2]).toBeCloseTo(0, 6);
+        // Surface CoM should be on the face — far enough from origin that
+        // the divergence is unambiguous (face center is at (5, 5, 0) or similar).
+        const surfaceMagnitude = Math.hypot(surfaceCom[0]!, surfaceCom[1]!, surfaceCom[2]!);
+        expect(surfaceMagnitude).toBeGreaterThan(1);
         faces.delete();
+    });
+
+    it("loftWithVertices accepts ruled flag at position 3", () => {
+        // Regression for the breaking ABI change: ruled was inserted as the
+        // 3rd positional arg, before startVertexId/endVertexId. A caller that
+        // forgets to update would silently pass startVertex as ruled.
+        const wires = new Module.VectorUint32();
+        // Build two square wires at z=0 and z=10
+        const makeSquareWire = (z: number) => {
+            const e1 = kernel.makeLineEdge(0, 0, z, 5, 0, z);
+            const e2 = kernel.makeLineEdge(5, 0, z, 5, 5, z);
+            const e3 = kernel.makeLineEdge(5, 5, z, 0, 5, z);
+            const e4 = kernel.makeLineEdge(0, 5, z, 0, 0, z);
+            const ev = new Module.VectorUint32();
+            ev.push_back(e1); ev.push_back(e2); ev.push_back(e3); ev.push_back(e4);
+            const wire = kernel.makeWire(ev);
+            ev.delete();
+            return wire;
+        };
+        wires.push_back(makeSquareWire(0));
+        wires.push_back(makeSquareWire(10));
+        // ruled=true, no start/end vertex
+        const ruledLoft = kernel.loftWithVertices(wires, true, true, 0, 0);
+        const smoothLoft = kernel.loftWithVertices(wires, true, false, 0, 0);
+        expect(ruledLoft).toBeGreaterThan(0);
+        expect(smoothLoft).toBeGreaterThan(0);
+        // Both succeed and produce non-zero volume; their geometry differs.
+        // (Topology comparison is brittle; existence + non-degeneracy is the
+        // contract we care about for the param-plumbing regression.)
+        expect(kernel.getVolume(ruledLoft)).toBeGreaterThan(0);
+        expect(kernel.getVolume(smoothLoft)).toBeGreaterThan(0);
+        wires.delete();
     });
 });

--- a/test/surface-center-of-mass.test.ts
+++ b/test/surface-center-of-mass.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for getSurfaceCenterOfMass — added to address parity gap
+ * with brepjs (issue #90), where the brepjs occt-wasm adapter falls back to
+ * tessellation-based centroids because the facade didn't expose
+ * `BRepGProp::SurfaceProperties::CentreOfMass()`. Tessellation centroids
+ * land on the surface (off-axis by +radius) for cylindrical faces and bias
+ * toward holes for holed planar faces.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let Module: any;
+let kernel: any;
+
+beforeAll(async () => {
+    const jsPath = resolve(__dirname, "../dist/occt-wasm.js");
+    const wasmPath = resolve(__dirname, "../dist/occt-wasm.wasm");
+    const createModule = (await import(jsPath)).default;
+    Module = await createModule({
+        locateFile: (path: string) =>
+            path.endsWith(".wasm") ? wasmPath : path,
+    });
+    kernel = new Module.OcctKernel();
+}, 30_000);
+
+afterEach(() => {
+    kernel.releaseAll();
+});
+
+afterAll(() => {
+    kernel.releaseAll();
+    kernel.delete();
+});
+
+function vecToArray(vec: any): number[] {
+    const result: number[] = [];
+    for (let i = 0; i < vec.size(); i++) result.push(vec.get(i));
+    vec.delete();
+    return result;
+}
+
+describe("getSurfaceCenterOfMass", () => {
+    it("returns the geometric center for a planar square face", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const faces = kernel.getSubShapes(box, "face");
+        // Pick the +Z face. Its surface CoM should be (5, 5, 10).
+        let zMaxFaceId = -1;
+        for (let i = 0; i < faces.size(); i++) {
+            const fid = faces.get(i);
+            const bb = kernel.getBoundingBox(fid);
+            if (bb.zmin > 9.9 && bb.zmax < 10.1) {
+                zMaxFaceId = fid;
+                break;
+            }
+        }
+        expect(zMaxFaceId).toBeGreaterThan(0);
+        const com = vecToArray(kernel.getSurfaceCenterOfMass(zMaxFaceId));
+        expect(com[0]).toBeCloseTo(5, 4);
+        expect(com[1]).toBeCloseTo(5, 4);
+        expect(com[2]).toBeCloseTo(10, 4);
+        faces.delete();
+    });
+
+    it("returns the cylinder axis (not the surface) for a complete cylindrical face", () => {
+        // The hole-wall scenario from issue #90's parity test: a closed
+        // cylindrical band's surface CoM lies on the axis by symmetry, not
+        // at +radius on the surface.
+        const cyl = kernel.makeCylinder(5, 20);
+        const faces = kernel.getSubShapes(cyl, "face");
+        let lateralFaceId = -1;
+        for (let i = 0; i < faces.size(); i++) {
+            const fid = faces.get(i);
+            if (kernel.surfaceType(fid) === "cylinder") {
+                lateralFaceId = fid;
+                break;
+            }
+        }
+        expect(lateralFaceId).toBeGreaterThan(0);
+        const com = vecToArray(kernel.getSurfaceCenterOfMass(lateralFaceId));
+        // Cylinder is axis-aligned along +Z, base at origin, radius 5, height 20.
+        // The lateral surface's CoM is at (0, 0, 10).
+        expect(com[0]).toBeCloseTo(0, 4);
+        expect(com[1]).toBeCloseTo(0, 4);
+        expect(com[2]).toBeCloseTo(10, 4);
+        faces.delete();
+    });
+
+    it("differs from getCenterOfMass (which is volume-based) when called on a face", () => {
+        // Sanity check: the two methods are not aliases. For a face,
+        // getCenterOfMass(face) returns volume CoM (often (0,0,0) for a 2D
+        // shape with zero volume), while getSurfaceCenterOfMass returns the
+        // area-weighted point on the face.
+        const box = kernel.makeBox(10, 10, 10);
+        const faces = kernel.getSubShapes(box, "face");
+        const fid = faces.get(0);
+        const surfaceCom = vecToArray(kernel.getSurfaceCenterOfMass(fid));
+        // surfaceCom should be on the face (one coord pinned to 0 or 10,
+        // the other two near 5).
+        const onPlane = surfaceCom.filter((c) => Math.abs(c) < 0.01 || Math.abs(c - 10) < 0.01);
+        expect(onPlane.length).toBeGreaterThanOrEqual(1);
+        faces.delete();
+    });
+});

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -226,14 +226,14 @@ export interface OcctRawKernel {
     chamfer(solidId: number, edgeIds: EmbindVectorU32, distance: number): number;
     chamferDistAngle(solidId: number, edgeIds: EmbindVectorU32, distance: number, angleDeg: number): number;
     shell(solidId: number, faceIds: EmbindVectorU32, thickness: number): number;
-    offset(solidId: number, distance: number): number;
+    offset(solidId: number, distance: number, tolerance: number): number;
     draft(shapeId: number, faceId: number, angle: number, dx: number, dy: number, dz: number): number;
 
     // Sweeps
     pipe(profileId: number, spineId: number): number;
     simplePipe(profileId: number, spineId: number): number;
-    loft(wireIds: EmbindVectorU32, isSolid: boolean): number;
-    loftWithVertices(wireIds: EmbindVectorU32, isSolid: boolean, startVertexId: number, endVertexId: number): number;
+    loft(wireIds: EmbindVectorU32, isSolid: boolean, ruled: boolean): number;
+    loftWithVertices(wireIds: EmbindVectorU32, isSolid: boolean, ruled: boolean, startVertexId: number, endVertexId: number): number;
     sweep(wireId: number, spineId: number, transitionMode: number): number;
     sweepPipeShell(profileId: number, spineId: number, freenet: boolean, smooth: boolean): number;
     draftPrism(shapeId: number, dx: number, dy: number, dz: number, angleDeg: number): number;
@@ -323,6 +323,7 @@ export interface OcctRawKernel {
     getSurfaceArea(id: number): number;
     getLength(id: number): number;
     getCenterOfMass(id: number): EmbindVectorF64;
+    getSurfaceCenterOfMass(faceId: number): EmbindVectorF64;
     getLinearCenterOfMass(id: number): EmbindVectorF64;
     surfaceCurvature(faceId: number, u: number, v: number): EmbindVectorF64;
 
@@ -745,8 +746,15 @@ export class OcctKernel {
         });
     }
 
-    offset(solid: ShapeHandle, distance: number): ShapeHandle {
-        return wrap("offset", () => handle(this.#raw.offset(solid, distance)));
+    /**
+     * Offset all faces of a solid by `distance`.
+     *
+     * @param tolerance - OCCT precision for the offset reconstruction. Use
+     *     `1e-6` for precise offsets (matches brepjs default); `1e-3` is a
+     *     coarser legacy value.
+     */
+    offset(solid: ShapeHandle, distance: number, tolerance: number): ShapeHandle {
+        return wrap("offset", () => handle(this.#raw.offset(solid, distance, tolerance)));
     }
 
     draft(shape: ShapeHandle, face: ShapeHandle, angleRad: number, direction: Vec3): ShapeHandle {
@@ -767,18 +775,25 @@ export class OcctKernel {
         return wrap("simplePipe", () => handle(this.#raw.simplePipe(profile, spine)));
     }
 
-    loft(wires: ShapeHandle[], isSolid: boolean): ShapeHandle {
+    /**
+     * Loft a solid (or shell) through a sequence of wire profiles.
+     *
+     * @param ruled - When `true`, sections are joined by ruled (linear)
+     *     surfaces; when `false`, by smooth B-spline surfaces. The two modes
+     *     produce dramatically different topology for the same input.
+     */
+    loft(wires: ShapeHandle[], isSolid: boolean, ruled: boolean): ShapeHandle {
         return wrap("loft", () => {
             const vec = this.#makeVectorU32(wires);
-            try { return handle(this.#raw.loft(vec, isSolid)); }
+            try { return handle(this.#raw.loft(vec, isSolid, ruled)); }
             finally { vec.delete(); }
         });
     }
 
-    loftWithVertices(wires: ShapeHandle[], isSolid: boolean, startVertex: ShapeHandle, endVertex: ShapeHandle): ShapeHandle {
+    loftWithVertices(wires: ShapeHandle[], isSolid: boolean, ruled: boolean, startVertex: ShapeHandle, endVertex: ShapeHandle): ShapeHandle {
         return wrap("loftWithVertices", () => {
             const vec = this.#makeVectorU32(wires);
-            try { return handle(this.#raw.loftWithVertices(vec, isSolid, startVertex, endVertex)); }
+            try { return handle(this.#raw.loftWithVertices(vec, isSolid, ruled, startVertex, endVertex)); }
             finally { vec.delete(); }
         });
     }
@@ -1438,6 +1453,21 @@ export class OcctKernel {
     getCenterOfMass(shape: ShapeHandle): Vec3 {
         return wrap("getCenterOfMass", () => {
             const v = this.#raw.getCenterOfMass(shape);
+            return this.#vec3FromEmbind(v);
+        });
+    }
+
+    /**
+     * Surface (area-weighted) center of mass for a face. Equivalent to
+     * `BRepGProp::SurfaceProperties(face, props).CentreOfMass()`.
+     *
+     * Use this for face fingerprinting and finder predicates rather than a
+     * tessellation-based centroid — for non-planar faces (cylinders, holed
+     * planes) the two diverge.
+     */
+    getSurfaceCenterOfMass(face: ShapeHandle): Vec3 {
+        return wrap("getSurfaceCenterOfMass", () => {
+            const v = this.#raw.getSurfaceCenterOfMass(face);
             return this.#vec3FromEmbind(v);
         });
     }

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -472,12 +472,16 @@ return store(maker.Shape());",
     MethodSpec {
         name: "offset",
         kind: MethodKind::CustomBody,
-        params: &[FacadeParam::ShapeId("solidId"), FacadeParam::Double("distance")],
+        params: &[
+            FacadeParam::ShapeId("solidId"),
+            FacadeParam::Double("distance"),
+            FacadeParam::Double("tolerance"),
+        ],
         occt_class: "",
         ctor_args: "",
         setup_code: "\
 BRepOffsetAPI_MakeOffsetShape maker;
-maker.PerformByJoin(get(solidId), distance, 1e-3);
+maker.PerformByJoin(get(solidId), distance, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"offset: operation failed\");
@@ -2001,6 +2005,22 @@ return {com.X(), com.Y(), com.Z()};",
         return_type: ReturnType::VectorDouble,
     },
     MethodSpec {
+        name: "getSurfaceCenterOfMass",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("faceId")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+const auto& face = get(faceId);
+GProp_GProps props;
+BRepGProp::SurfaceProperties(face, props);
+gp_Pnt com = props.CentreOfMass();
+return {com.X(), com.Y(), com.Z()};",
+        includes: &["BRepGProp.hxx", "GProp_GProps.hxx", "gp_Pnt.hxx"],
+        category: "query",
+        return_type: ReturnType::VectorDouble,
+    },
+    MethodSpec {
         name: "vertexPosition",
         kind: MethodKind::CustomBody,
         params: &[FacadeParam::ShapeId("vertexId")],
@@ -2710,11 +2730,12 @@ return store(maker.Shape());",
         params: &[
             FacadeParam::VectorShapeIds("wireIds"),
             FacadeParam::Bool("isSolid"),
+            FacadeParam::Bool("ruled"),
         ],
         occt_class: "",
         ctor_args: "",
         setup_code: "\
-BRepOffsetAPI_ThruSections maker(isSolid);
+BRepOffsetAPI_ThruSections maker(isSolid, ruled);
 for (uint32_t wid : wireIds) {
     maker.AddWire(TopoDS::Wire(get(wid)));
 }
@@ -2733,13 +2754,14 @@ return store(maker.Shape());",
         params: &[
             FacadeParam::VectorShapeIds("wireIds"),
             FacadeParam::Bool("isSolid"),
+            FacadeParam::Bool("ruled"),
             FacadeParam::ShapeId("startVertexId"),
             FacadeParam::ShapeId("endVertexId"),
         ],
         occt_class: "",
         ctor_args: "",
         setup_code: "\
-BRepOffsetAPI_ThruSections maker(isSolid);
+BRepOffsetAPI_ThruSections maker(isSolid, ruled);
 if (startVertexId != 0) {
     maker.AddVertex(TopoDS::Vertex(get(startVertexId)));
 }
@@ -4461,7 +4483,7 @@ mod tests {
             .iter()
             .filter(|m| m.kind != MethodKind::Skip)
             .count();
-        assert_eq!(count, 172, "expected 172 generable methods");
+        assert_eq!(count, 173, "expected 173 generable methods");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three facade-level fixes for the brepjs-vs-occt-wasm parity gap reported in #90:

1. **`loft(wires, isSolid, ruled)`** — adds the missing `ruled` flag to `BRepOffsetAPI_ThruSections`. brepjs's adapter accepts `_ruled?` but our facade had no parameter, so `ruled=true` was silently downgraded to smooth/B-spline interpolation. Different topology, different volume.
2. **`offset(solid, distance, tolerance)`** — exposes the `tolerance` argument to `BRepOffsetAPI_MakeOffsetShape::PerformByJoin`. Was hardcoded to `1e-3`; brepjs uses `1e-6` (1000× finer).
3. **`getSurfaceCenterOfMass(faceId)`** *(new)* — calls `BRepGProp::SurfaceProperties(face).CentreOfMass()`. Resolves the **confirmed** root cause of #90: brepjs's adapter was falling back to a tessellation-triangle centroid which lands on the surface (off-axis by +radius) for cylindrical faces and biases toward holes for holed planar faces.

See [issue #90 comment thread](https://github.com/andymai/occt-wasm/issues/90) for the bisection that pinned (3) and the silent-param-drop analysis for (1) and (2).

## Implementation

- Edit `xtask/src/codegen/config.rs` (declarative method specs)
- `cargo xtask codegen` regenerates `kernel.cpp`, `bindings.cpp`, `wasi_exports.cpp`, `kernel_generated.rs`
- Hand-edit `facade/include/occt_kernel.h` and `ts/src/index.ts` wrapper
- Update three existing tests (offset/loft callers) to pass new required args
- New `test/surface-center-of-mass.test.ts` regression test (3 cases: planar, cylinder lateral, sanity vs `getCenterOfMass`)
- Dockerfile: add `cd ts && npm run build` step before vitest, and copy `ts/scripts/` *after* the WASM build so the link-step cache isn't invalidated by edits to `copy-wasm.sh`

## Breaking change

⚠️ Callers of `kernel.loft(wires, isSolid)`, `kernel.offset(solid, distance)`, or the equivalent raw-Embind methods must add the new positional argument. There's no silent default to preserve old behavior because the old defaults were the silent-correctness bugs being fixed here.

Migration:
```ts
// before
kernel.loft(wires, true);
kernel.offset(solid, 1.0);
// after
kernel.loft(wires, true, /*ruled=*/false);     // pass true if you want linear interpolation
kernel.offset(solid, 1.0, /*tolerance=*/1e-6); // 1e-3 was the old hardcoded value
```

The brepjs `OcctWasmAdapter` will need a one-line follow-up to stop dropping `_ruled` and `_tolerance` (separate PR in brepjs repo).

## Test plan
- [x] `cargo xtask codegen` — 173 generable methods (was 172, +1 for new method)
- [x] `cargo test -p xtask` — 26 passed (count assertion updated)
- [x] `cargo build --workspace` — clean
- [x] `npm run docker:dist` — full WASM rebuild + 268 vitest tests pass
- [x] `cd ts && npm run build && npx vitest run` — 267 passed | 1 skipped
- [ ] Verify against gridfinity-layout-tool's `occtWasmIterationOrder.test.ts` after the brepjs adapter is updated to use `getSurfaceCenterOfMass` (out of scope for this PR)

Closes #90.