### PR TITLE
chore: harden supply chain against npm + actions attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       actions:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      npm:
+        patterns: ["*"]
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: npm
+    directory: /ts
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      npm:
+        patterns: ["*"]
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,7 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+      semver-major-days: 14
     groups:
       actions:
         patterns: ["*"]

--- a/.github/workflows/build-wasi.yml
+++ b/.github/workflows/build-wasi.yml
@@ -42,7 +42,7 @@ jobs:
     container:
       image: ghcr.io/andymai/occt-wasm-builder:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload fresh .wasm.br when stale
         if: steps.stale.outputs.stale == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: occt-wasm.wasm.br-fresh
           path: crate/src/occt-wasm.wasm.br

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: ghcr.io/andymai/occt-wasm-builder:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
@@ -29,7 +29,7 @@ jobs:
           cp -r /workspace/3rdparty 3rdparty
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 
@@ -56,7 +56,7 @@ jobs:
         run: set -o pipefail; npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: occt-wasm-dist
           path: ts/dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Lint & Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -25,7 +25,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -34,7 +34,7 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -72,17 +72,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: package-lock.json
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: occt-wasm-dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.95"
           components: rustfmt, clippy

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,47 @@
+name: OSV Scan
+
+# Defense complement to Dependabot cooldown. Cooldown blocks fresh-but-untrusted
+# in PR proposals; OSV catches old-but-known-bad in the lockfiles. Scans every
+# lockfile in the repo (root + ts/ npm, root Cargo).
+# PRs are report-only; main + weekly schedule fail closed.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan-pr:
+    name: OSV Scan (report-only)
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=Cargo.lock
+        --lockfile=package-lock.json
+        --lockfile=ts/package-lock.json
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+  scan-main:
+    name: OSV Scan (blocking)
+    if: github.event_name != 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=Cargo.lock
+        --lockfile=package-lock.json
+        --lockfile=ts/package-lock.json
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -15,7 +15,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Don't cancel in-progress main/schedule scans — a rapid second push would
+  # otherwise leave the older commit's lockfile unscanned.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   scan-pr:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
@@ -33,7 +33,7 @@ jobs:
       # (added in npm 11.5.1). Avoids the in-place npm self-upgrade bug
       # (`MODULE_NOT_FOUND: promise-retry`) that bites Node 22's npm 10.x.
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           registry-url: https://registry.npmjs.org
@@ -42,7 +42,7 @@ jobs:
         run: cd ts && npm ci
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: occt-wasm-dist
           path: ts/dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           manifest-file: .release-please-manifest.json
@@ -56,7 +56,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
 
@@ -64,7 +64,7 @@ jobs:
       # (added in npm 11.5.1). Avoids the in-place npm self-upgrade bug
       # (`MODULE_NOT_FOUND: promise-retry`) that bites Node 22's npm 10.x.
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           registry-url: https://registry.npmjs.org
@@ -73,7 +73,7 @@ jobs:
         run: cd ts && npm ci
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: occt-wasm-dist
           path: ts/dist/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,3 +9,15 @@ If you discover a security vulnerability, please report it by emailing the maint
 The occt-wasm build tooling (xtask, Dockerfile, scripts) is MIT/Apache-2.0 licensed.
 
 The compiled WASM output inherits OCCT's LGPL-2.1 license and includes OCCT's C++ code. Security issues in OCCT itself should be reported to [OpenCascade](https://dev.opencascade.org/).
+
+## Supply Chain
+
+In response to the 2025–2026 wave of npm and GitHub Actions supply-chain attacks (Shai-Hulud worm, chalk/debug compromise, tj-actions tag retag, prt-scan AI campaign), the build is configured to fail closed on the patterns those attacks exploited:
+
+| Defense | Where | What it blocks |
+|---|---|---|
+| All GitHub Actions pinned to commit SHA | `.github/workflows/*.yml` | Tag-retag attacks (tj-actions class). |
+| OSV scan against `Cargo.lock` + both `package-lock.json` files (PRs report-only, main blocking) | `.github/workflows/osv-scan.yml` | Known-CVE versions in any ecosystem. |
+| Dependabot cooldown (7d default / 14d major) across cargo, npm (root + `ts/`), github-actions | `.github/dependabot.yml` | Fresh malicious uploads. |
+
+Direct install-time cooldown via `.npmrc` `min-release-age` is not enabled here: npm bundled with Node 24 is 11.6.1, which silently ignores the field (added in npm 11.10). Revisit once Node ships a newer npm.


### PR DESCRIPTION
## Summary

Same hardening pattern as the gridfinity-layout-tool reference PR; adapted for a Rust+npm repo with a root package.json (build tooling) and `ts/` package (published occt-wasm).

| Defense | What it blocks |
|---|---|
| All Actions SHA-pinned across 5 workflows | tj-actions tag-retag class. |
| OSV scan against `Cargo.lock` + root `package-lock.json` + `ts/package-lock.json` | Known-CVE versions in any ecosystem. |
| New Dependabot config with cooldown across cargo + 2 npm dirs + github-actions | Fresh malicious version proposals. |

## Changes

- 13 unique `uses:` references pinned (actions/checkout, setup-node, download-artifact, upload-artifact, Swatinem/rust-cache, googleapis/release-please-action). Kept on existing major versions (v4); Dependabot can surface major upgrades separately.
- `.github/dependabot.yml`: new (none existed).
- `.github/workflows/osv-scan.yml`: new.
- `SECURITY.md`: appended Supply Chain section.

## Test plan

- [ ] CI green
- [ ] OSV scan workflow runs (first invocation)