### PR TITLE
fix(xtask): restore WASI build path via emcc -sSTANDALONE_WASM (closes #106)

### DIFF
--- a/xtask/src/build_wasi.rs
+++ b/xtask/src/build_wasi.rs
@@ -1,22 +1,26 @@
-//! WASI build pipeline: OCCT + facade → standalone `.wasm` for wasmtime.
+//! WASI build pipeline: facade + OCCT → standalone `.wasm` for wasmtime.
 //!
 //! This produces a WASI-compatible WASM binary with `extern "C"` exports
 //! instead of Embind. The output is consumed by the `occt-wasm` Rust crate.
 //!
-//! # Prerequisites
+//! Built with `em++ -sSTANDALONE_WASM=1`: same Emscripten toolchain as the
+//! npm build (`cargo xtask build`), but emitting a single self-contained
+//! wasm with WASI imports (`wasi_snapshot_preview1.*`) and no JS glue.
+//! Reuses the existing `occt/build/` Emscripten OCCT static libs.
 //!
-//! - **wasi-sdk** installed (set `WASI_SDK_PATH` or install to `/opt/wasi-sdk`)
-//! - OCCT source at `occt/` (git submodule)
-//! - Generated facade at `facade/generated/` (run `cargo xtask codegen` first)
+//! Why emcc-standalone instead of wasi-sdk: wasi-sdk's libc++abi.a ships
+//! without C++ exception runtime symbols (`__cxa_throw`, `__cxa_allocate_exception`,
+//! `_Unwind_*`), so OCCT — which throws `Standard_Failure` extensively — cannot
+//! link against it. emcc bundles its own libc++abi with full EH support.
 //!
 //! # Build steps
 //!
-//! 1. Configure OCCT with wasi-sdk clang via cmake
-//! 2. Build OCCT static libs
-//! 3. Compile facade + `wasi_exports.cpp`
-//! 4. Link into standalone WASI .wasm
-//! 5. wasm-opt post-processing (release only)
-//! 6. Brotli-compress → crate/src/occt-wasm.wasm.br
+//! 1. Compile facade + `wasi_exports.cpp` with em++ (Embind's `bindings.cpp`
+//!    is skipped — only the C ABI is needed for wasmtime consumption).
+//! 2. Link against `occt/build/` static libs with `em++ -sSTANDALONE_WASM=1`.
+//! 3. wasm-opt with `--experimental-new-eh` to convert emcc's legacy try/catch
+//!    (Phase 2 wasm-eh) to the exnref encoding (Phase 4) that wasmtime expects.
+//! 4. Brotli-compress → `crate/src/occt-wasm.wasm.br`.
 
 use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
@@ -24,146 +28,43 @@ use xshell::{Shell, cmd};
 
 use crate::util::project_root;
 
-/// Locate the wasi-sdk installation.
-fn find_wasi_sdk() -> Result<PathBuf> {
-    // Check WASI_SDK_PATH env var first
-    if let Ok(path) = std::env::var("WASI_SDK_PATH") {
-        let p = PathBuf::from(&path);
-        if p.join("bin/clang++").exists() {
-            return Ok(p);
-        }
-        bail!("WASI_SDK_PATH={path} does not contain bin/clang++");
-    }
-
-    // Common installation paths
-    let candidates = [
-        PathBuf::from("/opt/wasi-sdk"),
-        PathBuf::from("/usr/local/wasi-sdk"),
-    ];
-
-    for dir in &candidates {
-        if dir.join("bin/clang++").exists() {
-            return Ok(dir.clone());
-        }
-    }
-
-    bail!(
-        "wasi-sdk not found. Install it and set WASI_SDK_PATH, or install to /opt/wasi-sdk.\n\
-         Download from: https://github.com/WebAssembly/wasi-sdk/releases"
-    );
+#[allow(clippy::cast_precision_loss)]
+fn bytes_to_mb(n: u64) -> f64 {
+    n as f64 / 1_048_576.0
 }
 
-/// Step 1: Configure and build OCCT with wasi-sdk.
-fn build_occt_wasi(sh: &Shell, root: &Path, wasi_sdk: &Path) -> Result<PathBuf> {
-    let occt_dir = root.join("occt");
-    let build_dir = occt_dir.join("build-wasi");
+/// OCCT static libs not exercised by the WASI build's call graph. Excluding
+/// them shrinks the .wasm output without affecting functionality. Mirrors the
+/// exclusion list in `xtask::build` to keep the two paths in sync.
+const EXCLUDED_LIBS: &[&str] = &["libTKDraw.a"];
 
-    if !occt_dir.join("CMakeLists.txt").exists() {
-        bail!(
-            "OCCT source not found at {}. Run: git submodule update --init",
-            occt_dir.display()
-        );
-    }
-
-    sh.create_dir(&build_dir)?;
-
-    let clang = wasi_sdk.join("bin/clang");
-    let clangxx = wasi_sdk.join("bin/clang++");
-    let sysroot = wasi_sdk.join("share/wasi-sysroot");
-    let clang_str = clang.display().to_string();
-    let clangxx_str = clangxx.display().to_string();
-    let sysroot_str = sysroot.display().to_string();
-
-    // C code doesn't throw exceptions, so no -fwasm-exceptions needed
-    let c_flags = format!(
-        "--sysroot={sysroot_str} -fno-exceptions -O3 -msimd128 \
-         -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS"
-    );
-    let cxx_flags = format!(
-        "--sysroot={sysroot_str} -fwasm-exceptions -O3 -msimd128 \
-         -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS"
-    );
-    let rapidjson_inc = root.join("3rdparty/rapidjson").display().to_string();
-
-    // Skip if already configured
-    if build_dir.join("build.ninja").exists() {
-        eprintln!("Step 1a: OCCT-WASI already configured, skipping cmake.");
-    } else {
-        eprintln!("Step 1a: Configuring OCCT with wasi-sdk...");
-
-        sh.change_dir(&build_dir);
-        cmd!(
-            sh,
-            "cmake ..
-            -G Ninja
-            -DCMAKE_SYSTEM_NAME=WASI
-            -DCMAKE_SYSTEM_PROCESSOR=wasm32
-            -DCMAKE_C_COMPILER={clang_str}
-            -DCMAKE_CXX_COMPILER={clangxx_str}
-            -DCMAKE_SYSROOT={sysroot_str}
-            -DCMAKE_BUILD_TYPE=Release
-            -DBUILD_MODULE_FoundationClasses=TRUE
-            -DBUILD_MODULE_ModelingData=TRUE
-            -DBUILD_MODULE_ModelingAlgorithms=TRUE
-            -DBUILD_MODULE_DataExchange=TRUE
-            -DBUILD_MODULE_ApplicationFramework=TRUE
-            -DBUILD_MODULE_Visualization=FALSE
-            -DBUILD_MODULE_Draw=FALSE
-            -DBUILD_LIBRARY_TYPE=Static
-            -DUSE_FREETYPE=OFF
-            -DUSE_RAPIDJSON=ON
-            -D3RDPARTY_RAPIDJSON_INCLUDE_DIR={rapidjson_inc}
-            -DCMAKE_C_FLAGS={c_flags}
-            -DCMAKE_CXX_FLAGS={cxx_flags}
-            -Wno-dev"
-        )
-        .run()?;
-    }
-
-    eprintln!("Step 1b: Building OCCT-WASI...");
-    sh.change_dir(&build_dir);
-    cmd!(sh, "cmake --build . --parallel").run()?;
-
-    Ok(build_dir)
-}
-
-/// Step 2: Compile facade C++ files with wasi-sdk clang.
-fn compile_facade_wasi(
-    sh: &Shell,
-    root: &Path,
-    wasi_sdk: &Path,
-    occt_build: &Path,
-) -> Result<Vec<PathBuf>> {
+/// Step 1: Compile facade C++ files for the C-ABI WASI build.
+fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
     let build_dir = root.join("build-wasi");
     sh.create_dir(&build_dir)?;
 
-    let clangxx = wasi_sdk.join("bin/clang++");
-    let sysroot = wasi_sdk.join("share/wasi-sysroot");
-    let occt_inc = occt_build.join("include/opencascade");
+    let occt_inc = root.join("occt/build/include/opencascade");
+    if !occt_inc.exists() {
+        bail!(
+            "OCCT-Emscripten include dir not found at {}. Run `cargo xtask build-occt` first.",
+            occt_inc.display()
+        );
+    }
     let facade_inc = root.join("facade/include");
 
-    let clangxx_str = clangxx.display().to_string();
-    let sysroot_str = sysroot.display().to_string();
-    let occt_inc_str = occt_inc.display().to_string();
-    let facade_inc_str = facade_inc.display().to_string();
-
-    // Collect facade source files
     let mut sources: Vec<PathBuf> = vec![root.join("facade/src/kernel.cpp")];
 
-    // Add generated files (kernel.cpp for implementations, wasi_exports.cpp for C ABI)
     let gen_dir = root.join("facade/generated");
     if gen_dir.is_dir() {
-        for entry in std::fs::read_dir(&gen_dir)?.filter_map(Result::ok) {
+        // bindings.cpp is Embind-only; skip it for the C-ABI WASI build.
+        // wasi_exports.cpp is the C-ABI export layer — required here, skipped by
+        // the npm path in xtask::build.
+        for entry in std::fs::read_dir(&gen_dir)?.flatten() {
             let path = entry.path();
-            if path.extension().is_some_and(|e| e == "cpp") {
-                let name = path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_default();
-                // Skip bindings.cpp (Embind-only) for WASI build
-                if name != "bindings.cpp" {
-                    sources.push(path);
-                }
+            let is_cpp = path.extension().is_some_and(|e| e == "cpp");
+            let is_bindings = path.file_name().is_some_and(|n| n == "bindings.cpp");
+            if is_cpp && !is_bindings {
+                sources.push(path);
             }
         }
     }
@@ -173,20 +74,22 @@ fn compile_facade_wasi(
 
     for src in &sources {
         let name = src.file_stem().context("no file stem")?.to_string_lossy();
-        let obj = build_dir.join(format!("{name}.o"));
+        // Prefix generated outputs so kernel.cpp from src/ and generated/ don't
+        // collide on disk (and link to duplicate symbols).
+        let prefix = if src.starts_with(&gen_dir) {
+            "gen_"
+        } else {
+            ""
+        };
+        let obj = build_dir.join(format!("{prefix}{name}.o"));
 
-        eprintln!("  Compiling {name}.cpp (wasi-sdk)...");
-        let src_str = src.display().to_string();
-        let obj_str = obj.display().to_string();
-
+        eprintln!("  Compiling {name}.cpp...");
         cmd!(
             sh,
-            "{clangxx_str} --target=wasm32-wasi
-            --sysroot={sysroot_str}
-            -std=c++17 -fwasm-exceptions -O3 -msimd128
+            "em++ -std=c++17 -fwasm-exceptions -O3 -msimd128 -mrelaxed-simd
             -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS
-            -I{occt_inc_str} -I{facade_inc_str}
-            -w -c {src_str} -o {obj_str}"
+            -I{occt_inc} -I{facade_inc}
+            -w -c {src} -o {obj}"
         )
         .run()?;
 
@@ -196,100 +99,78 @@ fn compile_facade_wasi(
     Ok(objects)
 }
 
-/// Step 3: Link facade + OCCT static libs → standalone WASI .wasm
-fn link_wasi(
-    sh: &Shell,
-    root: &Path,
-    wasi_sdk: &Path,
-    occt_build: &Path,
-    objects: &[PathBuf],
-    release: bool,
-) -> Result<()> {
+/// Step 2: Link facade + OCCT static libs → standalone WASI .wasm.
+fn link(root: &Path, objects: &[PathBuf], release: bool) -> Result<PathBuf> {
     let dist_dir = root.join("dist");
-    sh.create_dir(&dist_dir)?;
+    std::fs::create_dir_all(&dist_dir)?;
 
-    let clangxx = wasi_sdk.join("bin/clang++");
-    let sysroot = wasi_sdk.join("share/wasi-sysroot");
-    let clangxx_str = clangxx.display().to_string();
-    let sysroot_str = sysroot.display().to_string();
-
-    // Find OCCT libs
-    let lib_dir = find_occt_wasi_lib_dir(occt_build)?;
-    let mut occt_libs: Vec<String> = std::fs::read_dir(&lib_dir)?
-        .filter_map(Result::ok)
+    let lib_dir = find_occt_lib_dir(&root.join("occt/build"))?;
+    let mut occt_libs: Vec<PathBuf> = std::fs::read_dir(&lib_dir)?
+        .flatten()
         .map(|e| e.path())
-        .filter(|p| p.extension().is_some_and(|e| e == "a"))
-        .map(|p| p.display().to_string())
+        .filter(|p| {
+            p.extension().is_some_and(|e| e == "a")
+                && !p
+                    .file_name()
+                    .is_some_and(|n| EXCLUDED_LIBS.contains(&n.to_string_lossy().as_ref()))
+        })
         .collect();
     occt_libs.sort();
 
-    let obj_strs: Vec<String> = objects.iter().map(|p| p.display().to_string()).collect();
     let output = dist_dir.join("occt-wasm-wasi.wasm");
-    let output_str = output.display().to_string();
+    let export_names = extract_export_names(&root.join("facade/generated/wasi_exports.cpp"))?;
+    eprintln!("  Exporting {} occt_* functions.", export_names.len());
 
     let opt_level = if release { "-O3" } else { "-O2" };
 
-    // Read export names from the generated wasi_exports.cpp
-    let wasi_exports_path = root.join("facade/generated/wasi_exports.cpp");
-    let export_names = extract_export_names(&wasi_exports_path)?;
-    eprintln!("  Exporting {} occt_* functions.", export_names.len());
-
-    let mut args: Vec<String> = vec![
-        "--target=wasm32-wasi".into(),
-        format!("--sysroot={sysroot_str}"),
-        "-fwasm-exceptions".into(),
-        "-msimd128".into(),
-        opt_level.into(),
-        "-Wl,--no-entry".into(),
-    ];
-    // Export only the occt_* functions + memory + malloc/free
-    for name in &export_names {
-        args.push(format!("-Wl,--export={name}"));
+    let mut cmd = std::process::Command::new("em++");
+    cmd.args([
+        "-fwasm-exceptions",
+        "-msimd128",
+        "-mrelaxed-simd",
+        opt_level,
+        "-sSTANDALONE_WASM=1",
+        "-sALLOW_MEMORY_GROWTH=1",
+        "-sINITIAL_MEMORY=134217728",
+        "-sMAXIMUM_MEMORY=4294967296",
+        "--no-entry",
+    ]);
+    for name in export_names
+        .iter()
+        .map(String::as_str)
+        .chain(["malloc", "free"])
+    {
+        cmd.arg(format!("-Wl,--export={name}"));
     }
-    args.push("-Wl,--export=malloc".into());
-    args.push("-Wl,--export=free".into());
-    args.push("-Wl,--export=memory".into());
-
     if release {
-        args.push("-flto".into());
+        cmd.arg("-flto");
     }
+    cmd.args(objects).args(&occt_libs).arg("-o").arg(&output);
 
-    args.extend(obj_strs);
-    args.extend(occt_libs);
-    args.push("-o".into());
-    args.push(output_str);
-
-    eprintln!("Step 3: Linking WASI WASM ({opt_level})...");
-
-    let status = std::process::Command::new(&clangxx_str)
-        .args(&args)
-        .status()
-        .context("failed to run wasi-sdk clang++")?;
-
+    eprintln!("Step 2: Linking WASI WASM ({opt_level})...");
+    let status = cmd.status().context("failed to run em++")?;
     if !status.success() {
-        bail!("WASI linking failed with status: {status}");
+        bail!("em++ linking failed with status: {status}");
     }
-
-    Ok(())
+    Ok(output)
 }
 
-/// Extract `occt_*` export names from the generated `wasi_exports.cpp`.
-///
-/// Looks for lines matching `<type> occt_<name>(` to find exported function names.
+/// Extract `occt_*` export names from generated `wasi_exports.cpp` by scanning
+/// for `<type> occt_<name>(` patterns.
 fn extract_export_names(wasi_exports_path: &Path) -> Result<Vec<String>> {
     let content = std::fs::read_to_string(wasi_exports_path)
         .context("failed to read wasi_exports.cpp — run `cargo xtask codegen` first")?;
     let mut names = Vec::new();
     for line in content.lines() {
-        // Match lines like "uint32_t occt_make_box(..." or "void occt_destroy() {"
         let Some(start) = line.find("occt_") else {
             continue;
         };
-        if let Some(paren) = line[start..].find('(') {
-            let name = &line[start..start + paren];
-            if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-                names.push(name.to_owned());
-            }
+        let Some(paren) = line[start..].find('(') else {
+            continue;
+        };
+        let name = &line[start..start + paren];
+        if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            names.push(name.to_owned());
         }
     }
     names.sort();
@@ -300,58 +181,80 @@ fn extract_export_names(wasi_exports_path: &Path) -> Result<Vec<String>> {
     Ok(names)
 }
 
-/// Locate OCCT static lib directory in the WASI build.
-fn find_occt_wasi_lib_dir(occt_build: &Path) -> Result<PathBuf> {
-    let candidates = [
-        occt_build.join("lib"),
-        occt_build.join("lin32/clang/lib"),
-        occt_build.join("wasm32/clang/lib"),
-    ];
-    for dir in &candidates {
-        if dir.exists() {
-            return Ok(dir.clone());
-        }
-    }
-    bail!(
-        "OCCT-WASI static libs not found in: {}",
-        candidates
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
+/// Locate the OCCT static-lib directory in an Emscripten build tree.
+fn find_occt_lib_dir(occt_build: &Path) -> Result<PathBuf> {
+    let candidates = ["lib", "lin32/clang/lib", "wasm32/clang/lib"];
+    candidates
+        .iter()
+        .map(|c| occt_build.join(c))
+        .find(|p| p.exists())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "OCCT static libs not found under {}; tried: {}",
+                occt_build.display(),
+                candidates.join(", "),
+            )
+        })
 }
 
-/// Step 4: Brotli-compress and copy to crate/src/.
-fn compress_and_install(root: &Path) -> Result<()> {
-    let wasm = root.join("dist/occt-wasm-wasi.wasm");
-    let output = root.join("crate/src/occt-wasm.wasm.br");
+/// Step 3: Run wasm-opt to convert emcc's legacy exception encoding to the
+/// new exnref encoding that wasmtime accepts when `wasm_exceptions(true)` is set.
+fn convert_eh(sh: &Shell, wasm: &Path) -> Result<()> {
+    let wasm_opt = find_wasm_opt();
+    eprintln!("Step 3: wasm-opt --experimental-new-eh...");
+    cmd!(
+        sh,
+        "{wasm_opt} {wasm}
+        --translate-to-new-eh --experimental-new-eh
+        --strip-debug --strip-producers
+        --enable-bulk-memory --enable-sign-ext
+        --enable-nontrapping-float-to-int --enable-mutable-globals
+        --enable-exception-handling --enable-reference-types --enable-multivalue
+        --enable-simd --enable-tail-call --enable-relaxed-simd
+        -o {wasm}"
+    )
+    .run()?;
+    Ok(())
+}
 
+fn find_wasm_opt() -> PathBuf {
+    let candidate = std::env::var("EMSDK")
+        .ok()
+        .map(|e| PathBuf::from(e).join("upstream/bin/wasm-opt"));
+    if let Some(p) = candidate.filter(|p| p.exists()) {
+        return p;
+    }
+    if let Some(home) = std::env::var("HOME").ok().map(PathBuf::from) {
+        let p = home.join("emsdk/upstream/bin/wasm-opt");
+        if p.exists() {
+            return p;
+        }
+    }
+    PathBuf::from("wasm-opt")
+}
+
+/// Step 4: Brotli-compress and install into crate/src/.
+fn compress_and_install(root: &Path, wasm: &Path) -> Result<()> {
+    let output = root.join("crate/src/occt-wasm.wasm.br");
     if !wasm.exists() {
         bail!("WASI WASM not found at {}", wasm.display());
     }
 
     eprintln!("Step 4: Brotli-compressing...");
-    let input_bytes = std::fs::read(&wasm)?;
+    let input_bytes = std::fs::read(wasm)?;
     let mut output_bytes = Vec::new();
-
     let params = brotli::enc::BrotliEncoderParams {
         quality: 11,
         ..Default::default()
     };
-
     brotli::BrotliCompress(&mut input_bytes.as_slice(), &mut output_bytes, &params)
         .context("brotli compression failed")?;
-
     std::fs::write(&output, &output_bytes)?;
 
-    #[allow(clippy::cast_precision_loss)]
-    let raw_mb = input_bytes.len() as f64 / 1_048_576.0;
-    #[allow(clippy::cast_precision_loss)]
-    let br_mb = output_bytes.len() as f64 / 1_048_576.0;
+    let raw_mb = bytes_to_mb(input_bytes.len() as u64);
+    let br_mb = bytes_to_mb(output_bytes.len() as u64);
     eprintln!("  {raw_mb:.1} MB → {br_mb:.1} MB (brotli)");
     eprintln!("  Installed to {}", output.display());
-
     Ok(())
 }
 
@@ -360,36 +263,21 @@ pub fn build_wasi(release: bool) -> Result<()> {
     let root = project_root()?;
     let sh = Shell::new()?;
 
-    let wasi_sdk = find_wasi_sdk()?;
-    eprintln!("Using wasi-sdk at: {}", wasi_sdk.display());
-
-    // Ensure codegen has been run
-    let gen_wasi = root.join("facade/generated/wasi_exports.cpp");
-    if !gen_wasi.exists() {
+    if !root.join("facade/generated/wasi_exports.cpp").exists() {
         eprintln!("Generated facade not found, running codegen...");
         crate::codegen::run::run()?;
     }
 
-    // Step 1: Build OCCT with wasi-sdk
-    let occt_build = build_occt_wasi(&sh, &root, &wasi_sdk)?;
-
-    // Step 2: Compile facade
-    eprintln!("Step 2: Compiling facade (wasi-sdk)...");
-    let objects = compile_facade_wasi(&sh, &root, &wasi_sdk, &occt_build)?;
+    eprintln!("Step 1: Compiling facade...");
+    let objects = compile_facade(&sh, &root)?;
     eprintln!("  {} object files ready.", objects.len());
 
-    // Step 3: Link
-    link_wasi(&sh, &root, &wasi_sdk, &occt_build, &objects, release)?;
+    let wasm = link(&root, &objects, release)?;
+    convert_eh(&sh, &wasm)?;
+    compress_and_install(&root, &wasm)?;
 
-    // Step 4: Compress and install
-    compress_and_install(&root)?;
-
-    let wasm_path = root.join("dist/occt-wasm-wasi.wasm");
-    if wasm_path.exists() {
-        #[allow(clippy::cast_precision_loss)]
-        let size_mb = std::fs::metadata(&wasm_path)?.len() as f64 / 1_048_576.0;
-        eprintln!("WASI build complete: dist/occt-wasm-wasi.wasm ({size_mb:.1}MB)");
-    }
+    let size_mb = bytes_to_mb(std::fs::metadata(&wasm)?.len());
+    eprintln!("WASI build complete: {} ({size_mb:.1}MB)", wasm.display());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Restores the WASI build path that bit-rotted per #106. **The root cause turned out to be deeper than the issue described.**

## What I found

1. `wasi-sdk`'s `libc++abi.a` ships **without** C++ exception runtime symbols (`__cxa_throw`, `__cxa_allocate_exception`, `_Unwind_*`) in every released version (22, 24, 25, ... 33). Verified by scanning every `.a` in each sysroot.
2. OCCT throws `Standard_Failure` extensively, so it cannot link against any wasi-sdk sysroot.
3. **The existing crate `.wasm.br` shipped at PR #82 was actually `emcc -sSTANDALONE_WASM=1` output**, not wasi-sdk. Verified by inspecting its imports: `env.emscripten_get_callstack`, `env.__syscall_*`, etc. alongside `wasi_snapshot_preview1.*`. The `xtask/src/build_wasi.rs` that called wasi-sdk clang was aspirational and never produced what shipped.

## What this PR does

Rewrites `xtask::build_wasi` to match what actually ships:

- Drops the entire wasi-sdk download / install / sysroot / target / `-pthread` / `-lwasi-emulated-*` machinery.
- Reuses the existing `occt/build/` Emscripten static libs — same toolchain as `cargo xtask build`.
- Compiles `facade/src/kernel.cpp` + generated `kernel.cpp` + `wasi_exports.cpp` with em++ (Embind's `bindings.cpp` is skipped).
- Links with `em++ -sSTANDALONE_WASM=1` + raw `-Wl,--export=` of every `occt_*` symbol + malloc/free. No JS module, no MODULARIZE, no `-lembind`.
- Runs `wasm-opt --translate-to-new-eh --experimental-new-eh` so wasmtime's `wasm_exceptions(true)` config accepts the binary.
- Brotli-compresses → `crate/src/occt-wasm.wasm.br`.

## Result

22.5 MB raw WASM → 4.6 MB brotli. **18 imports** (env.* + wasi_snapshot_preview1.*) vs **30 imports** in the previous shipped blob (which still pulled Emscripten JS callbacks).

## Test plan

- [x] `cargo check -p xtask` clean
- [x] `cargo clippy -p xtask --all-targets` clean
- [x] `docker run` of the new xtask in the builder image produces a valid WASM
- [x] `cargo test --release -p occt-wasm` — **14/14 integration tests pass** against the rebuilt `.wasm.br`
- [ ] CI Build WASI workflow green (Layer 2 PR adds the gate)

## Stack

This is **Layer 1 of 3**:
1. **fix(xtask): WASI build via emcc-standalone** ← this PR (base: main)
2. ci: add build-wasi.yml stale-check (base: this PR)
3. release(crate): v3.0.1 with fresh .wasm.br (base: layer 2)

Closes #106.