### PR TITLE
perf(ts): bulk-marshal liftCurve2dToPlane points

### DIFF
--- a/test/ts-wrapper-bulk.test.ts
+++ b/test/ts-wrapper-bulk.test.ts
@@ -117,6 +117,31 @@ describe("wrapper bulk return path: edgeToFaceMap (Int32 read)", () => {
     });
 });
 
+describe("wrapper bulk input path: liftCurve2dToPlane (Float64 write)", () => {
+    const ORIGIN = { x: 0, y: 0, z: 0 };
+    const Z = { x: 0, y: 0, z: 1 };
+    const X = { x: 1, y: 0, z: 0 };
+
+    it("below threshold: few 2D points (push_back path)", () => {
+        const pts = Array.from({ length: 5 }, (_, i) => ({ x: i, y: 0 }));
+        const edge = kernel.liftCurve2dToPlane(pts, ORIGIN, Z, X);
+        const bbox = kernel.getBoundingBox(edge, false);
+        expect(bbox.xmax).toBeCloseTo(4, 6);
+    });
+
+    it("above threshold: many 2D points marshal via heap copy (#bulkF64 path)", () => {
+        // 40 points * 2 = 80 doubles, above the 64 threshold → bulk inbound copy.
+        const pts = Array.from({ length: 40 }, (_, i) => ({ x: i, y: Math.sin(i) }));
+        const edge = kernel.liftCurve2dToPlane(pts, ORIGIN, Z, X);
+        // (u,v) lifts to (u, v, 0) on the XY plane: x spans 0..39, z is flat.
+        const bbox = kernel.getBoundingBox(edge, false);
+        expect(bbox.xmin).toBeCloseTo(0, 6);
+        expect(bbox.xmax).toBeCloseTo(39, 6);
+        expect(bbox.zmin).toBeCloseTo(0, 6);
+        expect(bbox.zmax).toBeCloseTo(0, 6);
+    });
+});
+
 describe("wrapper bulk return path: getNurbsCurveData poles (Float64 read)", () => {
     it("above threshold: many poles read back finite, endpoints match input (dataPtr path)", () => {
         const pts = Array.from({ length: 30 }, (_, i) => ({ x: i, y: Math.sin(i), z: 0 }));

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1654,11 +1654,13 @@ export class OcctKernel {
         planeX: Vec3,
     ): ShapeHandle {
         return wrap("liftCurve2dToPlane", () => {
-            const flat = new this.#module.VectorDouble();
+            const flatArr = new Array<number>(points2d.length * 2);
+            let j = 0;
             for (const p of points2d) {
-                flat.push_back(p.x);
-                flat.push_back(p.y);
+                flatArr[j++] = p.x;
+                flatArr[j++] = p.y;
             }
+            const flat = this.#makeVectorF64(flatArr);
             try {
                 return handle(this.#raw.liftCurve2dToPlane(
                     flat,


### PR DESCRIPTION
## Summary

Tail of the boundary-crossing work (#133 inbound arrays, #134 outbound vectors). `liftCurve2dToPlane` was the **last input-path method still flattening its points with a per-element `push_back` loop** — 2 JS→WASM crossings per 2D point. It now routes through `#makeVectorF64`, so above the 64-element threshold the points cross in a single heap copy (the same path the other point methods already use); below it, the cheap `push_back` loop is retained.

## Validation

- TS-only change (the WASM method is unchanged), validated against the existing build: full suite **282 passed / 2 skipped**.
- Adds the **first test coverage** for `liftCurve2dToPlane` — both the below-threshold (`push_back`) and above-threshold (`#bulkF64`) input paths, asserting the lifted curve's bounding box matches the input extent.
- `tsc` + `eslint` clean.

After this, the per-element marshalling surface is fully covered in both directions; remaining struct `.property()` crossings are fixed, O(fields) cost (and unavoidable for structs exposing pointer-accessor methods).