### PR TITLE
ci: bump Node to 24 for OIDC publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,16 +29,14 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
+      # Node 24 ships with npm 11.x, which supports OIDC trusted publishing
+      # (added in npm 11.5.1). Avoids the in-place npm self-upgrade bug
+      # (`MODULE_NOT_FOUND: promise-retry`) that bites Node 22's npm 10.x.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
-
-      # npm trusted publishing (OIDC) requires npm CLI >= 11.5.1.
-      # Node 22 ships with npm 10.x, so upgrade in-place.
-      - name: Upgrade npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: cd ts && npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,14 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
+      # Node 24 ships with npm 11.x, which supports OIDC trusted publishing
+      # (added in npm 11.5.1). Avoids the in-place npm self-upgrade bug
+      # (`MODULE_NOT_FOUND: promise-retry`) that bites Node 22's npm 10.x.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
-
-      # npm trusted publishing (OIDC) requires npm CLI >= 11.5.1.
-      # Node 22 ships with npm 10.x, so upgrade in-place.
-      - name: Upgrade npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: cd ts && npm ci


### PR DESCRIPTION
## Summary

The in-place \`npm install -g npm@latest\` step from #95 hit a known npm bug on Node 22:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

The bug surfaces during npm 10.x's self-upgrade on Node 22 — the new npm CLI's transitive deps aren't fully populated before the rebuild phase needs them.

## Fix

Bump runner Node from 22 → 24, which ships with **npm 11.x natively**. No self-upgrade needed. Same change applied to both \`release.yml\` and \`publish.yml\`.

## Verifying after merge

\`\`\`bash
gh workflow run publish.yml -f tag=v2.0.0 --repo andymai/occt-wasm
\`\`\`

This will retry the v2.0.0 publish with Node 24 + bundled npm 11.x + OIDC. Once 2.0.0 lands on npm:

\`\`\`bash
gh run rerun 25367478355 --repo andymai/brepjs --failed
\`\`\`

…to unblock the brepjs 16.0.0 publish that's currently failing on \`npm ci\`.

## Test plan
- [x] YAML syntax (gh CLI parses both files)
- [ ] After merge: \`gh workflow run publish.yml -f tag=v2.0.0\` succeeds
- [ ] \`npm view occt-wasm version\` returns 2.0.0
- [ ] brepjs 16.0.0 publish unblocks