### PR TITLE
fix: makeHelixWire undershoots height and length

### DIFF
--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -1315,7 +1315,12 @@ uint32_t OcctKernel::makeHelixWire(double px, double py, double pz, double dx, d
         // A helix on a cylindrical surface is a 2D line: u = t, v = pitch/(2*pi) * t
         double slope = pitch / (2.0 * M_PI);
         double nTurns = height / pitch;
-        double uMax = nTurns * 2.0 * M_PI;
+        // gp_Dir2d normalizes (1, slope) to unit length, so advancing the edge
+        // parameter by t moves only t / sqrt(1 + slope^2) along u (the angle). Scale
+        // the parameter range by that length so the edge actually sweeps nTurns full
+        // turns and the full height instead of falling short.
+        double dirLen = std::sqrt(1.0 + slope * slope);
+        double uMax = nTurns * 2.0 * M_PI * dirLen;
         
         Handle(Geom2d_Line) line2d = new Geom2d_Line(gp_Pnt2d(0, 0), gp_Dir2d(1, slope));
         

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -1390,7 +1390,12 @@ Handle(Geom_CylindricalSurface) cylinder = new Geom_CylindricalSurface(ax3, radi
 // A helix on a cylindrical surface is a 2D line: u = t, v = pitch/(2*pi) * t
 double slope = pitch / (2.0 * M_PI);
 double nTurns = height / pitch;
-double uMax = nTurns * 2.0 * M_PI;
+// gp_Dir2d normalizes (1, slope) to unit length, so advancing the edge
+// parameter by t moves only t / sqrt(1 + slope^2) along u (the angle). Scale
+// the parameter range by that length so the edge actually sweeps nTurns full
+// turns and the full height instead of falling short.
+double dirLen = std::sqrt(1.0 + slope * slope);
+double uMax = nTurns * 2.0 * M_PI * dirLen;
 
 Handle(Geom2d_Line) line2d = new Geom2d_Line(gp_Pnt2d(0, 0), gp_Dir2d(1, slope));
 


### PR DESCRIPTION
## Problem

`makeHelixWire` builds the helix as a 2D line on a cylindrical surface using `gp_Dir2d(1, slope)`. `gp_Dir2d` **normalizes** its direction to unit length, so advancing the edge parameter by `uMax = nTurns * 2*pi` only moves `uMax / sqrt(1 + slope^2)` along `u` (the angle). The helix therefore fell short of both the requested turn count and the requested height, and its arc length came out as the flat stacked circumference — the pitch contribution was silently lost.

Measured against the brepjs `occt` reference kernel (same inputs):

| input | reported length | correct length |
|-------|----------------|----------------|
| pitch=1, height=5, r=1 | 31.4159 (= 5·2π) | 31.8113 |
| pitch=3, height=9, r=2 | 34.9762 | 38.7585 |

Reported height was likewise short (e.g. 4.938 vs 5.0).

## Fix

Scale the parameter range by the 2D direction length `sqrt(1 + slope^2)`:

```cpp
double dirLen = std::sqrt(1.0 + slope * slope);
double uMax = nTurns * 2.0 * M_PI * dirLen;
```

This makes the edge sweep the full `nTurns` turns and full height. Arc length then equals `nTurns * sqrt((2*pi*r)^2 + pitch^2)`, verified analytically and against every measured value above.

## Changes
- `xtask/src/codegen/config.rs` — source of truth (`makeHelixWire` custom body)
- `facade/generated/kernel.cpp` — regenerated via `cargo xtask codegen`

## Verification
Math-verified exact (length, height, and turn count). **Not yet runtime-verified** — needs a WASM rebuild. Surfaced by the brepjs #1136 occt-wasm parity audit.