### PR TITLE
test(bench): loosen sanity ceilings to catastrophic-only

### DIFF
--- a/test/bench.test.ts
+++ b/test/bench.test.ts
@@ -117,7 +117,10 @@ describe("Core 5 — raw facade benchmarks", () => {
             }
         });
         record(r);
-        expect(r.median).toBeLessThan(100); // sanity: <100ms
+        // Catastrophic-only ceiling (~8x baseline). Real regression detection is
+        // bench-check.js against baseline.json; a tight ceiling here just flakes
+        // on loaded CI runners (translate has hit 104ms vs a 75ms baseline).
+        expect(r.median).toBeLessThan(600);
     });
 
     it("mesh sphere (tol=0.01)", () => {
@@ -135,7 +138,7 @@ describe("Core 5 — raw facade benchmarks", () => {
             for (let i = 0; i < 10; i++) kernel.exportStep(box);
         });
         record(r);
-        expect(r.median).toBeLessThan(100); // sanity
+        expect(r.median).toBeLessThan(300); // catastrophic-only (~8x baseline)
     });
 
     it("translateBatch ×1000 (single call)", () => {
@@ -154,7 +157,7 @@ describe("Core 5 — raw facade benchmarks", () => {
         ids.delete();
         offsets.delete();
         record(r);
-        expect(r.median).toBeLessThan(100);
+        expect(r.median).toBeLessThan(600); // catastrophic-only (~8x baseline)
     });
 
     it("booleanPipeline ×3 (fuse+cut+fuse)", () => {


### PR DESCRIPTION
## Problem

`bench.test.ts` has two layers of perf gating:
1. `bench-check.js` vs `baseline.json` — the **real** regression gate (now with a 0.5ms absolute floor, #136).
2. Inline `expect(median).toBeLessThan(N)` smoke checks per benchmark.

The inline ceilings were set too tight relative to CI runner variance: `translate ×1000` and `translateBatch ×1000` capped at **100ms vs a 75ms baseline (~1.3×)**, and `exportSTEP ×10` at 100ms (~2.9×). A loaded CI runner (observed ~1.8× slowdown: fuse 85→151ms) pushed `translate` to 104ms and failed the assertion — a spurious failure unrelated to the change under test (it blocked the crate-publish PR #138).

## Fix

Bump the tight ceilings to ~8× baseline (catastrophic-only), matching the headroom the other benches already have (makeBox 10×, booleanPipeline 31×, …):

| bench | baseline | before | after |
|---|---|---|---|
| translate ×1000 | 75ms | 100 (1.3×) | 600 (8×) |
| translateBatch ×1000 | 75ms | 100 (1.3×) | 600 (8×) |
| exportSTEP ×10 | 35ms | 100 (2.9×) | 300 (8.6×) |

These are smoke checks for catastrophic blowups only — real regressions are caught by `bench-check.js`, and hangs by vitest's 30s timeout. Other ceilings already had ≥6× headroom and are unchanged.

`test/` is in release-please `exclude-paths`, so no release impact.