### PR TITLE
perf(ts): bulk-marshal large arrays across the WASM boundary (~2.3x)

### DIFF
--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -296,5 +296,12 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("xcafGetRootLabels", &OcctKernel::xcafGetRootLabels)
         .function("xcafExportSTEP", &OcctKernel::xcafExportSTEP)
         .function("xcafImportSTEP", &OcctKernel::xcafImportSTEP)
-        .function("xcafExportGLTF", &OcctKernel::xcafExportGLTF);
+        .function("xcafExportGLTF", &OcctKernel::xcafExportGLTF)
+
+        // marshal
+        .function("allocBytes", &OcctKernel::allocBytes)
+        .function("freeBytes", &OcctKernel::freeBytes)
+        .function("vectorF64FromHeap", &OcctKernel::vectorF64FromHeap)
+        .function("vectorU32FromHeap", &OcctKernel::vectorU32FromHeap)
+        .function("vectorI32FromHeap", &OcctKernel::vectorI32FromHeap);
 }

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -147,6 +147,7 @@
 #include <gp_Pnt2d.hxx>
 #include <gp_Trsf.hxx>
 #include <gp_Vec.hxx>
+#include <stdexcept>
 
 #include <algorithm>
 #include <cmath>
@@ -3680,48 +3681,31 @@ std::string OcctKernel::xcafExportGLTF(uint32_t docId, double linDeflection, dou
 // === marshal ===
 
 int OcctKernel::allocBytes(int byteCount) {
-    try {
-        return static_cast<int>(
-            reinterpret_cast<uintptr_t>(std::malloc(static_cast<size_t>(byteCount))));
-    } catch (const Standard_Failure& e) {
-        throw std::runtime_error(std::string("allocBytes: ") + e.what());
+    void* p = std::malloc(static_cast<size_t>(byteCount));
+    if (!p) {
+        throw std::runtime_error("allocBytes: malloc failed (out of WASM linear memory)");
     }
+    return static_cast<int>(reinterpret_cast<uintptr_t>(p));
 }
 
 void OcctKernel::freeBytes(int ptr) {
-    try {
-        std::free(reinterpret_cast<void*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr))));
-    } catch (const Standard_Failure& e) {
-        throw std::runtime_error(std::string("freeBytes: ") + e.what());
-    }
+    std::free(reinterpret_cast<void*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr))));
 }
 
 std::vector<double> OcctKernel::vectorF64FromHeap(int ptr, int count) {
-    try {
-        const double* p =
-            reinterpret_cast<const double*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
-        return std::vector<double>(p, p + count);
-    } catch (const Standard_Failure& e) {
-        throw std::runtime_error(std::string("vectorF64FromHeap: ") + e.what());
-    }
+    const double* p =
+        reinterpret_cast<const double*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
+    return std::vector<double>(p, p + count);
 }
 
 std::vector<uint32_t> OcctKernel::vectorU32FromHeap(int ptr, int count) {
-    try {
-        const uint32_t* p =
-            reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
-        return std::vector<uint32_t>(p, p + count);
-    } catch (const Standard_Failure& e) {
-        throw std::runtime_error(std::string("vectorU32FromHeap: ") + e.what());
-    }
+    const uint32_t* p =
+        reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
+    return std::vector<uint32_t>(p, p + count);
 }
 
 std::vector<int> OcctKernel::vectorI32FromHeap(int ptr, int count) {
-    try {
-        const int* p =
-            reinterpret_cast<const int*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
-        return std::vector<int>(p, p + count);
-    } catch (const Standard_Failure& e) {
-        throw std::runtime_error(std::string("vectorI32FromHeap: ") + e.what());
-    }
+    const int* p =
+        reinterpret_cast<const int*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
+    return std::vector<int>(p, p + count);
 }

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -132,6 +132,7 @@
 #include <XCAFDoc_ColorTool.hxx>
 #include <XCAFDoc_DocumentTool.hxx>
 #include <XCAFDoc_ShapeTool.hxx>
+#include <cstdlib>
 #include <gp_Ax1.hxx>
 #include <gp_Ax2.hxx>
 #include <gp_Ax3.hxx>
@@ -3673,5 +3674,54 @@ std::string OcctKernel::xcafExportGLTF(uint32_t docId, double linDeflection, dou
         return tmpPath;
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("xcafExportGLTF: ") + e.what());
+    }
+}
+
+// === marshal ===
+
+int OcctKernel::allocBytes(int byteCount) {
+    try {
+        return static_cast<int>(
+            reinterpret_cast<uintptr_t>(std::malloc(static_cast<size_t>(byteCount))));
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("allocBytes: ") + e.what());
+    }
+}
+
+void OcctKernel::freeBytes(int ptr) {
+    try {
+        std::free(reinterpret_cast<void*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr))));
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("freeBytes: ") + e.what());
+    }
+}
+
+std::vector<double> OcctKernel::vectorF64FromHeap(int ptr, int count) {
+    try {
+        const double* p =
+            reinterpret_cast<const double*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
+        return std::vector<double>(p, p + count);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("vectorF64FromHeap: ") + e.what());
+    }
+}
+
+std::vector<uint32_t> OcctKernel::vectorU32FromHeap(int ptr, int count) {
+    try {
+        const uint32_t* p =
+            reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
+        return std::vector<uint32_t>(p, p + count);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("vectorU32FromHeap: ") + e.what());
+    }
+}
+
+std::vector<int> OcctKernel::vectorI32FromHeap(int ptr, int count) {
+    try {
+        const int* p =
+            reinterpret_cast<const int*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));
+        return std::vector<int>(p, p + count);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("vectorI32FromHeap: ") + e.what());
     }
 }

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -396,6 +396,15 @@ class OcctKernel {
     uint32_t fixFaceOrientations(uint32_t id);
     uint32_t removeDegenerateEdges(uint32_t id);
 
+    // --- Bulk array marshalling (Embind heap transfer) ---
+    // Lets the JS wrapper hand large arrays to the kernel in one HEAP copy
+    // instead of N per-element push_back() boundary crossings.
+    int allocBytes(int byteCount);
+    void freeBytes(int ptr);
+    std::vector<double> vectorF64FromHeap(int ptr, int count);
+    std::vector<uint32_t> vectorU32FromHeap(int ptr, int count);
+    std::vector<int> vectorI32FromHeap(int ptr, int count);
+
   private:
     uint32_t store(const TopoDS_Shape& shape);
     const TopoDS_Shape& get(uint32_t id) const;

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -414,6 +414,14 @@ export interface OcctRawKernel {
     xcafImportSTEP(stepData: string): number;
     xcafExportGLTF(docId: number, linDefl: number, angDefl: number): string;
 
+    // Bulk array marshalling — move large arrays in one HEAP copy instead of
+    // N per-element push_back() boundary crossings.
+    allocBytes(byteCount: number): number;
+    freeBytes(ptr: number): void;
+    vectorF64FromHeap(ptr: number, count: number): EmbindVectorF64;
+    vectorU32FromHeap(ptr: number, count: number): EmbindVectorU32;
+    vectorI32FromHeap(ptr: number, count: number): EmbindVectorI32;
+
     delete(): void;
 }
 
@@ -2066,6 +2074,11 @@ export class OcctKernel {
     // Private helpers
     // =======================================================================
 
+    // Each push_back() is a JS->WASM boundary crossing. Below this element count,
+    // the per-element loop still beats a malloc + bulk HEAP copy + free round-trip;
+    // above it, the single bulk copy wins (measured ~50% of cost on point methods).
+    static readonly #BULK_THRESHOLD = 64;
+
     #makeVector<T extends { push_back(v: number): void }>(
         ctor: new () => T,
         values: number[] | ShapeHandle[],
@@ -2077,26 +2090,78 @@ export class OcctKernel {
         return vec;
     }
 
+    // Copy an array into WASM memory in one shot, then build the vector C++-side.
+    // allocBytes() may grow the heap, so the backing buffer is read after it; a
+    // fresh typed-array view is layered over it at the malloc'd (aligned) offset.
+    #bulkF64(values: ArrayLike<number>): EmbindVectorF64 {
+        const ptr = this.#raw.allocBytes(values.length * 8);
+        new Float64Array(this.#module.HEAPU32.buffer, ptr, values.length).set(values);
+        try {
+            return this.#raw.vectorF64FromHeap(ptr, values.length);
+        } finally {
+            this.#raw.freeBytes(ptr);
+        }
+    }
+
+    #bulkU32(values: ArrayLike<number>): EmbindVectorU32 {
+        const ptr = this.#raw.allocBytes(values.length * 4);
+        new Uint32Array(this.#module.HEAPU32.buffer, ptr, values.length).set(values);
+        try {
+            return this.#raw.vectorU32FromHeap(ptr, values.length);
+        } finally {
+            this.#raw.freeBytes(ptr);
+        }
+    }
+
+    #bulkI32(values: ArrayLike<number>): EmbindVectorI32 {
+        const ptr = this.#raw.allocBytes(values.length * 4);
+        new Int32Array(this.#module.HEAPU32.buffer, ptr, values.length).set(values);
+        try {
+            return this.#raw.vectorI32FromHeap(ptr, values.length);
+        } finally {
+            this.#raw.freeBytes(ptr);
+        }
+    }
+
     #makeVectorU32(ids: ShapeHandle[] | number[]): EmbindVectorU32 {
-        return this.#makeVector(this.#module.VectorUint32, ids);
+        if (ids.length < OcctKernel.#BULK_THRESHOLD) {
+            return this.#makeVector(this.#module.VectorUint32, ids);
+        }
+        return this.#bulkU32(ids as number[]);
     }
 
     #makeVectorF64(values: number[]): EmbindVectorF64 {
-        return this.#makeVector(this.#module.VectorDouble, values);
+        if (values.length < OcctKernel.#BULK_THRESHOLD) {
+            return this.#makeVector(this.#module.VectorDouble, values);
+        }
+        return this.#bulkF64(values);
     }
 
     #makeVectorI32(values: number[]): EmbindVectorI32 {
-        return this.#makeVector(this.#module.VectorInt, values);
+        if (values.length < OcctKernel.#BULK_THRESHOLD) {
+            return this.#makeVector(this.#module.VectorInt, values);
+        }
+        return this.#bulkI32(values);
     }
 
     #flattenPoints(points: Vec3[]): EmbindVectorF64 {
-        const vec = new this.#module.VectorDouble();
-        for (const p of points) {
-            vec.push_back(p.x);
-            vec.push_back(p.y);
-            vec.push_back(p.z);
+        if (points.length * 3 < OcctKernel.#BULK_THRESHOLD) {
+            const vec = new this.#module.VectorDouble();
+            for (const p of points) {
+                vec.push_back(p.x);
+                vec.push_back(p.y);
+                vec.push_back(p.z);
+            }
+            return vec;
         }
-        return vec;
+        const flat = new Float64Array(points.length * 3);
+        let j = 0;
+        for (const p of points) {
+            flat[j++] = p.x;
+            flat[j++] = p.y;
+            flat[j++] = p.z;
+        }
+        return this.#bulkF64(flat);
     }
 
     #vec2FromEmbind(vec: EmbindVectorF64): { u: number; v: number } {

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -4549,20 +4549,23 @@ return tmpPath;",
     // measured as ~50% of the cost of point-array methods like interpolatePoints.
     // Emitted to the Embind target only (filtered out of WASI/crate in run.rs):
     // the crate marshals via wasmtime linear memory and has no use for them.
+    // These never enter OCCT, so they use CustomBodyRaw (no Standard_Failure
+    // catch — that would be dead code). allocBytes throws on malloc failure so
+    // the JS side never silently writes a typed-array view at offset 0.
     MethodSpec {
         name: "allocBytes",
-        kind: MethodKind::CustomBody,
+        kind: MethodKind::CustomBodyRaw,
         params: &[FacadeParam::Int("byteCount")],
         occt_class: "",
         ctor_args: "",
-        setup_code: "return static_cast<int>(\n    reinterpret_cast<uintptr_t>(std::malloc(static_cast<size_t>(byteCount))));",
-        includes: &["cstdlib"],
+        setup_code: "void* p = std::malloc(static_cast<size_t>(byteCount));\nif (!p) {\n    throw std::runtime_error(\"allocBytes: malloc failed (out of WASM linear memory)\");\n}\nreturn static_cast<int>(reinterpret_cast<uintptr_t>(p));",
+        includes: &["cstdlib", "stdexcept"],
         category: "marshal",
         return_type: ReturnType::Int,
     },
     MethodSpec {
         name: "freeBytes",
-        kind: MethodKind::CustomBody,
+        kind: MethodKind::CustomBodyRaw,
         params: &[FacadeParam::Int("ptr")],
         occt_class: "",
         ctor_args: "",
@@ -4573,7 +4576,7 @@ return tmpPath;",
     },
     MethodSpec {
         name: "vectorF64FromHeap",
-        kind: MethodKind::CustomBody,
+        kind: MethodKind::CustomBodyRaw,
         params: &[FacadeParam::Int("ptr"), FacadeParam::Int("count")],
         occt_class: "",
         ctor_args: "",
@@ -4584,7 +4587,7 @@ return tmpPath;",
     },
     MethodSpec {
         name: "vectorU32FromHeap",
-        kind: MethodKind::CustomBody,
+        kind: MethodKind::CustomBodyRaw,
         params: &[FacadeParam::Int("ptr"), FacadeParam::Int("count")],
         occt_class: "",
         ctor_args: "",
@@ -4595,7 +4598,7 @@ return tmpPath;",
     },
     MethodSpec {
         name: "vectorI32FromHeap",
-        kind: MethodKind::CustomBody,
+        kind: MethodKind::CustomBodyRaw,
         params: &[FacadeParam::Int("ptr"), FacadeParam::Int("count")],
         occt_class: "",
         ctor_args: "",
@@ -4631,7 +4634,10 @@ mod tests {
     #[test]
     fn all_generable_methods_have_occt_class_or_custom_body() {
         for m in target_methods() {
-            if m.kind != MethodKind::Skip && m.kind != MethodKind::CustomBody {
+            if m.kind != MethodKind::Skip
+                && m.kind != MethodKind::CustomBody
+                && m.kind != MethodKind::CustomBodyRaw
+            {
                 assert!(
                     !m.occt_class.is_empty(),
                     "generable method '{}' is missing occt_class",

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -4543,6 +4543,67 @@ return tmpPath;",
         category: "xcaf",
         return_type: ReturnType::String,
     },
+    // --- Bulk array marshalling (Embind-only heap transfer) ---
+    // These let the JS wrapper move large arrays across the WASM boundary in a
+    // single HEAP copy instead of N per-element push_back() crossings, which
+    // measured as ~50% of the cost of point-array methods like interpolatePoints.
+    // Emitted to the Embind target only (filtered out of WASI/crate in run.rs):
+    // the crate marshals via wasmtime linear memory and has no use for them.
+    MethodSpec {
+        name: "allocBytes",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::Int("byteCount")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "return static_cast<int>(\n    reinterpret_cast<uintptr_t>(std::malloc(static_cast<size_t>(byteCount))));",
+        includes: &["cstdlib"],
+        category: "marshal",
+        return_type: ReturnType::Int,
+    },
+    MethodSpec {
+        name: "freeBytes",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::Int("ptr")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "std::free(reinterpret_cast<void*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr))));",
+        includes: &["cstdlib"],
+        category: "marshal",
+        return_type: ReturnType::Void,
+    },
+    MethodSpec {
+        name: "vectorF64FromHeap",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::Int("ptr"), FacadeParam::Int("count")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "const double* p =\n    reinterpret_cast<const double*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));\nreturn std::vector<double>(p, p + count);",
+        includes: &[],
+        category: "marshal",
+        return_type: ReturnType::VectorDouble,
+    },
+    MethodSpec {
+        name: "vectorU32FromHeap",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::Int("ptr"), FacadeParam::Int("count")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "const uint32_t* p =\n    reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));\nreturn std::vector<uint32_t>(p, p + count);",
+        includes: &[],
+        category: "marshal",
+        return_type: ReturnType::VectorUint32,
+    },
+    MethodSpec {
+        name: "vectorI32FromHeap",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::Int("ptr"), FacadeParam::Int("count")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "const int* p =\n    reinterpret_cast<const int*>(static_cast<uintptr_t>(static_cast<uint32_t>(ptr)));\nreturn std::vector<int>(p, p + count);",
+        includes: &[],
+        category: "marshal",
+        return_type: ReturnType::VectorInt,
+    },
 ];
 
 /// Returns the complete list of facade method specifications.
@@ -4564,7 +4625,7 @@ mod tests {
             .iter()
             .filter(|m| m.kind != MethodKind::Skip)
             .count();
-        assert_eq!(count, 173, "expected 173 generable methods");
+        assert_eq!(count, 178, "expected 178 generable methods");
     }
 
     #[test]

--- a/xtask/src/codegen/emitter.rs
+++ b/xtask/src/codegen/emitter.rs
@@ -189,10 +189,9 @@ fn emit_setup_shape(buf: &mut String, spec: &MethodSpec) {
     let _ = writeln!(buf, "}}");
 }
 
-/// Emit a `CustomBody` method — the `setup_code` field contains the complete body.
-fn emit_custom_body(buf: &mut String, spec: &MethodSpec) {
-    let name = spec.name;
-    let ret_type = match spec.return_type {
+/// Map a `ReturnType` to its C++ type spelling.
+const fn cpp_return_type(ret: ReturnType) -> &'static str {
+    match ret {
         ReturnType::ShapeId | ReturnType::Uint32 => "uint32_t",
         ReturnType::Bool => "bool",
         ReturnType::Void => "void",
@@ -210,7 +209,13 @@ fn emit_custom_body(buf: &mut String, spec: &MethodSpec) {
         ReturnType::EdgeData => "EdgeData",
         ReturnType::ProjectionData => "ProjectionData",
         ReturnType::XCAFLabelInfo => "XCAFLabelInfo",
-    };
+    }
+}
+
+/// Emit a `CustomBody` method — the `setup_code` field contains the complete body.
+fn emit_custom_body(buf: &mut String, spec: &MethodSpec) {
+    let name = spec.name;
+    let ret_type = cpp_return_type(spec.return_type);
 
     let _ = writeln!(
         buf,
@@ -229,6 +234,25 @@ fn emit_custom_body(buf: &mut String, spec: &MethodSpec) {
         "        throw std::runtime_error(std::string(\"{name}: \") + e.what());"
     );
     let _ = writeln!(buf, "    }}");
+    let _ = writeln!(buf, "}}");
+}
+
+/// Emit a `CustomBodyRaw` method — `setup_code` is the full body, emitted with
+/// no `Standard_Failure` try/catch wrapper (for methods that never enter OCCT).
+fn emit_custom_body_raw(buf: &mut String, spec: &MethodSpec) {
+    let ret_type = cpp_return_type(spec.return_type);
+
+    let _ = writeln!(
+        buf,
+        "{ret_type} OcctKernel::{name}({params}) {{",
+        name = spec.name,
+        params = param_list(spec.params)
+    );
+
+    for line in spec.setup_code.lines() {
+        let _ = writeln!(buf, "    {line}");
+    }
+
     let _ = writeln!(buf, "}}");
 }
 
@@ -447,6 +471,7 @@ pub fn emit_kernel(methods: &[&MethodSpec]) -> String {
                 MethodKind::FilletLike => emit_fillet_like(&mut buf, spec),
                 MethodKind::SetupShape => emit_setup_shape(&mut buf, spec),
                 MethodKind::CustomBody => emit_custom_body(&mut buf, spec),
+                MethodKind::CustomBodyRaw => emit_custom_body_raw(&mut buf, spec),
                 MethodKind::Skip => {}
             }
             let _ = writeln!(buf);

--- a/xtask/src/codegen/run.rs
+++ b/xtask/src/codegen/run.rs
@@ -55,14 +55,23 @@ pub fn run() -> Result<()> {
     eprintln!("  Wrote {}", kernel_path.display());
     eprintln!("  Wrote {}", bindings_path.display());
 
+    // The "marshal" helpers (allocBytes/freeBytes/vector*FromHeap) exist only to
+    // speed up the Embind/JS boundary. The crate marshals via wasmtime linear
+    // memory directly, so exclude them from the WASI C-ABI and Rust host API.
+    let host_methods: Vec<&_> = generable
+        .iter()
+        .copied()
+        .filter(|m| m.category != "marshal")
+        .collect();
+
     // Emit WASI C-ABI exports
-    let wasi_cpp = wasi_emitter::emit_wasi_exports(&generable);
+    let wasi_cpp = wasi_emitter::emit_wasi_exports(&host_methods);
     let wasi_path = facade_out.join("wasi_exports.cpp");
     std::fs::write(&wasi_path, &wasi_cpp).context("failed to write wasi_exports.cpp")?;
     eprintln!("  Wrote {}", wasi_path.display());
 
     // Emit Rust host API
-    let rust_src = rust_emitter::emit_rust_host(&generable);
+    let rust_src = rust_emitter::emit_rust_host(&host_methods);
     let rust_path = crate_out.join("kernel_generated.rs");
     std::fs::write(&rust_path, &rust_src).context("failed to write kernel_generated.rs")?;
     eprintln!("  Wrote {}", rust_path.display());

--- a/xtask/src/codegen/types.rs
+++ b/xtask/src/codegen/types.rs
@@ -29,6 +29,12 @@ pub enum MethodKind {
     /// (everything between the opening `try {` and closing `} catch`).
     CustomBody,
 
+    /// Inline C++ body emitted verbatim, with no `Standard_Failure` try/catch
+    /// wrapper. For methods that never call into OCCT (e.g. the marshal helpers
+    /// that only touch malloc/free and raw memory), where a `Standard_Failure`
+    /// catch would be dead code.
+    CustomBodyRaw,
+
     /// Not auto-generated — the hand-written implementation uses complex
     /// multi-step logic that doesn't fit a template.
     Skip,


### PR DESCRIPTION
## Summary

Large arrays passed into the kernel were marshalled one element at a time via `VectorXxx.push_back()` — and **each `push_back` is a JS→WASM boundary crossing**. Profiling `interpolatePoints` showed this marshalling was **~50% of the call's total time** (the boundary plumbing cost as much as OCCT's actual interpolation).

This routes large arrays through a single bulk HEAP copy instead.

## Measured result (same machine, `interpolatePoints` end-to-end)

| Points | Before (push_back) | After (bulk heap) | Speedup |
|---|---|---|---|
| 500  | 0.141 ms | 0.065 ms | **2.18×** |
| 2000 | 0.541 ms | 0.239 ms | **2.26×** |
| 5000 | 1.387 ms | 0.602 ms | **2.30×** |

Benefits every array-input method above the threshold: `interpolatePoints`, `approximatePoints`, `makeBezierEdge`, `makeBSplineSurface`, `makePolygon`, batch transforms/booleans, etc.

## How it works

- **Facade (`feat` commit):** adds `allocBytes`/`freeBytes` and `vector{F64,U32,I32}FromHeap`. The JS side allocs one WASM buffer, writes the whole array with a single typed-array `.set()`, and C++ builds the `std::vector` from it — zero per-element crossings.
- **Embind-only:** a one-line category filter in `run.rs` keeps these helpers out of the WASI C-ABI and the Rust host API. The crate already marshals via wasmtime linear memory, so it has no use for them — and this means **the WASI binary is unchanged (no `wasm.br` re-embed)** and the crate's public API stays clean.
- **Threshold of 64 elements (`perf` commit):** small arrays (transform matrices, 1–2-shape booleans) keep the `push_back` path, which is cheaper than a malloc round-trip — so **no regression** on the common small-array case; only large arrays take the bulk path.

## Validation

- **A/B above** confirms ~2.3× end-to-end.
- All **134 integration/api-coverage/ts-wrapper tests pass**; `tsc` + `eslint` clean.
- Heap roundtrip verified; wrapper bulk path (200-point interpolation) and small path both produce valid shapes.
- Codegen **idempotent** (drift gate passes); crate compiles; `wasi_exports.cpp` and `kernel_generated.rs` are **untouched** (Embind-only filter confirmed).