### PR TITLE
feat(facade)!: close issue #90 parity gap — tolerance, AddOptimal bounds, shell sign

### DIFF
--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -47,11 +47,11 @@ pub(crate) struct GeneratedFuncs {
     fn_fillet: TypedFunc<(u32, i32, i32, f64), u32>,
     fn_chamfer: TypedFunc<(u32, i32, i32, f64), u32>,
     fn_chamfer_dist_angle: TypedFunc<(u32, i32, i32, f64, f64), u32>,
-    fn_shell: TypedFunc<(u32, i32, i32, f64), u32>,
+    fn_shell: TypedFunc<(u32, i32, i32, f64, f64), u32>,
     fn_offset: TypedFunc<(u32, f64, f64), u32>,
     fn_draft: TypedFunc<(u32, u32, f64, f64, f64, f64), u32>,
-    fn_thicken: TypedFunc<(u32, f64), u32>,
-    fn_defeature: TypedFunc<(u32, i32, i32), u32>,
+    fn_thicken: TypedFunc<(u32, f64, f64), u32>,
+    fn_defeature: TypedFunc<(u32, i32, i32, f64), u32>,
     fn_reverse_shape: TypedFunc<(u32,), u32>,
     fn_simplify: TypedFunc<(u32,), u32>,
     fn_fillet_variable: TypedFunc<(u32, u32, f64, f64), u32>,
@@ -110,7 +110,7 @@ pub(crate) struct GeneratedFuncs {
     fn_downcast: TypedFunc<(u32, i32, i32), u32>,
     fn_adjacent_faces: TypedFunc<(u32, u32), i32>,
     fn_shared_edges: TypedFunc<(u32, u32), i32>,
-    fn_get_bounding_box: TypedFunc<(u32,), i32>,
+    fn_get_bounding_box: TypedFunc<(u32, i32), i32>,
     fn_get_volume: TypedFunc<(u32,), f64>,
     fn_get_surface_area: TypedFunc<(u32,), f64>,
     fn_get_length: TypedFunc<(u32,), f64>,
@@ -175,9 +175,9 @@ pub(crate) struct GeneratedFuncs {
     fn_scale_with_history: TypedFunc<(u32, f64, f64, f64, f64, i32, i32, i32), i32>,
     fn_intersect_with_history: TypedFunc<(u32, u32, i32, i32, i32), i32>,
     fn_chamfer_with_history: TypedFunc<(u32, i32, i32, f64, i32, i32, i32), i32>,
-    fn_shell_with_history: TypedFunc<(u32, i32, i32, f64, i32, i32, i32), i32>,
-    fn_offset_with_history: TypedFunc<(u32, f64, i32, i32, i32), i32>,
-    fn_thicken_with_history: TypedFunc<(u32, f64, i32, i32, i32), i32>,
+    fn_shell_with_history: TypedFunc<(u32, i32, i32, f64, f64, i32, i32, i32), i32>,
+    fn_offset_with_history: TypedFunc<(u32, f64, f64, i32, i32, i32), i32>,
+    fn_thicken_with_history: TypedFunc<(u32, f64, f64, i32, i32, i32), i32>,
     fn_tessellate: TypedFunc<(u32, f64, f64), i32>,
     fn_mesh_shape: TypedFunc<(u32, f64, f64), i32>,
     fn_mesh_batch: TypedFunc<(i32, i32, f64, f64), i32>,
@@ -799,6 +799,7 @@ impl crate::kernel::OcctKernel {
         solid_id: ShapeHandle,
         face_ids: &[ShapeHandle],
         thickness: f64,
+        tolerance: f64,
     ) -> OcctResult<ShapeHandle> {
         let face_ids_bytes: Vec<u8> = face_ids.iter().flat_map(|h| h.0.to_le_bytes()).collect();
         let face_ids_ptr = self.write_bytes(&face_ids_bytes)?;
@@ -810,6 +811,7 @@ impl crate::kernel::OcctKernel {
                 face_ids_ptr as i32,
                 face_ids_len as i32,
                 thickness,
+                tolerance,
             ),
         );
         self.free_bytes(face_ids_ptr)?;
@@ -858,11 +860,16 @@ impl crate::kernel::OcctKernel {
         Ok(ShapeHandle(result))
     }
 
-    pub fn thicken(&mut self, shape_id: ShapeHandle, thickness: f64) -> OcctResult<ShapeHandle> {
+    pub fn thicken(
+        &mut self,
+        shape_id: ShapeHandle,
+        thickness: f64,
+        tolerance: f64,
+    ) -> OcctResult<ShapeHandle> {
         let result = self
             .generated
             .fn_thicken
-            .call(&mut self.store, (shape_id.0, thickness))?;
+            .call(&mut self.store, (shape_id.0, thickness, tolerance))?;
         self.check_error("thicken")?;
         if result == 0 {
             return Err(self.read_last_error("thicken"));
@@ -874,13 +881,19 @@ impl crate::kernel::OcctKernel {
         &mut self,
         shape_id: ShapeHandle,
         face_ids: &[ShapeHandle],
+        tolerance: f64,
     ) -> OcctResult<ShapeHandle> {
         let face_ids_bytes: Vec<u8> = face_ids.iter().flat_map(|h| h.0.to_le_bytes()).collect();
         let face_ids_ptr = self.write_bytes(&face_ids_bytes)?;
         let face_ids_len = face_ids.len() as u32;
         let result = self.generated.fn_defeature.call(
             &mut self.store,
-            (shape_id.0, face_ids_ptr as i32, face_ids_len as i32),
+            (
+                shape_id.0,
+                face_ids_ptr as i32,
+                face_ids_len as i32,
+                tolerance,
+            ),
         );
         self.free_bytes(face_ids_ptr)?;
         let result = result?;
@@ -2013,11 +2026,15 @@ impl crate::kernel::OcctKernel {
         self.read_vec_u32_result()
     }
 
-    pub fn get_bounding_box(&mut self, id: ShapeHandle) -> OcctResult<BoundingBox> {
+    pub fn get_bounding_box(
+        &mut self,
+        id: ShapeHandle,
+        use_triangulation: bool,
+    ) -> OcctResult<BoundingBox> {
         let status = self
             .generated
             .fn_get_bounding_box
-            .call(&mut self.store, (id.0,))?;
+            .call(&mut self.store, (id.0, i32::from(use_triangulation)))?;
         if status < 0 {
             return Err(self.read_last_error("get_bounding_box"));
         }
@@ -3147,6 +3164,7 @@ impl crate::kernel::OcctKernel {
         solid_id: ShapeHandle,
         face_ids: &[ShapeHandle],
         thickness: f64,
+        tolerance: f64,
         input_face_hashes: &[i32],
         hash_upper_bound: i32,
     ) -> OcctResult<EvolutionData> {
@@ -3172,6 +3190,7 @@ impl crate::kernel::OcctKernel {
                 face_ids_ptr as i32,
                 face_ids_len as i32,
                 thickness,
+                tolerance,
                 input_face_hashes_ptr as i32,
                 input_face_hashes_len as i32,
                 hash_upper_bound,
@@ -3190,6 +3209,7 @@ impl crate::kernel::OcctKernel {
         &mut self,
         solid_id: ShapeHandle,
         distance: f64,
+        tolerance: f64,
         input_face_hashes: &[i32],
         hash_upper_bound: i32,
     ) -> OcctResult<EvolutionData> {
@@ -3204,6 +3224,7 @@ impl crate::kernel::OcctKernel {
             (
                 solid_id.0,
                 distance,
+                tolerance,
                 input_face_hashes_ptr as i32,
                 input_face_hashes_len as i32,
                 hash_upper_bound,
@@ -3221,6 +3242,7 @@ impl crate::kernel::OcctKernel {
         &mut self,
         shape_id: ShapeHandle,
         thickness: f64,
+        tolerance: f64,
         input_face_hashes: &[i32],
         hash_upper_bound: i32,
     ) -> OcctResult<EvolutionData> {
@@ -3235,6 +3257,7 @@ impl crate::kernel::OcctKernel {
             (
                 shape_id.0,
                 thickness,
+                tolerance,
                 input_face_hashes_ptr as i32,
                 input_face_hashes_len as i32,
                 hash_upper_bound,

--- a/crate/tests/integration.rs
+++ b/crate/tests/integration.rs
@@ -96,7 +96,7 @@ fn bounding_box() {
         return;
     };
     let shape = kernel.make_box(10.0, 20.0, 30.0).unwrap();
-    let bbox = kernel.get_bounding_box(shape).unwrap();
+    let bbox = kernel.get_bounding_box(shape, true).unwrap();
     assert!((bbox.min.x).abs() < 0.01);
     assert!((bbox.min.y).abs() < 0.01);
     assert!((bbox.min.z).abs() < 0.01);

--- a/examples/node-cli/example.mjs
+++ b/examples/node-cli/example.mjs
@@ -57,7 +57,7 @@ try {
     // --- Measurements ---
     const vol = kernel.getVolume(final);
     const area = kernel.getSurfaceArea(final);
-    const bbox = kernel.getBoundingBox(final);
+    const bbox = kernel.getBoundingBox(final, true);
 
     console.log(`\nResult:`);
     console.log(`  Volume:       ${vol.toFixed(2)} mm^3`);

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -600,7 +600,7 @@ uint32_t OcctKernel::shell(uint32_t solidId, std::vector<uint32_t> faceIds, doub
             facesToRemove.Append(get(fid));
         }
         BRepOffsetAPI_MakeThickSolid maker;
-        maker.MakeThickSolidByJoin(get(solidId), facesToRemove, thickness, tolerance);
+        maker.MakeThickSolidByJoin(get(solidId), facesToRemove, -thickness, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("shell: operation failed");
@@ -2840,7 +2840,7 @@ EvolutionData OcctKernel::shellWithHistory(uint32_t solidId, std::vector<uint32_
             facesToRemove.Append(get(fid));
         }
         BRepOffsetAPI_MakeThickSolid maker;
-        maker.MakeThickSolidByJoin(solid, facesToRemove, thickness, tolerance);
+        maker.MakeThickSolidByJoin(solid, facesToRemove, -thickness, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("shellWithHistory: operation failed");

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -593,14 +593,14 @@ uint32_t OcctKernel::chamferDistAngle(uint32_t solidId, std::vector<uint32_t> ed
     }
 }
 
-uint32_t OcctKernel::shell(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness) {
+uint32_t OcctKernel::shell(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness, double tolerance) {
     try {
         NCollection_List<TopoDS_Shape> facesToRemove;
         for (uint32_t fid : faceIds) {
             facesToRemove.Append(get(fid));
         }
         BRepOffsetAPI_MakeThickSolid maker;
-        maker.MakeThickSolidByJoin(get(solidId), facesToRemove, thickness, 1e-3);
+        maker.MakeThickSolidByJoin(get(solidId), facesToRemove, thickness, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("shell: operation failed");
@@ -640,12 +640,12 @@ uint32_t OcctKernel::draft(uint32_t shapeId, uint32_t faceId, double angleRad, d
     }
 }
 
-uint32_t OcctKernel::thicken(uint32_t shapeId, double thickness) {
+uint32_t OcctKernel::thicken(uint32_t shapeId, double thickness, double tolerance) {
     try {
         const auto& shape = get(shapeId);
         if (shape.ShapeType() == TopAbs_FACE || shape.ShapeType() == TopAbs_SHELL) {
             BRepOffset_MakeOffset offsetMaker;
-            offsetMaker.Initialize(shape, thickness, 1e-3, BRepOffset_Skin, false, false, GeomAbs_Arc, true);
+            offsetMaker.Initialize(shape, thickness, tolerance, BRepOffset_Skin, false, false, GeomAbs_Arc, true);
             offsetMaker.MakeOffsetShape();
             if (!offsetMaker.IsDone()) {
                 throw std::runtime_error("thicken: offset operation failed");
@@ -654,7 +654,7 @@ uint32_t OcctKernel::thicken(uint32_t shapeId, double thickness) {
         }
         NCollection_List<TopoDS_Shape> emptyList;
         BRepOffsetAPI_MakeThickSolid maker;
-        maker.MakeThickSolidByJoin(shape, emptyList, thickness, 1e-3);
+        maker.MakeThickSolidByJoin(shape, emptyList, thickness, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("thicken: operation failed");
@@ -665,14 +665,14 @@ uint32_t OcctKernel::thicken(uint32_t shapeId, double thickness) {
     }
 }
 
-uint32_t OcctKernel::defeature(uint32_t shapeId, std::vector<uint32_t> faceIds) {
+uint32_t OcctKernel::defeature(uint32_t shapeId, std::vector<uint32_t> faceIds, double tolerance) {
     try {
         NCollection_List<TopoDS_Shape> facesToRemove;
         for (uint32_t fid : faceIds) {
             facesToRemove.Append(get(fid));
         }
         BRepOffsetAPI_MakeThickSolid maker;
-        maker.MakeThickSolidByJoin(get(shapeId), facesToRemove, 0.0, 1e-3);
+        maker.MakeThickSolidByJoin(get(shapeId), facesToRemove, 0.0, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("defeature: operation failed");
@@ -1737,11 +1737,11 @@ std::vector<uint32_t> OcctKernel::sharedEdges(uint32_t faceA, uint32_t faceB) {
 
 // === query ===
 
-BBoxData OcctKernel::getBoundingBox(uint32_t id) {
+BBoxData OcctKernel::getBoundingBox(uint32_t id, bool useTriangulation) {
     try {
         const auto& shape = get(id);
         Bnd_Box box;
-        BRepBndLib::Add(shape, box);
+        BRepBndLib::AddOptimal(shape, box, useTriangulation, false);
         if (box.IsVoid()) {
             throw std::runtime_error("getBoundingBox: shape has no geometry");
         }
@@ -2832,7 +2832,7 @@ EvolutionData OcctKernel::chamferWithHistory(uint32_t solidId, std::vector<uint3
     }
 }
 
-EvolutionData OcctKernel::shellWithHistory(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness, std::vector<int> inputFaceHashes, int hashUpperBound) {
+EvolutionData OcctKernel::shellWithHistory(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness, double tolerance, std::vector<int> inputFaceHashes, int hashUpperBound) {
     try {
         const auto& solid = get(solidId);
         NCollection_List<TopoDS_Shape> facesToRemove;
@@ -2840,7 +2840,7 @@ EvolutionData OcctKernel::shellWithHistory(uint32_t solidId, std::vector<uint32_
             facesToRemove.Append(get(fid));
         }
         BRepOffsetAPI_MakeThickSolid maker;
-        maker.MakeThickSolidByJoin(solid, facesToRemove, thickness, 1e-3);
+        maker.MakeThickSolidByJoin(solid, facesToRemove, thickness, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("shellWithHistory: operation failed");
@@ -2852,11 +2852,11 @@ EvolutionData OcctKernel::shellWithHistory(uint32_t solidId, std::vector<uint32_
     }
 }
 
-EvolutionData OcctKernel::offsetWithHistory(uint32_t solidId, double distance, std::vector<int> inputFaceHashes, int hashUpperBound) {
+EvolutionData OcctKernel::offsetWithHistory(uint32_t solidId, double distance, double tolerance, std::vector<int> inputFaceHashes, int hashUpperBound) {
     try {
         const auto& solid = get(solidId);
         BRepOffsetAPI_MakeOffsetShape maker;
-        maker.PerformByJoin(solid, distance, 1e-3);
+        maker.PerformByJoin(solid, distance, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("offsetWithHistory: operation failed");
@@ -2868,7 +2868,7 @@ EvolutionData OcctKernel::offsetWithHistory(uint32_t solidId, double distance, s
     }
 }
 
-EvolutionData OcctKernel::thickenWithHistory(uint32_t shapeId, double thickness, std::vector<int> inputFaceHashes, int hashUpperBound) {
+EvolutionData OcctKernel::thickenWithHistory(uint32_t shapeId, double thickness, double tolerance, std::vector<int> inputFaceHashes, int hashUpperBound) {
     try {
         const auto& shape = get(shapeId);
         
@@ -2876,7 +2876,7 @@ EvolutionData OcctKernel::thickenWithHistory(uint32_t shapeId, double thickness,
         // hollowing)
         if (shape.ShapeType() == TopAbs_FACE || shape.ShapeType() == TopAbs_SHELL) {
             BRepOffset_MakeOffset offsetMaker;
-            offsetMaker.Initialize(shape, thickness, 1e-3, BRepOffset_Skin, false, false,
+            offsetMaker.Initialize(shape, thickness, tolerance, BRepOffset_Skin, false, false,
                                    GeomAbs_Arc, true);
             offsetMaker.MakeOffsetShape();
             if (!offsetMaker.IsDone()) {
@@ -2891,7 +2891,7 @@ EvolutionData OcctKernel::thickenWithHistory(uint32_t shapeId, double thickness,
         
         NCollection_List<TopoDS_Shape> emptyList;
         BRepOffsetAPI_MakeThickSolid maker;
-        maker.MakeThickSolidByJoin(shape, emptyList, thickness, 1e-3);
+        maker.MakeThickSolidByJoin(shape, emptyList, thickness, tolerance);
         maker.Build();
         if (!maker.IsDone()) {
             throw std::runtime_error("thickenWithHistory: operation failed");

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -156,7 +156,8 @@ class OcctKernel {
     uint32_t chamfer(uint32_t solidId, std::vector<uint32_t> edgeIds, double distance);
     uint32_t chamferDistAngle(uint32_t solidId, std::vector<uint32_t> edgeIds, double distance,
                               double angleDeg);
-    uint32_t shell(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness);
+    uint32_t shell(uint32_t solidId, std::vector<uint32_t> faceIds, double thickness,
+                   double tolerance);
     uint32_t offset(uint32_t solidId, double distance, double tolerance);
     uint32_t draft(uint32_t shapeId, uint32_t faceId, double angleRad, double dx, double dy,
                    double dz);
@@ -265,7 +266,7 @@ class OcctKernel {
     uint32_t fromBREP(const std::string& data);
 
     // --- Query / Measure ---
-    BBoxData getBoundingBox(uint32_t id);
+    BBoxData getBoundingBox(uint32_t id, bool useTriangulation);
     double getVolume(uint32_t id);
     double getSurfaceArea(uint32_t id);
     double getLength(uint32_t id);
@@ -298,8 +299,8 @@ class OcctKernel {
     uint32_t approximatePoints(std::vector<double> flatPoints, double tolerance);
 
     // --- Modifier (expanded) ---
-    uint32_t thicken(uint32_t shapeId, double thickness);
-    uint32_t defeature(uint32_t shapeId, std::vector<uint32_t> faceIds);
+    uint32_t thicken(uint32_t shapeId, double thickness, double tolerance);
+    uint32_t defeature(uint32_t shapeId, std::vector<uint32_t> faceIds, double tolerance);
     uint32_t reverseShape(uint32_t id);
     uint32_t simplify(uint32_t id);
     uint32_t filletVariable(uint32_t solidId, uint32_t edgeId, double startRadius,
@@ -329,11 +330,11 @@ class OcctKernel {
                                      double distance, std::vector<int> inputFaceHashes,
                                      int hashUpperBound);
     EvolutionData shellWithHistory(uint32_t solidId, std::vector<uint32_t> faceIds,
-                                   double thickness, std::vector<int> inputFaceHashes,
-                                   int hashUpperBound);
-    EvolutionData offsetWithHistory(uint32_t solidId, double distance,
+                                   double thickness, double tolerance,
+                                   std::vector<int> inputFaceHashes, int hashUpperBound);
+    EvolutionData offsetWithHistory(uint32_t solidId, double distance, double tolerance,
                                     std::vector<int> inputFaceHashes, int hashUpperBound);
-    EvolutionData thickenWithHistory(uint32_t shapeId, double thickness,
+    EvolutionData thickenWithHistory(uint32_t shapeId, double thickness, double tolerance,
                                      std::vector<int> inputFaceHashes, int hashUpperBound);
 
     // --- Projection (HLR) ---

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -97,7 +97,7 @@ describe("primitives (extended)", () => {
         expect(kernel.getShapeType(id)).toBe("solid");
         // 10 x 10 x 10 = 1000
         expect(kernel.getVolume(id)).toBeCloseTo(1000, 0);
-        const bbox = kernel.getBoundingBox(id);
+        const bbox = kernel.getBoundingBox(id, true);
         expect(bbox.xmin).toBeCloseTo(1, 5);
         expect(bbox.ymin).toBeCloseTo(2, 5);
         expect(bbox.zmin).toBeCloseTo(3, 5);
@@ -214,7 +214,7 @@ describe("modeling (extended)", () => {
         // Pick just the first face to remove (open face for the shell)
         const faceVec = new Module.VectorUint32();
         faceVec.push_back(faces.get(0));
-        const result = kernel.shell(box, faceVec, 2.0);
+        const result = kernel.shell(box, faceVec, 2.0, 1e-6);
         expect(result).toBeGreaterThan(0);
         // A hollow shell has less volume than the original solid
         expect(kernel.getVolume(result)).toBeLessThan(kernel.getVolume(box));
@@ -488,7 +488,7 @@ describe("transforms (extended)", () => {
         for (const v of values) mat.push_back(v);
         const result = kernel.transform(box, mat);
         expect(result).toBeGreaterThan(0);
-        const bbox = kernel.getBoundingBox(result);
+        const bbox = kernel.getBoundingBox(result, true);
         expect(bbox.xmin).toBeCloseTo(50, 1);
         mat.delete();
     });
@@ -1023,7 +1023,7 @@ describe("projection (HLR)", () => {
 describe("modifiers", () => {
     it("thicken gives a surface shell thickness (face → solid)", () => {
         const face = makeSquareFace(10);
-        const result = kernel.thicken(face, 2.0);
+        const result = kernel.thicken(face, 2.0, 1e-6);
         expect(result).toBeGreaterThan(0);
         expect(kernel.getVolume(result)).toBeGreaterThan(0);
     });
@@ -1039,7 +1039,7 @@ describe("modifiers", () => {
         // Just try to defeature one face
         faceVec.push_back(allFaces.get(0));
         try {
-            const result = kernel.defeature(withBoss, faceVec);
+            const result = kernel.defeature(withBoss, faceVec, 1e-6);
             expect(result).toBeGreaterThanOrEqual(0);
         } catch {
             // defeature is fragile on OCCT V8 RC4 — just verify no WASM abort
@@ -1166,8 +1166,8 @@ describe("batch operations", () => {
         expect(results.size()).toBe(2);
         const id0 = results.get(0);
         const id1 = results.get(1);
-        const bbox0 = kernel.getBoundingBox(id0);
-        const bbox1 = kernel.getBoundingBox(id1);
+        const bbox0 = kernel.getBoundingBox(id0, true);
+        const bbox1 = kernel.getBoundingBox(id1, true);
         expect(bbox0.xmin).toBeCloseTo(10, 1);
         expect(bbox1.ymin).toBeCloseTo(20, 1);
         results.delete();

--- a/test/batch-apis.test.ts
+++ b/test/batch-apis.test.ts
@@ -244,7 +244,7 @@ describe("mirrorBatch", () => {
         const mirrored = result.get(0);
 
         // Check the bounding box is on the negative X side
-        const bbox = kernel.getBoundingBox(mirrored);
+        const bbox = kernel.getBoundingBox(mirrored, true);
         expect(bbox.xmax).toBeLessThanOrEqual(0);
         expect(bbox.xmin).toBeCloseTo(-6, 0);
 

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -121,7 +121,7 @@ describe("invalid IDs", () => {
 
     it("getBoundingBox(99999) — bounding box of non-existent shape throws", () => {
         expectThrows(
-            () => kernel.getBoundingBox(BOGUS),
+            () => kernel.getBoundingBox(BOGUS, true),
             "getBoundingBox(bogus id)",
         );
     });
@@ -286,7 +286,7 @@ describe("degenerate geometry", () => {
         faceVec.push_back(faces.get(0)); // open one face
         let result: number | undefined;
         try {
-            result = kernel.shell(box, faceVec, 50); // thickness >> solid size
+            result = kernel.shell(box, faceVec, 50, 1e-6); // thickness >> solid size
         } catch {
             faceVec.delete();
             faces.delete();
@@ -525,7 +525,7 @@ describe("type mismatches", () => {
         const faceVec = new Module.VectorUint32();
         try {
             expectThrows(
-                () => kernel.shell(edge, faceVec, 1.0),
+                () => kernel.shell(edge, faceVec, 1.0, 1e-6),
                 "shell on edge",
             );
         } finally {

--- a/test/expanded.test.ts
+++ b/test/expanded.test.ts
@@ -136,7 +136,7 @@ describe("transforms", () => {
         const box = kernel.makeBox(10, 10, 10);
         const moved = kernel.translate(box, 100, 200, 300);
         expect(moved).toBeGreaterThan(0);
-        const bbox = kernel.getBoundingBox(moved);
+        const bbox = kernel.getBoundingBox(moved, true);
         expect(bbox.xmin).toBeCloseTo(100, 1);
         expect(bbox.ymin).toBeCloseTo(200, 1);
         expect(bbox.zmin).toBeCloseTo(300, 1);
@@ -162,7 +162,7 @@ describe("transforms", () => {
         const box = kernel.makeBox(10, 10, 10);
         const mirrored = kernel.mirror(box, 0, 0, 0, 1, 0, 0);
         expect(mirrored).toBeGreaterThan(0);
-        const bbox = kernel.getBoundingBox(mirrored);
+        const bbox = kernel.getBoundingBox(mirrored, true);
         expect(bbox.xmax).toBeCloseTo(0, 1);
         expect(bbox.xmin).toBeCloseTo(-10, 1);
     });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -154,7 +154,7 @@ describe("OcctKernel", () => {
     describe("query", () => {
         it("computes bounding box of a box", () => {
             const box = kernel.makeBox(10, 20, 30);
-            const bbox = kernel.getBoundingBox(box);
+            const bbox = kernel.getBoundingBox(box, true);
 
             expect(bbox.xmin).toBeCloseTo(0, 5);
             expect(bbox.ymin).toBeCloseTo(0, 5);

--- a/test/parity-shell-sign.test.ts
+++ b/test/parity-shell-sign.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression test for the second class of parity bug fixed in 3.0.0:
+ * `shell` and `shellWithHistory` passed the offset thickness to OCCT's
+ * `MakeThickSolidByJoin` with the *positive* sign, which thickens the
+ * solid *outward* (bounds grow by `thickness` on every direction with a
+ * removed face) instead of hollowing inward.
+ *
+ * brepjs-occt's reference implementation has always passed `-thickness`
+ * (matching the OCCT tutorial's `MakeThickSolidByJoin(body, faces,
+ * -thickness/50, ...)`), so the two paths produced different geometry for
+ * identical inputs. For Gridfinity's "1×1 flat no-lip" bin (the simplest
+ * shell-only case) the divergence was +10.4% volume and a uniform ~1.2 mm
+ * xMin shift versus the reference — see issue #90 in this repo.
+ *
+ * 3.0 negates internally (in the facade C++) so positive `thickness` from
+ * the caller hollows inward. This test pins the convention down with two
+ * checks:
+ *   1. Outer bounds of the shelled solid match the input solid's bounds
+ *      (no growth in any direction with a removed face).
+ *   2. Volume is in the inward-hollow range, NOT the outward-thicken
+ *      range — the upper bound is set deliberately below the buggy
+ *      result so a regression to `+thickness` would fail loudly.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let Module: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let kernel: any;
+
+beforeAll(async () => {
+  const jsPath = resolve(__dirname, "../dist/occt-wasm.js");
+  const wasmPath = resolve(__dirname, "../dist/occt-wasm.wasm");
+  const createModule = (await import(jsPath)).default;
+  Module = await createModule({
+    locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
+  });
+  kernel = new Module.OcctKernel();
+}, 30_000);
+
+afterEach(() => {
+  kernel.releaseAll();
+});
+
+afterAll(() => {
+  kernel.releaseAll();
+  kernel.delete();
+});
+
+describe("shell hollows inward (sign convention)", () => {
+  it("preserves outer bounds when hollowing a box from the top", () => {
+    // Standard 1×1 Gridfinity bin dimensions.
+    const w = 41.5;
+    const d = 41.5;
+    const h = 21;
+    const t = 1.2;
+
+    const box = kernel.makeBox(w, d, h);
+    const faces = kernel.getSubShapes(box, "face");
+
+    // Find the +Z (top) face by bounding box.
+    let topFaceId = -1;
+    for (let i = 0; i < faces.size(); i++) {
+      const fid = faces.get(i);
+      const fbb = kernel.getBoundingBox(fid, true);
+      if (fbb.zmin > h - 0.01 && fbb.zmax < h + 0.01) {
+        topFaceId = fid;
+        break;
+      }
+    }
+    faces.delete();
+    expect(topFaceId).toBeGreaterThan(0);
+
+    const removed = new Module.VectorUint32();
+    removed.push_back(topFaceId);
+    const shelled = kernel.shell(box, removed, t, 1e-6);
+    removed.delete();
+
+    // (1) Outer bounds preserved. Old `+thickness` path produced
+    //     xmin ≈ −1.2, xmax ≈ 42.7, ymin ≈ −1.2, ymax ≈ 42.7,
+    //     zmin ≈ −1.2 (from outward-thickened side faces),
+    //     zmax = h (top removed so no offset surface there).
+    const bb = kernel.getBoundingBox(shelled, true);
+    expect(bb.xmin).toBeCloseTo(0, 3);
+    expect(bb.ymin).toBeCloseTo(0, 3);
+    expect(bb.zmin).toBeCloseTo(0, 3);
+    expect(bb.xmax).toBeCloseTo(w, 3);
+    expect(bb.ymax).toBeCloseTo(d, 3);
+    expect(bb.zmax).toBeCloseTo(h, 3);
+
+    // (2) Volume is the inward shell, not the outward skin.
+    //     Inward:  41.5²·21 − 39.1²·19.8 ≈ 5910 mm³
+    //     Outward: 43.9²·22.2 − 41.5²·21 ≈ 6620 mm³  (old buggy result)
+    //     The 6300 ceiling is well below outward-buggy and well above
+    //     inward-correct, so a sign regression flips the assertion.
+    const vol = kernel.getVolume(shelled);
+    expect(vol).toBeGreaterThan(5000);
+    expect(vol).toBeLessThan(6300);
+  });
+});

--- a/test/parity-tolerance.test.ts
+++ b/test/parity-tolerance.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Regression tests for the parity-bug class fixed in 3.0.0: shell-family
+ * facade methods that hardcoded the OCCT tolerance to 1e-3 (PR #94 missed
+ * these; only `offset` was fixed there). brepjs-occt callers default to
+ * 1e-6, so the silent coercion produced different topology and volume.
+ *
+ * These tests don't assert the *correct* answer — there isn't one without
+ * a reference implementation — only that the tolerance argument is wired
+ * through to OCCT and is load-bearing. If a future refactor drops it back
+ * to a hardcoded constant, these tests will catch the regression by
+ * showing the two tolerance values produce identical output.
+ *
+ * Also covers `getBoundingBox` switching from `BRepBndLib::Add` to
+ * `AddOptimal`: the old path overshoots curved geometry by ~0.27·r when
+ * triangulation is absent. This test verifies the new bounds are tight
+ * for a cylinder, where the old behavior would have given xmin ≈ −r·1.27
+ * instead of xmin ≈ −r.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let Module: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let kernel: any;
+
+beforeAll(async () => {
+    const jsPath = resolve(__dirname, "../dist/occt-wasm.js");
+    const wasmPath = resolve(__dirname, "../dist/occt-wasm.wasm");
+    const createModule = (await import(jsPath)).default;
+    Module = await createModule({
+        locateFile: (path: string) =>
+            path.endsWith(".wasm") ? wasmPath : path,
+    });
+    kernel = new Module.OcctKernel();
+}, 30_000);
+
+afterEach(() => {
+    kernel.releaseAll();
+});
+
+afterAll(() => {
+    kernel.releaseAll();
+    kernel.delete();
+});
+
+describe("shell tolerance plumbing", () => {
+    // Build a curved-edge solid: extruding a filleted square produces enough
+    // tolerance-sensitive topology that 1e-3 vs 1e-6 should yield distinct
+    // shell results. A plain box is too easy and both tolerances will agree.
+    function makeFilletedSolid(): number {
+        const box = kernel.makeBox(20, 20, 10);
+        const edges = kernel.getSubShapes(box, "edge");
+        // Fillet the four vertical edges (small radius).
+        const verticals = new Module.VectorUint32();
+        for (let i = 0; i < edges.size(); i++) {
+            const eid = edges.get(i);
+            const bb = kernel.getBoundingBox(eid, true);
+            const dx = bb.xmax - bb.xmin;
+            const dy = bb.ymax - bb.ymin;
+            const dz = bb.zmax - bb.zmin;
+            if (dz > dx && dz > dy) verticals.push_back(eid);
+        }
+        edges.delete();
+        const filleted = kernel.fillet(box, verticals, 1.5);
+        verticals.delete();
+        return filleted;
+    }
+
+    it("forwards tolerance to MakeThickSolidByJoin", () => {
+        const solid1 = makeFilletedSolid();
+        const solid2 = makeFilletedSolid();
+        const faces1 = kernel.getSubShapes(solid1, "face");
+        const faces2 = kernel.getSubShapes(solid2, "face");
+        // Pick the +Z (top) face on each.
+        const pickTop = (faces: any, id: number): number => {
+            for (let i = 0; i < faces.size(); i++) {
+                const fid = faces.get(i);
+                const bb = kernel.getBoundingBox(fid, true);
+                if (bb.zmin > 9.9 && bb.zmax < 10.1) return fid;
+            }
+            throw new Error(`top face not found for ${id}`);
+        };
+        const facesA = new Module.VectorUint32();
+        facesA.push_back(pickTop(faces1, solid1));
+        const facesB = new Module.VectorUint32();
+        facesB.push_back(pickTop(faces2, solid2));
+        faces1.delete();
+        faces2.delete();
+
+        // Same input geometry, different tolerance.
+        const shellLoose = kernel.shell(solid1, facesA, 1.0, 1e-3);
+        const shellTight = kernel.shell(solid2, facesB, 1.0, 1e-6);
+        facesA.delete();
+        facesB.delete();
+
+        expect(shellLoose).toBeGreaterThan(0);
+        expect(shellTight).toBeGreaterThan(0);
+
+        // Both must be valid solids.
+        expect(kernel.getVolume(shellLoose)).toBeGreaterThan(0);
+        expect(kernel.getVolume(shellTight)).toBeGreaterThan(0);
+
+        // The whole point of this regression test: tolerance is load-bearing
+        // and reaches OCCT. If a future refactor reverts to a hardcoded
+        // tolerance, both shell results would be byte-identical and this
+        // assertion catches it. We allow either volume or face-count to
+        // differ — OCCT may produce identical output for some inputs at
+        // these tolerances, but at least one of these signals should differ
+        // for the filleted-solid case.
+        const volLoose = kernel.getVolume(shellLoose);
+        const volTight = kernel.getVolume(shellTight);
+        const facesShellLoose = kernel.getSubShapes(shellLoose, "face");
+        const facesShellTight = kernel.getSubShapes(shellTight, "face");
+        const fcLoose = facesShellLoose.size();
+        const fcTight = facesShellTight.size();
+        facesShellLoose.delete();
+        facesShellTight.delete();
+
+        const volumesDiffer = Math.abs(volLoose - volTight) > 1e-9;
+        const faceCountsDiffer = fcLoose !== fcTight;
+        // If both happen to agree exactly, that's still legal output — but
+        // we check the tolerance arg was at least *seen* by OCCT by passing
+        // an absurd tolerance and expecting failure or a clearly different
+        // result.
+        if (!volumesDiffer && !faceCountsDiffer) {
+            // Try a wildly coarse tolerance — if it still produces the same
+            // result, the arg is being silently ignored.
+            const solid3 = makeFilletedSolid();
+            const faces3 = kernel.getSubShapes(solid3, "face");
+            const facesC = new Module.VectorUint32();
+            facesC.push_back(pickTop(faces3, solid3));
+            faces3.delete();
+            let shellAbsurd: number | undefined;
+            try {
+                shellAbsurd = kernel.shell(solid3, facesC, 1.0, 10.0);
+            } catch {
+                // OCCT rejecting a 10mm tolerance on a 20mm solid is itself
+                // proof the tolerance was honored.
+                facesC.delete();
+                return;
+            }
+            facesC.delete();
+            const volAbsurd = kernel.getVolume(shellAbsurd);
+            // Either the absurd tolerance produces a different volume or
+            // fails to build at all; if it builds and matches the tight
+            // tolerance result, the arg is ignored.
+            expect(volAbsurd).not.toBeCloseTo(volTight, 6);
+        }
+    });
+});
+
+describe("getBoundingBox uses surface-precise bounds", () => {
+    it("gives tight bounds on a cylinder without prior tessellation", () => {
+        // Cylinder of radius 5, height 10, axis +Z, base at origin.
+        // True bounds: x ∈ [−5, 5], y ∈ [−5, 5], z ∈ [0, 10].
+        // The old BRepBndLib::Add path (without triangulation) would give
+        // x ∈ [≈−6.35, ≈6.35] from BSpline pole hulls — overshoot ≈ r·0.27.
+        const cyl = kernel.makeCylinder(5, 10);
+        const bbox = kernel.getBoundingBox(cyl, true);
+
+        // Tight to within OCCT tolerance, NOT pole-hull overshoot.
+        expect(bbox.xmin).toBeCloseTo(-5, 3);
+        expect(bbox.xmax).toBeCloseTo(5, 3);
+        expect(bbox.ymin).toBeCloseTo(-5, 3);
+        expect(bbox.ymax).toBeCloseTo(5, 3);
+        expect(bbox.zmin).toBeCloseTo(0, 3);
+        expect(bbox.zmax).toBeCloseTo(10, 3);
+
+        // Specifically, xmin must NOT have the ≈1.27 overshoot the old path
+        // produced — that was the source of the issue #90 1.2 mm shift.
+        expect(bbox.xmin).toBeGreaterThan(-5.5);
+    });
+
+    it("matches reference bounds on a sphere", () => {
+        const sphere = kernel.makeSphere(7);
+        const bbox = kernel.getBoundingBox(sphere, true);
+        expect(bbox.xmin).toBeCloseTo(-7, 3);
+        expect(bbox.xmax).toBeCloseTo(7, 3);
+    });
+});

--- a/test/surface-center-of-mass.test.ts
+++ b/test/surface-center-of-mass.test.ts
@@ -50,7 +50,7 @@ describe("getSurfaceCenterOfMass", () => {
         let zMaxFaceId = -1;
         for (let i = 0; i < faces.size(); i++) {
             const fid = faces.get(i);
-            const bb = kernel.getBoundingBox(fid);
+            const bb = kernel.getBoundingBox(fid, true);
             if (bb.zmin > 9.9 && bb.zmax < 10.1) {
                 zMaxFaceId = fid;
                 break;

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "occt-wasm",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "OpenCascade (OCCT) compiled to WebAssembly with a clean TypeScript API",
   "type": "module",
   "exports": {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -225,7 +225,7 @@ export interface OcctRawKernel {
     fillet(solidId: number, edgeIds: EmbindVectorU32, radius: number): number;
     chamfer(solidId: number, edgeIds: EmbindVectorU32, distance: number): number;
     chamferDistAngle(solidId: number, edgeIds: EmbindVectorU32, distance: number, angleDeg: number): number;
-    shell(solidId: number, faceIds: EmbindVectorU32, thickness: number): number;
+    shell(solidId: number, faceIds: EmbindVectorU32, thickness: number, tolerance: number): number;
     offset(solidId: number, distance: number, tolerance: number): number;
     draft(shapeId: number, faceId: number, angle: number, dx: number, dy: number, dz: number): number;
 
@@ -318,7 +318,7 @@ export interface OcctRawKernel {
     fromBREP(data: string): number;
 
     // Query
-    getBoundingBox(id: number): BoundingBox;
+    getBoundingBox(id: number, useTriangulation: boolean): BoundingBox;
     getVolume(id: number): number;
     getSurfaceArea(id: number): number;
     getLength(id: number): number;
@@ -357,8 +357,8 @@ export interface OcctRawKernel {
     projectEdges(shapeId: number, ox: number, oy: number, oz: number, dx: number, dy: number, dz: number, xx: number, xy: number, xz: number, hasXAxis: boolean): RawProjectionData;
 
     // Modifiers
-    thicken(shapeId: number, thickness: number): number;
-    defeature(shapeId: number, faceIds: EmbindVectorU32): number;
+    thicken(shapeId: number, thickness: number, tolerance: number): number;
+    defeature(shapeId: number, faceIds: EmbindVectorU32, tolerance: number): number;
     reverseShape(id: number): number;
     simplify(id: number): number;
     filletVariable(solidId: number, edgeId: number, startRadius: number, endRadius: number): number;
@@ -374,9 +374,9 @@ export interface OcctRawKernel {
     scaleWithHistory(id: number, cx: number, cy: number, cz: number, factor: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
     intersectWithHistory(a: number, b: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
     chamferWithHistory(solidId: number, edgeIds: EmbindVectorU32, distance: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
-    shellWithHistory(solidId: number, faceIds: EmbindVectorU32, thickness: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
-    offsetWithHistory(solidId: number, distance: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
-    thickenWithHistory(shapeId: number, thickness: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
+    shellWithHistory(solidId: number, faceIds: EmbindVectorU32, thickness: number, tolerance: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
+    offsetWithHistory(solidId: number, distance: number, tolerance: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
+    thickenWithHistory(shapeId: number, thickness: number, tolerance: number, inputFaceHashes: EmbindVectorI32, hashUpperBound: number): RawEvolutionData;
 
     // Null shape
     makeNullShape(): number;
@@ -738,10 +738,20 @@ export class OcctKernel {
         });
     }
 
-    shell(solid: ShapeHandle, facesToRemove: ShapeHandle[], thickness: number): ShapeHandle {
+    /**
+     * Hollow a solid by removing the listed faces and offsetting remaining
+     * faces inward by `thickness`.
+     *
+     * @param tolerance - OCCT precision for the thick-solid reconstruction.
+     *     Use `1e-6` for precise shells (matches brepjs default); `1e-3` is a
+     *     coarser legacy value that survives more inputs but produces
+     *     different topology than brepjs.
+     */
+    shell(solid: ShapeHandle, facesToRemove: ShapeHandle[], thickness: number,
+          tolerance: number): ShapeHandle {
         return wrap("shell", () => {
             const vec = this.#makeVectorU32(facesToRemove);
-            try { return handle(this.#raw.shell(solid, vec, thickness)); }
+            try { return handle(this.#raw.shell(solid, vec, thickness, tolerance)); }
             finally { vec.delete(); }
         });
     }
@@ -1434,8 +1444,23 @@ export class OcctKernel {
     // Query / Measure
     // =======================================================================
 
-    getBoundingBox(shape: ShapeHandle): BoundingBox {
-        return wrap("getBoundingBox", () => this.#raw.getBoundingBox(shape));
+    /**
+     * Compute the axis-aligned bounding box of a shape.
+     *
+     * Uses `BRepBndLib::AddOptimal` for surface-precise bounds independent of
+     * tessellation state. The simpler `BRepBndLib::Add` falls back to BSpline
+     * pole hulls when triangulation is absent, which overshoots curved
+     * geometry by ~0.27·r for arcs of radius r — that was the source of the
+     * uniform 1.2 mm bounds shift versus brepjs in occt-wasm 2.0.
+     *
+     * @param useTriangulation - If `true`, use existing triangulation as the
+     *     starting bound and refine via surface analysis (faster). If `false`,
+     *     do the surface analysis from scratch (slower, but doesn't depend on
+     *     prior tessellation). Both modes produce tight bounds; brepjs's
+     *     `BRepBndLib.Add(shape, box, true)` corresponds to `true` here.
+     */
+    getBoundingBox(shape: ShapeHandle, useTriangulation: boolean): BoundingBox {
+        return wrap("getBoundingBox", () => this.#raw.getBoundingBox(shape, useTriangulation));
     }
 
     getVolume(shape: ShapeHandle): number {
@@ -1708,14 +1733,28 @@ export class OcctKernel {
     // Modifiers
     // =======================================================================
 
-    thicken(shape: ShapeHandle, thickness: number): ShapeHandle {
-        return wrap("thicken", () => handle(this.#raw.thicken(shape, thickness)));
+    /**
+     * Thicken a face/shell into a solid (or grow a solid uniformly).
+     *
+     * @param tolerance - OCCT precision for the offset reconstruction. Use
+     *     `1e-6` for precise thickening (matches brepjs default); `1e-3` is a
+     *     coarser legacy value.
+     */
+    thicken(shape: ShapeHandle, thickness: number, tolerance: number): ShapeHandle {
+        return wrap("thicken", () => handle(this.#raw.thicken(shape, thickness, tolerance)));
     }
 
-    defeature(shape: ShapeHandle, faces: ShapeHandle[]): ShapeHandle {
+    /**
+     * Remove faces from a solid by closing them off (zero-thickness shell).
+     *
+     * @param tolerance - OCCT precision for the reconstruction. Use `1e-6`
+     *     for precise feature removal (matches brepjs default); `1e-3` is a
+     *     coarser legacy value.
+     */
+    defeature(shape: ShapeHandle, faces: ShapeHandle[], tolerance: number): ShapeHandle {
         return wrap("defeature", () => {
             const vec = this.#makeVectorU32(faces);
-            try { return handle(this.#raw.defeature(shape, vec)); }
+            try { return handle(this.#raw.defeature(shape, vec, tolerance)); }
             finally { vec.delete(); }
         });
     }
@@ -1834,27 +1873,27 @@ export class OcctKernel {
         });
     }
 
-    shellWithHistory(solid: ShapeHandle, faces: ShapeHandle[], thickness: number, inputFaceHashes: number[], hashUpperBound: number): EvolutionData {
+    shellWithHistory(solid: ShapeHandle, faces: ShapeHandle[], thickness: number, tolerance: number, inputFaceHashes: number[], hashUpperBound: number): EvolutionData {
         return wrap("shellWithHistory", () => {
             const faceVec = this.#makeVectorU32(faces);
             const hashes = this.#makeVectorI32(inputFaceHashes);
-            try { return this.#extractEvolution(this.#raw.shellWithHistory(solid, faceVec, thickness, hashes, hashUpperBound)); }
+            try { return this.#extractEvolution(this.#raw.shellWithHistory(solid, faceVec, thickness, tolerance, hashes, hashUpperBound)); }
             finally { faceVec.delete(); hashes.delete(); }
         });
     }
 
-    offsetWithHistory(solid: ShapeHandle, distance: number, inputFaceHashes: number[], hashUpperBound: number): EvolutionData {
+    offsetWithHistory(solid: ShapeHandle, distance: number, tolerance: number, inputFaceHashes: number[], hashUpperBound: number): EvolutionData {
         return wrap("offsetWithHistory", () => {
             const hashes = this.#makeVectorI32(inputFaceHashes);
-            try { return this.#extractEvolution(this.#raw.offsetWithHistory(solid, distance, hashes, hashUpperBound)); }
+            try { return this.#extractEvolution(this.#raw.offsetWithHistory(solid, distance, tolerance, hashes, hashUpperBound)); }
             finally { hashes.delete(); }
         });
     }
 
-    thickenWithHistory(shape: ShapeHandle, thickness: number, inputFaceHashes: number[], hashUpperBound: number): EvolutionData {
+    thickenWithHistory(shape: ShapeHandle, thickness: number, tolerance: number, inputFaceHashes: number[], hashUpperBound: number): EvolutionData {
         return wrap("thickenWithHistory", () => {
             const hashes = this.#makeVectorI32(inputFaceHashes);
-            try { return this.#extractEvolution(this.#raw.thickenWithHistory(shape, thickness, hashes, hashUpperBound)); }
+            try { return this.#extractEvolution(this.#raw.thickenWithHistory(shape, thickness, tolerance, hashes, hashUpperBound)); }
             finally { hashes.delete(); }
         });
     }
@@ -1962,7 +2001,7 @@ export class OcctKernel {
     /** Return a human-readable summary of a shape for debugging. */
     describe(shape: ShapeHandle): string {
         const type = this.getShapeType(shape);
-        const bbox = this.getBoundingBox(shape);
+        const bbox = this.getBoundingBox(shape, true);
         const dims = `[${(bbox.xmax - bbox.xmin).toFixed(2)} x ${(bbox.ymax - bbox.ymin).toFixed(2)} x ${(bbox.zmax - bbox.zmin).toFixed(2)}]`;
         const parts: string[] = [`${type} ${dims}`];
 

--- a/ts/src/worker.ts
+++ b/ts/src/worker.ts
@@ -49,7 +49,7 @@ export interface OcctWorkerProxy {
     revolve(shape: ShapeHandle, axis: { point: Vec3; direction: Vec3 }, angleRad: number): Promise<ShapeHandle>;
     fillet(solid: ShapeHandle, edges: ShapeHandle[], radius: number): Promise<ShapeHandle>;
     chamfer(solid: ShapeHandle, edges: ShapeHandle[], distance: number): Promise<ShapeHandle>;
-    shell(solid: ShapeHandle, facesToRemove: ShapeHandle[], thickness: number): Promise<ShapeHandle>;
+    shell(solid: ShapeHandle, facesToRemove: ShapeHandle[], thickness: number, tolerance: number): Promise<ShapeHandle>;
     offset(solid: ShapeHandle, distance: number): Promise<ShapeHandle>;
     draft(shape: ShapeHandle, face: ShapeHandle, angleRad: number, direction: Vec3): Promise<ShapeHandle>;
 
@@ -112,7 +112,7 @@ export interface OcctWorkerProxy {
     loadCached(brep: string): Promise<ShapeHandle>;
 
     // Query
-    getBoundingBox(shape: ShapeHandle): Promise<BoundingBox>;
+    getBoundingBox(shape: ShapeHandle, useTriangulation: boolean): Promise<BoundingBox>;
     getVolume(shape: ShapeHandle): Promise<number>;
     getSurfaceArea(shape: ShapeHandle): Promise<number>;
     getLength(shape: ShapeHandle): Promise<number>;
@@ -226,7 +226,7 @@ export class OcctWorker {
     exportStep(shape: ShapeHandle) { return this.#proxy.exportStep(shape); }
     cacheStep(data: string | ArrayBuffer) { return this.#proxy.cacheStep(data); }
     loadCached(brep: string) { return this.#proxy.loadCached(brep); }
-    getBoundingBox(shape: ShapeHandle) { return this.#proxy.getBoundingBox(shape); }
+    getBoundingBox(shape: ShapeHandle, useTriangulation: boolean) { return this.#proxy.getBoundingBox(shape, useTriangulation); }
     getVolume(shape: ShapeHandle) { return this.#proxy.getVolume(shape); }
     getSurfaceArea(shape: ShapeHandle) { return this.#proxy.getSurfaceArea(shape); }
     getShapeType(shape: ShapeHandle) { return this.#proxy.getShapeType(shape); }

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -449,7 +449,7 @@ return store(maker.Shape());",
         kind: MethodKind::CustomBody,
         params: &[
             FacadeParam::ShapeId("solidId"), FacadeParam::VectorShapeIds("faceIds"),
-            FacadeParam::Double("thickness"),
+            FacadeParam::Double("thickness"), FacadeParam::Double("tolerance"),
         ],
         occt_class: "",
         ctor_args: "",
@@ -459,7 +459,7 @@ for (uint32_t fid : faceIds) {
     facesToRemove.Append(get(fid));
 }
 BRepOffsetAPI_MakeThickSolid maker;
-maker.MakeThickSolidByJoin(get(solidId), facesToRemove, thickness, 1e-3);
+maker.MakeThickSolidByJoin(get(solidId), facesToRemove, thickness, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"shell: operation failed\");
@@ -517,14 +517,17 @@ return store(maker.Shape());",
     MethodSpec {
         name: "thicken",
         kind: MethodKind::CustomBody,
-        params: &[FacadeParam::ShapeId("shapeId"), FacadeParam::Double("thickness")],
+        params: &[
+            FacadeParam::ShapeId("shapeId"), FacadeParam::Double("thickness"),
+            FacadeParam::Double("tolerance"),
+        ],
         occt_class: "",
         ctor_args: "",
         setup_code: "\
 const auto& shape = get(shapeId);
 if (shape.ShapeType() == TopAbs_FACE || shape.ShapeType() == TopAbs_SHELL) {
     BRepOffset_MakeOffset offsetMaker;
-    offsetMaker.Initialize(shape, thickness, 1e-3, BRepOffset_Skin, false, false, GeomAbs_Arc, true);
+    offsetMaker.Initialize(shape, thickness, tolerance, BRepOffset_Skin, false, false, GeomAbs_Arc, true);
     offsetMaker.MakeOffsetShape();
     if (!offsetMaker.IsDone()) {
         throw std::runtime_error(\"thicken: offset operation failed\");
@@ -533,7 +536,7 @@ if (shape.ShapeType() == TopAbs_FACE || shape.ShapeType() == TopAbs_SHELL) {
 }
 NCollection_List<TopoDS_Shape> emptyList;
 BRepOffsetAPI_MakeThickSolid maker;
-maker.MakeThickSolidByJoin(shape, emptyList, thickness, 1e-3);
+maker.MakeThickSolidByJoin(shape, emptyList, thickness, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"thicken: operation failed\");
@@ -550,7 +553,10 @@ return store(maker.Shape());",
     MethodSpec {
         name: "defeature",
         kind: MethodKind::CustomBody,
-        params: &[FacadeParam::ShapeId("shapeId"), FacadeParam::VectorShapeIds("faceIds")],
+        params: &[
+            FacadeParam::ShapeId("shapeId"), FacadeParam::VectorShapeIds("faceIds"),
+            FacadeParam::Double("tolerance"),
+        ],
         occt_class: "",
         ctor_args: "",
         setup_code: "\
@@ -559,7 +565,7 @@ for (uint32_t fid : faceIds) {
     facesToRemove.Append(get(fid));
 }
 BRepOffsetAPI_MakeThickSolid maker;
-maker.MakeThickSolidByJoin(get(shapeId), facesToRemove, 0.0, 1e-3);
+maker.MakeThickSolidByJoin(get(shapeId), facesToRemove, 0.0, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"defeature: operation failed\");
@@ -1926,13 +1932,17 @@ return result;",
     MethodSpec {
         name: "getBoundingBox",
         kind: MethodKind::CustomBody,
-        params: &[FacadeParam::ShapeId("id")],
+        params: &[FacadeParam::ShapeId("id"), FacadeParam::Bool("useTriangulation")],
         occt_class: "",
         ctor_args: "",
+        // AddOptimal gives surface-precise bounds independent of tessellation
+        // state (Add falls back to BSpline pole hulls without triangulation,
+        // overshooting curved geometry by ~0.27*r). useShapeTolerance=false
+        // matches brepjs's call surface.
         setup_code: "\
 const auto& shape = get(id);
 Bnd_Box box;
-BRepBndLib::Add(shape, box);
+BRepBndLib::AddOptimal(shape, box, useTriangulation, false);
 if (box.IsVoid()) {
     throw std::runtime_error(\"getBoundingBox: shape has no geometry\");
 }
@@ -3473,7 +3483,7 @@ return buildEvolution(maker, resultId, solid, inputFaceHashes, hashUpperBound);"
         kind: MethodKind::CustomBody,
         params: &[
             FacadeParam::ShapeId("solidId"), FacadeParam::VectorShapeIds("faceIds"),
-            FacadeParam::Double("thickness"),
+            FacadeParam::Double("thickness"), FacadeParam::Double("tolerance"),
             FacadeParam::VectorInt("inputFaceHashes"), FacadeParam::Int("hashUpperBound"),
         ],
         occt_class: "",
@@ -3485,7 +3495,7 @@ for (uint32_t fid : faceIds) {
     facesToRemove.Append(get(fid));
 }
 BRepOffsetAPI_MakeThickSolid maker;
-maker.MakeThickSolidByJoin(solid, facesToRemove, thickness, 1e-3);
+maker.MakeThickSolidByJoin(solid, facesToRemove, thickness, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"shellWithHistory: operation failed\");
@@ -3501,6 +3511,7 @@ return buildEvolution(maker, resultId, solid, inputFaceHashes, hashUpperBound);"
         kind: MethodKind::CustomBody,
         params: &[
             FacadeParam::ShapeId("solidId"), FacadeParam::Double("distance"),
+            FacadeParam::Double("tolerance"),
             FacadeParam::VectorInt("inputFaceHashes"), FacadeParam::Int("hashUpperBound"),
         ],
         occt_class: "",
@@ -3508,7 +3519,7 @@ return buildEvolution(maker, resultId, solid, inputFaceHashes, hashUpperBound);"
         setup_code: "\
 const auto& solid = get(solidId);
 BRepOffsetAPI_MakeOffsetShape maker;
-maker.PerformByJoin(solid, distance, 1e-3);
+maker.PerformByJoin(solid, distance, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"offsetWithHistory: operation failed\");
@@ -3524,6 +3535,7 @@ return buildEvolution(maker, resultId, solid, inputFaceHashes, hashUpperBound);"
         kind: MethodKind::CustomBody,
         params: &[
             FacadeParam::ShapeId("shapeId"), FacadeParam::Double("thickness"),
+            FacadeParam::Double("tolerance"),
             FacadeParam::VectorInt("inputFaceHashes"), FacadeParam::Int("hashUpperBound"),
         ],
         occt_class: "",
@@ -3535,7 +3547,7 @@ const auto& shape = get(shapeId);
 // hollowing)
 if (shape.ShapeType() == TopAbs_FACE || shape.ShapeType() == TopAbs_SHELL) {
     BRepOffset_MakeOffset offsetMaker;
-    offsetMaker.Initialize(shape, thickness, 1e-3, BRepOffset_Skin, false, false,
+    offsetMaker.Initialize(shape, thickness, tolerance, BRepOffset_Skin, false, false,
                            GeomAbs_Arc, true);
     offsetMaker.MakeOffsetShape();
     if (!offsetMaker.IsDone()) {
@@ -3550,7 +3562,7 @@ if (shape.ShapeType() == TopAbs_FACE || shape.ShapeType() == TopAbs_SHELL) {
 
 NCollection_List<TopoDS_Shape> emptyList;
 BRepOffsetAPI_MakeThickSolid maker;
-maker.MakeThickSolidByJoin(shape, emptyList, thickness, 1e-3);
+maker.MakeThickSolidByJoin(shape, emptyList, thickness, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"thickenWithHistory: operation failed\");

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -453,13 +453,20 @@ return store(maker.Shape());",
         ],
         occt_class: "",
         ctor_args: "",
+        // OCCT's MakeThickSolidByJoin offset sign selects which side of the
+        // original surface the walls grow on: positive thickens outward
+        // (bounding box grows by `thickness` on every open direction),
+        // negative hollows inward (bounding box preserved). We negate so
+        // `shell(solid, faces, thickness)` reads as "hollow `solid` inward by
+        // `thickness`" — the conventional CAD interpretation, matching the
+        // OCCT tutorial's `MakeThickSolidByJoin(body, faces, -thickness/50, ...)`.
         setup_code: "\
 NCollection_List<TopoDS_Shape> facesToRemove;
 for (uint32_t fid : faceIds) {
     facesToRemove.Append(get(fid));
 }
 BRepOffsetAPI_MakeThickSolid maker;
-maker.MakeThickSolidByJoin(get(solidId), facesToRemove, thickness, tolerance);
+maker.MakeThickSolidByJoin(get(solidId), facesToRemove, -thickness, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"shell: operation failed\");
@@ -3488,6 +3495,8 @@ return buildEvolution(maker, resultId, solid, inputFaceHashes, hashUpperBound);"
         ],
         occt_class: "",
         ctor_args: "",
+        // Mirror `shell`: negate offset so positive `thickness` hollows
+        // inward (preserves bounds) instead of thickening outward.
         setup_code: "\
 const auto& solid = get(solidId);
 NCollection_List<TopoDS_Shape> facesToRemove;
@@ -3495,7 +3504,7 @@ for (uint32_t fid : faceIds) {
     facesToRemove.Append(get(fid));
 }
 BRepOffsetAPI_MakeThickSolid maker;
-maker.MakeThickSolidByJoin(solid, facesToRemove, thickness, tolerance);
+maker.MakeThickSolidByJoin(solid, facesToRemove, -thickness, tolerance);
 maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"shellWithHistory: operation failed\");


### PR DESCRIPTION
Closes the residual parity gap with brepjs reported in #90 that survived #94.
**Three** classes of bug, all from the facade silently substituting OCCT
defaults or sign conventions for the caller's intent.

## 1. Hardcoded `1e-3` tolerance in shell-family methods

PR #94 fixed this for `offset(solid, distance, tolerance)`, but six sibling
methods inherited the same bug and were silently coercing all caller tolerances
to `1e-3`:

- `shell(solid, faces, thickness, tolerance)`
- `thicken(shape, thickness, tolerance)` — both face/shell and solid branches
- `defeature(shape, faces, tolerance)`
- `shellWithHistory(..., thickness, tolerance, ...)`
- `offsetWithHistory(..., distance, tolerance, ...)`
- `thickenWithHistory(..., thickness, tolerance, ...)`

## 2. `getBoundingBox` used `BRepBndLib::Add` instead of `AddOptimal`

When triangulation is absent, `Add` falls back to BSpline pole hulls, which
overshoot curved geometry by ~0.27·r for arcs of radius r. For the 4 mm
Gridfinity fillet this produced a ~1.1 mm bounds shift on filleted faces.

Switched to `AddOptimal(shape, box, useTriangulation, false)` which gives
tight bounds independent of tessellation state. Added a `useTriangulation`
parameter matching brepjs's `BRepBndLib.Add(shape, box, true)` call surface.

## 3. `shell` / `shellWithHistory` passed positive offset to `MakeThickSolidByJoin`

OCCT's docs are explicit: **"Offset's sign indicates which side of the
surface of the solid the hollowed shape is built on."** Negative = walls grow
inward (outer bounds preserved); positive = walls grow outward (bounds inflate
by `thickness`). The OCCT tutorial's bottle-hollow example uses
`MakeThickSolidByJoin(myBody, faces, -myThickness/50, ...)`, and brepjs-occt's
reference path negates: `builder.MakeThickSolidByJoin(shape, faces, -thickness, tolerance, ...)`.

The facade was passing **positive** `thickness` directly. For Gridfinity's
"1×1 flat no-lip" bin (the simplest shell-only case, 41.5×41.5×21 box hollowed
from the top with thickness=1.2):

| Path                           | Bounds            | Volume       |
|--------------------------------|-------------------|--------------|
| Inward (correct, brepjs-occt)  | 41.5×41.5×21      | ≈ 5910 mm³   |
| Outward (buggy, occt-wasm 2.x) | 43.9×43.9×22.2    | ≈ 6620 mm³   |

The +12% volume gap explains the gridfinity parity test's reported +10.4%
divergence. The uniform ~1.2 mm xMin shift across **every** bin variant is
the wall thickness growing outward in -X — `AddOptimal` only explained the
fillet-overshoot component, not this load-bearing source. `thicken` and
`defeature` were not affected (thicken's positive convention is conventional,
defeature uses 0.0 offset).

## Implementation

- **`xtask/src/codegen/config.rs`**: declarative method specs updated for all
  affected ops.
- **`facade/include/occt_kernel.h`**: hand-written header signatures match.
- **`facade/generated/{kernel,bindings,wasi_exports}.cpp`** + **`crate/src/kernel_generated.rs`**:
  regenerated via `cargo xtask codegen`.
- **`ts/src/index.ts`**: TypeScript bindings (raw + `OcctKernel` wrapper) match,
  with new doc blocks explaining the parity rationale.
- **Test call sites**: 8 existing test files updated for the new signatures;
  node-cli example + Rust integration test follow.
- **`test/parity-tolerance.test.ts`**: regression for tolerance plumbing
  (different tolerances must produce different output, or an absurd 10mm
  tolerance must fail to build — proves the arg reaches OCCT, not silently dropped).
- **`test/parity-tolerance.test.ts`**: regression for `getBoundingBox` —
  cylinder bounds must be `xmin ≈ -r` (tight), not `≈ -r·1.27` (pole-hull overshoot).
- **`test/parity-shell-sign.test.ts`**: regression for the shell sign — shelled
  bounds must equal input bounds, and volume must fall in the inward-hollow
  range, not the outward-skin range. A regression to `+thickness` would flip
  both assertions.

## Breaking changes (3.0.0)

Callers of these methods must add the new positional argument:

- `kernel.shell(s, f, t)` → `kernel.shell(s, f, t, tolerance)`
- `kernel.thicken(s, t)` → `kernel.thicken(s, t, tolerance)`
- `kernel.defeature(s, f)` → `kernel.defeature(s, f, tolerance)`
- `kernel.getBoundingBox(s)` → `kernel.getBoundingBox(s, useTriangulation)`
- Three `*WithHistory` variants gain `tolerance` in the same shape.

The shell sign change is a behavioral break: callers that were relying on the
previous "thicken outward" output of `shell` will now get inward hollowing.
This matches every conventional CAD `shell()` API and the OCCT docs.

This matches PR #94's pattern — no silent defaults preserved because the old
defaults were the silent-correctness bugs being fixed.

## Downstream

- **brepjs**: needs to drop the `_tolerance?: number` underscore-prefix
  ignored params in `OcctWasmAdapter` (`shell`, `shellWithHistory`,
  `offsetWithHistory`, `thickenWithHistory`) and pass them through to the
  raw kernel; needs to add `useTriangulation` (default `true`) to the
  two `getBoundingBox` call sites.
- **gridfinity**: can drop the `as any` casts in `wasmInstantiator.ts` and
  `kernelInit.ts` once the brepjs side widens its types to match.

Refs #90.