### PR TITLE
ci: add workflow_dispatch path to release.yml for manual republish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. v2.0.0). Bypasses release-please."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,6 +18,8 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    # Skip on workflow_dispatch -- the human knows what tag to publish.
+    if: github.event_name == 'push'
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -23,8 +31,13 @@ jobs:
           config-file: release-please-config.json
 
   build:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    needs: [release-please]
+    # Run on a real release-please release OR a manual dispatch. `always()`
+    # lets this evaluate even when release-please is skipped.
+    if: |
+      always() && !cancelled() &&
+      (needs.release-please.outputs.release_created == 'true' ||
+       github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/build-wasm.yml
     with:
       release: true
@@ -33,7 +46,11 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: [release-please, build]
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: |
+      always() && !cancelled() &&
+      needs.build.result == 'success' &&
+      (needs.release-please.outputs.release_created == 'true' ||
+       github.event_name == 'workflow_dispatch')
     environment: npm
     permissions:
       contents: read
@@ -41,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
 
       # Node 24 ships with npm 11.x, which supports OIDC trusted publishing
       # (added in npm 11.5.1). Avoids the in-place npm self-upgrade bug


### PR DESCRIPTION
## Summary

The npm trusted publisher is configured for \`release.yml\` + environment \`npm\`. Manual dispatches against \`publish.yml\` don't match those OIDC claims and fail with \`404 PUT - could not be found or you do not have permission\`.

Fix: add \`workflow_dispatch\` to \`release.yml\` itself, with a \`tag\` input. The publish step then runs from a workflow whose identity matches the trusted-publisher config.

## How it works

When dispatched manually:
- \`release-please\` is skipped (\`if: github.event_name == 'push'\`)
- \`build\` runs against the supplied tag (\`if: always() && (release_created || workflow_dispatch)\`)
- \`publish\` runs with \`ref: inputs.tag\` and matches OIDC claims (workflow=release.yml, environment=npm)

The \`always() && !cancelled()\` pattern lets downstream jobs evaluate even when release-please is skipped on workflow_dispatch.

## Catch-up publish for v2.0.0

After merge:
\`\`\`bash
gh workflow run release.yml -f tag=v2.0.0 --repo andymai/occt-wasm
\`\`\`

## Test plan
- [x] YAML syntax (gh CLI parses)
- [ ] After merge: manual dispatch with tag=v2.0.0 succeeds
- [ ] \`npm view occt-wasm version\` returns 2.0.0