### PR TITLE
chore(crate): bump occt-wasm to 3.2.2 for crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "occt-wasm"
-version = "3.0.1"
+version = "3.2.2"
 dependencies = [
  "brotli",
  "thiserror 2.0.18",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "occt-wasm"
-version = "3.0.1"
+version = "3.2.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## What

Bumps `crate/Cargo.toml` 3.0.1 → **3.2.2** to align the Rust crate with the npm package (now 3.2.2) and publish the updated kernel to crates.io.

## Context

The crate hasn't shipped since 3.0.1. Its **Rust API is unchanged** since then — the only delta is the embedded WASI kernel (`occt-wasm.wasm.br`), which now carries the fixes/perf merged since 3.0.1 (#128 glyph-hole orientation, #131 identity-face transform skip, etc.). Semver-wise that's a patch, but per the maintainer's call we align the crate onto the shared 3.2.x release line so a given version means the same release across npm and crates.io.

## Validated

- `cargo publish -p occt-wasm --dry-run` — packages 13 files (4.9 MiB incl. the wasm), compiles the packaged crate clean.
- Embedded wasm is current (release build; CI WASI stale-check passes on main).
- `chore` commit type so release-please does **not** open another npm release.

## Publish step (after merge)

Tag `crate-v3.2.2` on main and push it → `publish-crate.yml` verifies version==tag + wasm present, then publishes via OIDC trusted publishing (same path used for 3.0.1).