### PR TITLE
chore(deps-dev): bump brace-expansion to 5.0.6

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "occt-wasm",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "occt-wasm",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "comlink": "^4.4.2"
@@ -1051,9 +1051,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Resolves `GHSA-jxxr-4gwj-5jf2` (medium 6.5, ReDoS in `brace-expansion`), which the blocking OSV scan fails-closed on for every push to `main`.

- Transitive **dev-only** dependency in `ts/package-lock.json`; 5.0.5 → 5.0.6.
- Lockfile-only change (no `package.json` edit; 5.0.6 satisfies the existing range).
- `npm audit` now reports 0 vulnerabilities.