### PR TITLE
release(crate): v3.0.1 — first emcc-standalone WASM refresh (#106)

### DIFF
--- a/.github/workflows/build-wasi.yml
+++ b/.github/workflows/build-wasi.yml
@@ -1,0 +1,85 @@
+name: Build WASI
+
+# Refreshes the embedded `crate/src/occt-wasm.wasm.br` shipped to crates.io and
+# fails when the committed bytes drift from what the current sources produce.
+#
+# Uses the existing `ghcr.io/andymai/occt-wasm-builder` image — same emcc
+# toolchain + pre-built OCCT static libs as the npm build. xtask::build_wasi
+# compiles the C-ABI facade and links with `em++ -sSTANDALONE_WASM=1`, so the
+# only thing this workflow does on top is run the build, brotli, and diff.
+
+on:
+  pull_request:
+    paths:
+      - facade/**
+      - xtask/src/**
+      - 3rdparty/**
+      - crate/src/occt-wasm.wasm.br
+      - .gitmodules
+      - .github/workflows/build-wasi.yml
+  push:
+    branches: [main]
+    paths:
+      - facade/**
+      - xtask/src/**
+      - 3rdparty/**
+      - crate/src/occt-wasm.wasm.br
+      - .gitmodules
+      - .github/workflows/build-wasi.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-wasi-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: WASI build + stale-check
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/andymai/occt-wasm-builder:latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Link pre-built OCCT libs from builder image
+        run: |
+          cp -r /workspace/occt/build occt/build
+          cp -r /workspace/3rdparty 3rdparty
+
+      - name: Snapshot committed crate WASM
+        # Snapshot before the build overwrites the file. cmp works without
+        # needing a usable .git inside the container.
+        run: cp crate/src/occt-wasm.wasm.br /tmp/committed.wasm.br
+
+      - name: Build WASI WASM + brotli install
+        run: cargo xtask build-wasi --release
+
+      - name: Stale-check vs. committed crate WASM
+        id: stale
+        shell: bash
+        run: |
+          set -euo pipefail
+          new_size=$(stat -c%s crate/src/occt-wasm.wasm.br)
+          if cmp -s /tmp/committed.wasm.br crate/src/occt-wasm.wasm.br; then
+            echo "crate/src/occt-wasm.wasm.br is up to date ($new_size bytes)."
+          else
+            echo "::error file=crate/src/occt-wasm.wasm.br::Committed bytes diverge from the rebuild. Regenerate locally with: cargo xtask build-wasi --release && git add crate/src/occt-wasm.wasm.br. The fresh artifact is uploaded to this run."
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload fresh .wasm.br when stale
+        if: steps.stale.outputs.stale == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: occt-wasm.wasm.br-fresh
+          path: crate/src/occt-wasm.wasm.br
+          retention-days: 14
+
+      - name: Fail when stale
+        if: steps.stale.outputs.stale == 'true'
+        run: exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "occt-wasm"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "brotli",
  "thiserror 2.0.18",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "occt-wasm"
-version = "3.0.0"
+version = "3.0.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -41,7 +41,7 @@
 //! by wasmtime. Shape data lives in an arena inside the WASM sandbox,
 //! referenced by opaque [`ShapeHandle`] values.
 
-#![doc(html_root_url = "https://docs.rs/occt-wasm/3.0.0")]
+#![doc(html_root_url = "https://docs.rs/occt-wasm/3.0.1")]
 // Generated code does cross-boundary integer casting (u32 <-> i32 for WASM ABI)
 // and has parameter names from the C++ facade that trigger similar_names.
 #![allow(


### PR DESCRIPTION
## Summary

Bumps the `occt-wasm` crate from 3.0.0 to 3.0.1 and commits a freshly-built `crate/src/occt-wasm.wasm.br`. This is the first refresh since PR #82 (April 2026, OCCT rc4 era) — picks up the facade fixes from PRs #94, #98, the OCCT 8.0.0.beta2 bump from #100, and everything since.

## What's in the new .wasm.br

| | before (Apr 11) | after |
|---|---|---|
| raw | 23.2 MB | 22.5 MB |
| brotli | 4.62 MB | 4.66 MB |
| imports | 30 (incl. emscripten_*, __syscall_*) | 18 (only env.* + wasi_snapshot_preview1.*) |
| OCCT | rc4 | 8.0.0.beta2 |
| facade fixes | pre-#98 | current main |

The new build comes from the rewritten `xtask::build_wasi` (#107) using `em++ -sSTANDALONE_WASM=1` + `wasm-opt --experimental-new-eh`.

## Test plan

- [x] `cargo test --release -p occt-wasm` — **14/14 integration tests pass** against the new bytes
- [x] WASM imports verified — wasi_snapshot_preview1.* + env.* only, no JS callbacks
- [ ] Build WASI workflow (Layer 2) green on this PR — its job here is to confirm `.wasm.br` matches a fresh rebuild

## Publish

After merge, on `main`:
```sh
git tag crate-v3.0.1
git push origin crate-v3.0.1
```

`publish-crate.yml` + crates.io trusted publishing handle the rest.

## Stack

**Layer 3 of 3.** Base: #108.

Closes the original ask in #106 (publish a v3.0.x with a freshly-built embedded WASM).