### PR TITLE
fix(ts): include README in the published npm package

### DIFF
--- a/ts/.gitignore
+++ b/ts/.gitignore
@@ -1,0 +1,2 @@
+# Copied from the repo root by the `prepack` script at publish time.
+README.md

--- a/ts/package.json
+++ b/ts/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "tsc",
     "prebuild": "bash scripts/copy-wasm.sh",
+    "prepack": "cp ../README.md README.md",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Problem

The published npm package ships **no README** — `files: ["dist/"]`, there's no `ts/README.md`, and the CI release publishes a downloaded dist artifact without running a build. So [npmjs.com/package/occt-wasm](https://www.npmjs.com/package/occt-wasm) is blank (confirmed: registry `readme` length 0 for 3.2.2) — npm users see nothing, including the Rust-crate mention that the GitHub README already has.

## Fix

Add a `prepack` hook to `ts/package.json` that copies the root `README.md` into `ts/` right before packing. `prepack` runs automatically on `npm publish` (both CI `release.yml` and local `publish.sh`, neither of which needed changes), and npm auto-includes `README.md` in the tarball. The copy is gitignored so the root stays the single source — no duplicate to drift.

## Verified

`npm pack --dry-run` from `ts/`:
```
> occt-wasm@3.2.2 prepack
> cp ../README.md README.md
npm notice 16.1kB README.md      <-- now in the tarball
npm notice ... dist/...
```

## Note

This applies to the **next** npm release (release-please will cut a patch from this `fix:`). The already-published 3.2.2 stays blank — npm versions are immutable — but the next publish will carry the full README (which documents both the TS API and the companion Rust crate).