### PR TITLE
feat(crate): publish occt-wasm to crates.io + add OIDC publish workflow

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,89 @@
+name: Publish crate to crates.io
+
+# Publishes the `occt-wasm` Rust crate at `crate/` to crates.io.
+#
+# Triggers:
+#   - workflow_dispatch (manual, with version sanity check)
+#   - push of a tag like `crate-v3.0.0` (recommended path)
+#
+# Auth: OIDC trusted publishing via crates.io. Requires a one-time setup
+# on crates.io → Account Settings → Trusted Publishers, adding this repo
+# + this workflow filename + the `crates-io` environment name.
+#
+# The embedded WASM (`crate/src/occt-wasm.wasm.br`) is read from the repo
+# as-is. Refresh it locally with `cargo xtask build-wasi --release && brotli
+# -q 11 -o crate/src/occt-wasm.wasm.br target/wasm32-wasip1/release/occt-wasm.wasm`
+# and commit before tagging.
+
+on:
+  push:
+    tags:
+      - "crate-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Crate version that should be in crate/Cargo.toml (sanity check)."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: cargo publish
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify version matches tag / dispatch input
+        shell: bash
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          actual=$(grep -m1 '^version' crate/Cargo.toml | sed -E 's/version *= *"([^"]+)".*/\1/')
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            expected="${REF_NAME#crate-v}"
+          else
+            expected="$DISPATCH_VERSION"
+          fi
+          if [[ "$actual" != "$expected" ]]; then
+            echo "::error::crate/Cargo.toml version is $actual, expected $expected"
+            exit 1
+          fi
+          echo "Publishing occt-wasm v$actual"
+
+      - name: Verify embedded WASM is present and reasonable
+        shell: bash
+        run: |
+          set -euo pipefail
+          file=crate/src/occt-wasm.wasm.br
+          if [[ ! -f "$file" ]]; then
+            echo "::error::$file missing"
+            exit 1
+          fi
+          size=$(stat -c%s "$file")
+          if (( size < 1000000 )); then
+            echo "::error::$file is suspiciously small ($size bytes) — likely a placeholder"
+            exit 1
+          fi
+          echo "Embedded WASM: $size bytes"
+
+      - name: Authenticate with crates.io (OIDC)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p occt-wasm

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -38,10 +38,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to commit SHAs (not tags) because this workflow holds
+      # `id-token: write` and runs `cargo publish` — a tag re-point would
+      # otherwise hand a malicious revision the OIDC token + publish slot.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Verify version matches tag / dispatch input
         shell: bash
@@ -81,7 +84,7 @@ jobs:
 
       - name: Authenticate with crates.io (OIDC)
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
 
       - name: cargo publish
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "occt-wasm"
-version = "1.5.0"
+version = "3.0.0"
 dependencies = [
  "brotli",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-repository = "git+https://github.com/andymai/occt-wasm.git"
+repository = "https://github.com/andymai/occt-wasm"
 rust-version = "1.95"
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The same OCCT WASM is available as a [Rust crate](https://crates.io/crates/occt-
 
 ```toml
 [dependencies]
-occt-wasm = "1"
+occt-wasm = "3"
 ```
 
 ```rust
@@ -391,4 +391,4 @@ These will be addressed as OCCT V8.0.0 final is released and browser support imp
 
 **Compiled WASM output**: LGPL-2.1-only (inherits from [OCCT](https://dev.opencascade.org/resources/download))
 
-The LGPL requires that end users can replace the LGPL component. For web applications, this is satisfied by loading the `.wasm` file from a URL (which users can override via `OcctKernel.init({ wasm: '...' })`). If you ship a desktop app with the WASM embedded, consult the [LGPL FAQ](https://www.gnu.org/licenses/lgpl-3.0.en.html).
+The LGPL requires that end users can replace the LGPL component. For web applications, this is satisfied by loading the `.wasm` file from a URL (which users can override via `OcctKernel.init({ wasm: '...' })`). If you ship a desktop app with the WASM embedded, consult the [LGPL-2.1 FAQ](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [OpenCascade](https://github.com/Open-Cascade-SAS/OCCT) V8 compiled to WebAssembly with a clean TypeScript API.
 
 [![npm](https://img.shields.io/npm/v/occt-wasm)](https://www.npmjs.com/package/occt-wasm)
+[![Crates.io](https://img.shields.io/crates/v/occt-wasm.svg)](https://crates.io/crates/occt-wasm)
 [![CI](https://github.com/andymai/occt-wasm/actions/workflows/ci.yml/badge.svg)](https://github.com/andymai/occt-wasm/actions/workflows/ci.yml)
 [![Last release](https://img.shields.io/github/release-date/andymai/occt-wasm?label=last%20release)](https://github.com/andymai/occt-wasm/releases)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/andymai/occt-wasm?label=commits%2Fmonth)](https://github.com/andymai/occt-wasm/commits/main)
@@ -68,6 +69,28 @@ import { OcctKernel } from "occt-wasm";
   // kernel is disposed at end of block
 }
 ```
+
+## Rust Crate
+
+The same OCCT WASM is available as a [Rust crate](https://crates.io/crates/occt-wasm) for native targets (servers, CLIs, build scripts) — no C++ toolchain required:
+
+```toml
+[dependencies]
+occt-wasm = "1"
+```
+
+```rust
+use occt_wasm::OcctKernel;
+
+let mut kernel = OcctKernel::new()?;
+let box_shape = kernel.make_box(10.0, 20.0, 30.0)?;
+let sphere = kernel.make_sphere(8.0)?;
+let fused = kernel.fuse(box_shape, sphere)?;
+let mesh = kernel.tessellate(fused, 0.1, 0.5)?;
+let step = kernel.export_step(fused)?;
+```
+
+The crate embeds a brotli-compressed WASM binary (~4 MB) and runs it via [wasmtime](https://wasmtime.dev/). Same 170+ facade methods as the TS API. See [`crate/README.md`](./crate/README.md) and [docs.rs/occt-wasm](https://docs.rs/occt-wasm) for full details.
 
 ## Initialization
 

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "occt-wasm"
-version = "1.5.0"
+version = "3.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "OpenCascade CAD kernel via WebAssembly — no C++ toolchain required"
+readme = "README.md"
+documentation = "https://docs.rs/occt-wasm"
+homepage = "https://github.com/andymai/occt-wasm"
 keywords = ["cad", "opencascade", "wasm", "brep", "geometry"]
 categories = ["graphics", "science", "wasm"]
 

--- a/crate/README.md
+++ b/crate/README.md
@@ -1,0 +1,122 @@
+# occt-wasm
+
+[![Crates.io](https://img.shields.io/crates/v/occt-wasm.svg)](https://crates.io/crates/occt-wasm)
+[![Docs.rs](https://docs.rs/occt-wasm/badge.svg)](https://docs.rs/occt-wasm)
+[![CI](https://github.com/andymai/occt-wasm/actions/workflows/ci.yml/badge.svg)](https://github.com/andymai/occt-wasm/actions/workflows/ci.yml)
+
+[OpenCascade](https://github.com/Open-Cascade-SAS/OCCT) V8 CAD kernel as a Rust crate — backed by a pre-built, brotli-compressed WebAssembly module loaded via [wasmtime](https://wasmtime.dev/).
+
+No C++ toolchain, no CMake, no system OCCT. Just `cargo add occt-wasm`.
+
+```toml
+[dependencies]
+occt-wasm = "1"
+```
+
+## Why
+
+OCCT is a 2.5 MLoC C++ library. Building it from source takes ~10 minutes and a working Emscripten or system toolchain. This crate ships the WASM artifact in the package itself (~4 MB compressed → ~21 MB on first load), so you get a fully functional CAD kernel from `cargo build`.
+
+Use this crate when you want OCCT inside a Rust server, CLI, or build script — without taking on the OCCT build pipeline. For the browser, use the [`occt-wasm` npm package](https://www.npmjs.com/package/occt-wasm) instead; it wraps the same WASM via Embind.
+
+## Quick Start
+
+```rust,no_run
+use occt_wasm::OcctKernel;
+
+let mut kernel = OcctKernel::new()?;
+
+// Primitives
+let box_shape = kernel.make_box(10.0, 20.0, 30.0)?;
+let sphere = kernel.make_sphere(8.0)?;
+
+// Booleans
+let fused = kernel.fuse(box_shape, sphere)?;
+
+// Query
+let volume = kernel.get_volume(fused)?;
+let bbox = kernel.get_bounding_box(fused, true)?;
+
+// Tessellation (for rendering)
+let mesh = kernel.tessellate(fused, 0.1, 0.5)?;
+println!("{} triangles", mesh.indices.len() / 3);
+
+// STEP I/O
+let step = kernel.export_step(fused)?;
+let reimported = kernel.import_step(&step)?;
+# Ok::<(), occt_wasm::OcctError>(())
+```
+
+Every shape lives in an arena inside the WASM sandbox and is referenced by an opaque [`ShapeHandle`](https://docs.rs/occt-wasm/latest/occt_wasm/struct.ShapeHandle.html). Drop the `OcctKernel` and the arena (and all its memory) goes away.
+
+## What's Covered
+
+The crate exposes the full OCCT facade — 170+ methods generated from the same declarative spec as the C++/TypeScript bindings:
+
+| Category | Examples |
+|----------|----------|
+| **Primitives** | `make_box`, `make_cylinder`, `make_sphere`, `make_cone`, `make_torus`, `make_rectangle` |
+| **Booleans** | `fuse`, `cut`, `common`, `intersect`, `boolean_pipeline` + `*_with_history` variants |
+| **Modeling** | `extrude`, `revolve`, `fillet`, `chamfer`, `shell`, `offset`, `draft`, `thicken` |
+| **Sweeps** | `pipe`, `loft`, `sweep`, `draft_prism` |
+| **Construction** | `make_vertex/edge/wire/face/solid`, `sew`, `make_compound`, B-spline surface fitting |
+| **Transforms** | `translate`, `rotate`, `scale`, `mirror`, batch transforms |
+| **Topology** | `get_shape_type`, `get_sub_shapes`, `outer_wire`, `shared_edges`, `distance_between` |
+| **Tessellation** | `tessellate` (triangles), `mesh_shape` (with face groups), `mesh_batch` |
+| **I/O** | STEP (import/export), STL (import/export), glTF export |
+| **Query** | volume, surface area, length, center of mass, curvature |
+| **Curves** | NURBS data extraction, point/tangent evaluation, interpolation |
+| **Projection** | Hidden line removal (HLR) |
+| **Healing** | `fix_shape`, `unify_same_domain`, wire/face/solid repair |
+| **Evolution** | Per-face history tracking across modifications |
+| **XCAF** | Assembly documents with colors, names, component hierarchies |
+
+See the [API docs](https://docs.rs/occt-wasm) for the complete list.
+
+## Performance
+
+First `OcctKernel::new()` decompresses ~4 MB of brotli and JIT-compiles the WASM module. Expect ~100–500 ms depending on the host. Subsequent calls run at native wasmtime speed — typically within ~2x of native OCCT for compute-heavy operations, and dominated by the wasmtime boundary crossing for tiny operations.
+
+Re-use one `OcctKernel` per worker thread; creation is the slow part, individual calls are cheap.
+
+## Features
+
+- `async` — opt-in tokio-based async runtime support.
+
+```toml
+[dependencies]
+occt-wasm = { version = "1", features = ["async"] }
+```
+
+## Errors
+
+All operations return `OcctResult<T>` (`Result<T, OcctError>`). The error enum carries the failing operation name and the OCCT error message:
+
+```rust,no_run
+# use occt_wasm::{OcctKernel, OcctError};
+# let mut kernel = OcctKernel::new()?;
+# let a = kernel.make_box(1.0, 1.0, 1.0)?;
+# let b = kernel.make_box(1.0, 1.0, 1.0)?;
+match kernel.fuse(a, b) {
+    Ok(result) => { /* ... */ }
+    Err(OcctError::Operation { operation, message }) => {
+        eprintln!("OCCT op {operation} failed: {message}");
+    }
+    Err(OcctError::Runtime(e)) => eprintln!("WASM runtime error: {e}"),
+    Err(OcctError::Memory(msg)) => eprintln!("memory error: {msg}"),
+}
+# Ok::<(), OcctError>(())
+```
+
+## Browser?
+
+This crate uses `wasmtime`, so it runs on native targets — Linux, macOS, Windows, BSDs, anything wasmtime supports. For browsers, use the [`occt-wasm` npm package](https://www.npmjs.com/package/occt-wasm), which loads the same `.wasm` file via Emscripten's JS glue and Embind.
+
+For higher-level CAD in TypeScript, see [brepjs](https://github.com/andymai/brepjs), which builds on the npm package.
+
+## License
+
+- **Crate / wrapper code**: MIT OR Apache-2.0
+- **Embedded WASM binary** (the OCCT build): LGPL-2.1-only, inherited from [OCCT](https://dev.opencascade.org/resources/download)
+
+The LGPL requires that end users can replace the LGPL component. Because this crate ships a pre-built WASM, replacement is possible by forking and rebuilding from the [`occt-wasm` repo](https://github.com/andymai/occt-wasm). If you're shipping a closed-source product, consult the [LGPL FAQ](https://www.gnu.org/licenses/lgpl-3.0.en.html).

--- a/crate/README.md
+++ b/crate/README.md
@@ -10,7 +10,7 @@ No C++ toolchain, no CMake, no system OCCT. Just `cargo add occt-wasm`.
 
 ```toml
 [dependencies]
-occt-wasm = "1"
+occt-wasm = "3"
 ```
 
 ## Why
@@ -85,7 +85,7 @@ Re-use one `OcctKernel` per worker thread; creation is the slow part, individual
 
 ```toml
 [dependencies]
-occt-wasm = { version = "1", features = ["async"] }
+occt-wasm = { version = "3", features = ["async"] }
 ```
 
 ## Errors
@@ -119,4 +119,4 @@ For higher-level CAD in TypeScript, see [brepjs](https://github.com/andymai/brep
 - **Crate / wrapper code**: MIT OR Apache-2.0
 - **Embedded WASM binary** (the OCCT build): LGPL-2.1-only, inherited from [OCCT](https://dev.opencascade.org/resources/download)
 
-The LGPL requires that end users can replace the LGPL component. Because this crate ships a pre-built WASM, replacement is possible by forking and rebuilding from the [`occt-wasm` repo](https://github.com/andymai/occt-wasm). If you're shipping a closed-source product, consult the [LGPL FAQ](https://www.gnu.org/licenses/lgpl-3.0.en.html).
+The LGPL requires that end users can replace the LGPL component. Because this crate ships a pre-built WASM, replacement is possible by forking and rebuilding from the [`occt-wasm` repo](https://github.com/andymai/occt-wasm). If you're shipping a closed-source product, consult the [LGPL-2.1 FAQ](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html).

--- a/crate/examples/cli.rs
+++ b/crate/examples/cli.rs
@@ -88,8 +88,10 @@ fn run(step_out: Option<&std::path::Path>) -> Result<(), OcctError> {
     // --- STEP export ---
     let step_data = kernel.export_step(final_shape)?;
     if let Some(path) = step_out {
-        fs::write(path, &step_data)
-            .map_err(|e| OcctError::Memory(format!("write {}: {e}", path.display())))?;
+        fs::write(path, &step_data).map_err(|e| OcctError::Operation {
+            operation: "export_step_write".to_owned(),
+            message: format!("write {}: {e}", path.display()),
+        })?;
         println!("\nSTEP exported to: {}", path.display());
     } else {
         println!("\nTip: pass --step output.step to export the result");

--- a/crate/examples/cli.rs
+++ b/crate/examples/cli.rs
@@ -1,0 +1,107 @@
+//! Standalone Rust example: shape creation, booleans, measurements, STEP I/O.
+//!
+//! Build & run from the repo root:
+//!
+//! ```sh
+//! cargo run --release --example cli -p occt-wasm
+//! cargo run --release --example cli -p occt-wasm -- --step output.step
+//! ```
+//!
+//! Note: `--release` is strongly recommended. Debug-mode wasmtime compilation
+//! is ~100x slower than release.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use occt_wasm::{OcctError, OcctKernel};
+
+fn main() -> ExitCode {
+    println!("occt-wasm Rust CLI Example\n");
+
+    let step_out: Option<PathBuf> = env::args()
+        .collect::<Vec<_>>()
+        .windows(2)
+        .find(|w| w[0] == "--step")
+        .map(|w| PathBuf::from(&w[1]));
+
+    match run(step_out.as_deref()) {
+        Ok(()) => {
+            println!("\nDone.");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("\nError: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(step_out: Option<&std::path::Path>) -> Result<(), OcctError> {
+    let mut kernel = OcctKernel::new()?;
+
+    // --- Create shapes ---
+    let box_shape = kernel.make_box(30.0, 20.0, 15.0)?;
+    let cyl = kernel.make_cylinder(6.0, 25.0)?;
+    let sphere = kernel.make_sphere(4.0)?;
+    let moved_sphere = kernel.translate(sphere, 15.0, 10.0, 15.0)?;
+
+    println!("Created: box 30x20x15, cylinder r=6 h=25, sphere r=4");
+
+    // --- Boolean operations ---
+    let with_hole = kernel.cut(box_shape, cyl)?;
+    let final_shape = kernel.fuse(with_hole, moved_sphere)?;
+
+    // --- Measurements ---
+    let vol = kernel.get_volume(final_shape)?;
+    let area = kernel.get_surface_area(final_shape)?;
+    let bbox = kernel.get_bounding_box(final_shape, true)?;
+
+    println!("\nResult:");
+    println!("  Volume:       {vol:.2} mm^3");
+    println!("  Surface area: {area:.2} mm^2");
+    println!(
+        "  Bounding box: [{:.1}, {:.1}, {:.1}] to [{:.1}, {:.1}, {:.1}]",
+        bbox.min.x, bbox.min.y, bbox.min.z, bbox.max.x, bbox.max.y, bbox.max.z
+    );
+
+    // --- Topology counts ---
+    let faces = kernel.get_sub_shapes(final_shape, "Face")?;
+    let edges = kernel.get_sub_shapes(final_shape, "Edge")?;
+    let verts = kernel.get_sub_shapes(final_shape, "Vertex")?;
+    println!(
+        "  Topology:     {} faces, {} edges, {} vertices",
+        faces.len(),
+        edges.len(),
+        verts.len()
+    );
+
+    // --- Tessellate (renderer-ready mesh) ---
+    let mesh = kernel.tessellate(final_shape, 0.1, 0.5)?;
+    println!(
+        "  Mesh:         {} vertices, {} triangles",
+        mesh.positions.len() / 3,
+        mesh.indices.len() / 3
+    );
+
+    // --- STEP export ---
+    let step_data = kernel.export_step(final_shape)?;
+    if let Some(path) = step_out {
+        fs::write(path, &step_data)
+            .map_err(|e| OcctError::Memory(format!("write {}: {e}", path.display())))?;
+        println!("\nSTEP exported to: {}", path.display());
+    } else {
+        println!("\nTip: pass --step output.step to export the result");
+    }
+
+    // --- STEP round-trip ---
+    let reimported = kernel.import_step(&step_data)?;
+    let reimported_vol = kernel.get_volume(reimported)?;
+    println!(
+        "  Round-trip:   export -> import, volume delta = {:.6}",
+        (vol - reimported_vol).abs()
+    );
+
+    Ok(())
+}

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -41,7 +41,7 @@
 //! by wasmtime. Shape data lives in an arena inside the WASM sandbox,
 //! referenced by opaque [`ShapeHandle`] values.
 
-#![doc(html_root_url = "https://docs.rs/occt-wasm/1.5.0")]
+#![doc(html_root_url = "https://docs.rs/occt-wasm/3.0.0")]
 // Generated code does cross-boundary integer casting (u32 <-> i32 for WASM ABI)
 // and has parameter names from the C++ facade that trigger similar_names.
 #![allow(


### PR DESCRIPTION
## Summary

- **Published `occt-wasm` v3.0.0 to crates.io** ([crates.io](https://crates.io/crates/occt-wasm/3.0.0) · [docs.rs](https://docs.rs/occt-wasm/3.0.0)). The crate had been built, tested, and codegen-driven since #82 but never shipped. Aligned the crate version with the npm package's headline version (v1.5.0 was pushed once briefly first to validate the pipeline; future releases use a single shared version).
- **Added a `crate/README.md`** so crates.io and docs.rs render a focused Rust pitch instead of just the description line. Showcased the crate from the root README too.
- **Added `crate/examples/cli.rs`** — runnable via `cargo run --release --example cli -p occt-wasm`, mirrors the Node CLI demo flow.
- **Added `.github/workflows/publish-crate.yml`** — OIDC trusted publishing via `rust-lang/crates-io-auth-action`. Triggered by `crate-v*` tag push or manual `workflow_dispatch`. Matches the existing npm OIDC pattern; no API tokens stored as repo secrets.

## First-publish gotchas (fixed)

- Workspace `repository = "git+https://..."` is a valid Cargo URL form but crates.io rejects it with HTTP 400 (`URL for field 'repository' must begin with http:// or https://`). Fixed to plain `https://...`.
- Crate `Cargo.toml` was missing `readme`, `documentation`, and `homepage` — added so the README ships in the package and crates.io's listing links resolve.

## One-time setup needed after merge (out of this PR)

To make the new workflow actually publish, two manual setups are required:

1. **crates.io** → Account Settings → Trusted Publishers → add this repo (`andymai/occt-wasm`), workflow filename `publish-crate.yml`, environment `crates-io`.
2. **GitHub repo** → Settings → Environments → create `crates-io` (optionally add protection rules for manual approval before publish).

Future release flow:
```
bump crate/Cargo.toml → commit → git tag crate-v3.0.1 → git push --tags
```

## Known follow-up (not blocking)

`crate/src/occt-wasm.wasm.br` has been untouched since #82 (rc4-era OCCT). Both the v1.5.0 and v3.0.0 publishes ship that stale WASM. Refresh via:
```sh
cargo xtask build-wasi --release
brotli -q 11 -o crate/src/occt-wasm.wasm.br target/wasm32-wasip1/release/occt-wasm.wasm
```
…commit, tag `crate-v3.0.1`, push.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo doc -p occt-wasm` builds
- [x] `cargo package --allow-dirty` succeeds at 4.4 MiB compressed (under 10 MB crates.io limit)
- [x] `cargo publish` succeeded for v1.5.0 and v3.0.0 (crate is live)
- [x] Workflow YAML validates with `yaml.safe_load`
- [x] No `${{ inputs.* }}` interpolation directly inside `run:` (passed via `env:` to avoid GHA injection)
- [ ] CI: lint + typecheck + WASM build on this branch
- [ ] After merge + one-time setup: test the new workflow with `gh workflow run publish-crate.yml --field version=3.0.1` (dry-run will fail unless 3.0.1 is in Cargo.toml — that's the version sanity check working)

Note: two parity tests (`parity-shell-sign`, `parity-tolerance`) fail locally on this branch **and on `main`** with stale local WASM — pre-existing, not caused by this PR. CI rebuilds the WASM fresh so they pass there.