### PR TITLE
test: address PR #121 review feedback

### DIFF
--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -278,8 +278,9 @@ describe("sweeps", () => {
 
     it("loft through three monotonic sections produces a non-degenerate solid", () => {
         // Sections must taper monotonically (10 -> 8 -> 6); a non-monotonic
-        // profile builds a self-intersecting loft that corrupts WASM memory
-        // on OCCT V8.0.0 — see new-features.test.ts for the documented gap.
+        // profile builds a self-intersecting loft that corrupts WASM memory on
+        // OCCT V8.0.0 — same failure mode as the filletVariable gap tracked in
+        // new-features.test.ts ("OCCT V8.0.0 known gaps").
         const wireVec = new Module.VectorUint32();
         wireVec.push_back(makeSquareWireAt(10, 0));
         wireVec.push_back(makeSquareWireAt(8, 10));

--- a/test/expanded.test.ts
+++ b/test/expanded.test.ts
@@ -288,7 +288,7 @@ describe("I/O extended", () => {
         const imported = kernel.importStl(ascii);
         expect(imported).toBeGreaterThan(0);
         expect(kernel.isNull(imported)).toBe(false);
-        expect(kernel.getShapeType(imported)).not.toBe("");
+        expect(["shell", "compound", "solid"]).toContain(kernel.getShapeType(imported));
     });
 });
 


### PR DESCRIPTION
Addresses the two Greptile P2 comments on #121 (which had already merged):

- **`test/expanded.test.ts`** — tighten the STL round-trip assertion from `not.toBe("")` (only excludes empty string) to `expect(["shell", "compound", "solid"]).toContain(...)`, giving it real regression-detection value. V8.0.0's `importStl` returns a `compound` for a well-formed ASCII box.
- **`test/api-coverage.test.ts`** — the multi-section loft comment claimed "see new-features.test.ts for the documented gap," but only `filletVariable` is tracked there. Reworded to reference the `filletVariable` gap and shared failure mode instead of implying a loft-specific skip entry.

Comment-and-assertion only; no behavior change. Both files green locally (123 tests).