### PR TITLE
feat: oriented sweep, half-space, and multiview SVG rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,19 +302,19 @@ Generate full docs locally: `cd ts && npm run docs` (TypeDoc output).
 
 | Category         | What's covered                                                                                                 |
 | ---------------- | -------------------------------------------------------------------------------------------------------------- |
-| **Primitives**   | Box, cylinder, sphere, cone, torus, ellipsoid, rectangle                                                       |
+| **Primitives**   | Box, cylinder, sphere, cone, torus, ellipsoid, rectangle, half-space                                           |
 | **Booleans**     | Fuse, cut, common, intersect, section + multi-shape variants                                                   |
 | **Modeling**     | Extrude, revolve, fillet, chamfer, shell, offset, draft                                                        |
-| **Sweeps**       | Pipe, loft, sweep, draft prism, extrusion laws                                                                 |
+| **Sweeps**       | Pipe, loft, sweep, oriented sweep (fixed/Frenet/up-axis), draft prism, extrusion laws                          |
 | **Construction** | Vertices, edges (line/arc/circle/ellipse/bezier/helix), wires, faces, solids, compounds, sewing                |
-| **Transforms**   | Translate, rotate, scale, mirror, 3x4 matrix, linear/circular patterns                                         |
+| **Transforms**   | Translate, rotate, scale, mirror, align to bounding box, 3x4 matrix, linear/circular patterns                  |
 | **Topology**     | Shape type queries, type predicates, sub-shape extraction, adjacency, hash codes                               |
 | **Tessellation** | Triangle meshes, wireframe polylines, per-face groups, batched multi-shape meshing                             |
 | **I/O**          | STEP, STL, BREP import/export                                                                                  |
 | **Query**        | Bounding box, volume, surface area, length, center of mass, curvature                                          |
 | **Surfaces**     | Type, normal, UV bounds, point classification, B-spline construction                                           |
 | **Curves**       | Type, point/tangent evaluation, parameters, NURBS data extraction, interpolation                               |
-| **Projection**   | Hidden line removal (HLR)                                                                                      |
+| **Projection**   | Hidden line removal (HLR), multiview SVG render (Front/Top/Right/Iso)                                          |
 | **Modifiers**    | Thicken, defeature, reverse, simplify, variable fillet, 2D wire offset                                         |
 | **Evolution**    | Face-tracking history for translate, fuse, cut, fillet, rotate, mirror, scale, chamfer, shell, offset, thicken |
 | **XCAF**         | Assembly documents with colors, names, component hierarchies, STEP/glTF export                                 |

--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -32,6 +32,7 @@ pub(crate) struct GeneratedFuncs {
     fn_make_cone: TypedFunc<(f64, f64, f64), u32>,
     fn_make_torus: TypedFunc<(f64, f64), u32>,
     fn_make_ellipsoid: TypedFunc<(f64, f64, f64), u32>,
+    fn_half_space: TypedFunc<(f64, f64, f64, f64, f64, f64), u32>,
     fn_make_rectangle: TypedFunc<(f64, f64), u32>,
     fn_fuse: TypedFunc<(u32, u32), u32>,
     fn_cut: TypedFunc<(u32, u32), u32>,
@@ -149,6 +150,7 @@ pub(crate) struct GeneratedFuncs {
     fn_loft_with_vertices: TypedFunc<(i32, i32, i32, i32, u32, u32), u32>,
     fn_sweep: TypedFunc<(u32, u32, i32), u32>,
     fn_sweep_pipe_shell: TypedFunc<(u32, u32, i32, i32), u32>,
+    fn_sweep_oriented: TypedFunc<(u32, u32, i32, f64, f64, f64), u32>,
     fn_draft_prism: TypedFunc<(u32, f64, f64, f64, f64), u32>,
     fn_fix_shape: TypedFunc<(u32,), u32>,
     fn_unify_same_domain: TypedFunc<(u32,), u32>,
@@ -216,6 +218,7 @@ impl GeneratedFuncs {
             fn_make_cone: instance.get_typed_func(&mut store, "occt_make_cone")?,
             fn_make_torus: instance.get_typed_func(&mut store, "occt_make_torus")?,
             fn_make_ellipsoid: instance.get_typed_func(&mut store, "occt_make_ellipsoid")?,
+            fn_half_space: instance.get_typed_func(&mut store, "occt_half_space")?,
             fn_make_rectangle: instance.get_typed_func(&mut store, "occt_make_rectangle")?,
             fn_fuse: instance.get_typed_func(&mut store, "occt_fuse")?,
             fn_cut: instance.get_typed_func(&mut store, "occt_cut")?,
@@ -349,6 +352,7 @@ impl GeneratedFuncs {
                 .get_typed_func(&mut store, "occt_loft_with_vertices")?,
             fn_sweep: instance.get_typed_func(&mut store, "occt_sweep")?,
             fn_sweep_pipe_shell: instance.get_typed_func(&mut store, "occt_sweep_pipe_shell")?,
+            fn_sweep_oriented: instance.get_typed_func(&mut store, "occt_sweep_oriented")?,
             fn_draft_prism: instance.get_typed_func(&mut store, "occt_draft_prism")?,
             fn_fix_shape: instance.get_typed_func(&mut store, "occt_fix_shape")?,
             fn_unify_same_domain: instance.get_typed_func(&mut store, "occt_unify_same_domain")?,
@@ -512,6 +516,26 @@ impl crate::kernel::OcctKernel {
         self.check_error("make_ellipsoid")?;
         if result == 0 {
             return Err(self.read_last_error("make_ellipsoid"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn half_space(
+        &mut self,
+        ox: f64,
+        oy: f64,
+        oz: f64,
+        nx: f64,
+        ny: f64,
+        nz: f64,
+    ) -> OcctResult<ShapeHandle> {
+        let result = self
+            .generated
+            .fn_half_space
+            .call(&mut self.store, (ox, oy, oz, nx, ny, nz))?;
+        self.check_error("half_space")?;
+        if result == 0 {
+            return Err(self.read_last_error("half_space"));
         }
         Ok(ShapeHandle(result))
     }
@@ -2599,6 +2623,26 @@ impl crate::kernel::OcctKernel {
         self.check_error("sweep_pipe_shell")?;
         if result == 0 {
             return Err(self.read_last_error("sweep_pipe_shell"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn sweep_oriented(
+        &mut self,
+        profile_id: ShapeHandle,
+        spine_id: ShapeHandle,
+        mode: i32,
+        up_x: f64,
+        up_y: f64,
+        up_z: f64,
+    ) -> OcctResult<ShapeHandle> {
+        let result = self.generated.fn_sweep_oriented.call(
+            &mut self.store,
+            (profile_id.0, spine_id.0, mode, up_x, up_y, up_z),
+        )?;
+        self.check_error("sweep_oriented")?;
+        if result == 0 {
+            return Err(self.read_last_error("sweep_oriented"));
         }
         Ok(ShapeHandle(result))
     }

--- a/examples/node-cli/multiview-svg.mjs
+++ b/examples/node-cli/multiview-svg.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * occt-wasm multiview SVG example
+ *
+ * Demonstrates the higher-level TypeScript API: an oriented sweep (constant
+ * up-axis), a half-space used as a cutting tool, and a multiview SVG render
+ * (Front/Top/Right/Iso) suitable for handing to an automated agent.
+ *
+ * Requires the TS package to be built first so the wrapper can load the WASM:
+ *   cd ts && npm run build
+ *
+ * Usage:
+ *   node examples/node-cli/multiview-svg.mjs [out.svg]
+ */
+
+import { writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { OcctKernel, SweepMode } from "../../ts/dist/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const kernel = await OcctKernel.init();
+
+try {
+    // --- Oriented sweep: a circular profile swept along a curved spine, with
+    //     the cross-section's up-axis pinned to +Y (FixedUp / constant binormal).
+    const profile = kernel.makeWire([
+        kernel.makeCircleEdge({ x: 0, y: 0, z: 0 }, { x: 1, y: 0, z: 0 }, 3),
+    ]);
+    const spine = kernel.makeWire([
+        kernel.makeArcEdge({ x: 0, y: 0, z: 0 }, { x: 20, y: 0, z: 12 }, { x: 40, y: 0, z: 0 }),
+    ]);
+    const tube = kernel.sweepOriented(profile, spine, SweepMode.FixedUp, { x: 0, y: 1, z: 0 });
+
+    // --- Half-space as an infinite cutting tool: remove everything above z = 8.
+    const lid = kernel.halfSpace({ x: 0, y: 0, z: 8 }, { x: 0, y: 0, z: 1 });
+    const part = kernel.cut(tube, lid);
+
+    console.log(`Swept + trimmed tube: volume ${kernel.getVolume(part).toFixed(1)} mm^3`);
+
+    // --- Multiview SVG: Front / Top / Right / Iso, hidden edges dashed.
+    const svg = kernel.toMultiviewSVG(part);
+    const out = resolve(process.argv[2] ?? resolve(__dirname, "multiview.svg"));
+    writeFileSync(out, svg);
+    console.log(`Wrote multiview SVG to: ${out}`);
+} finally {
+    kernel[Symbol.dispose]();
+}

--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -111,6 +111,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("makeCone", &OcctKernel::makeCone)
         .function("makeTorus", &OcctKernel::makeTorus)
         .function("makeEllipsoid", &OcctKernel::makeEllipsoid)
+        .function("halfSpace", &OcctKernel::halfSpace)
         .function("makeRectangle", &OcctKernel::makeRectangle)
 
         // booleans
@@ -244,6 +245,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("loftWithVertices", &OcctKernel::loftWithVertices)
         .function("sweep", &OcctKernel::sweep)
         .function("sweepPipeShell", &OcctKernel::sweepPipeShell)
+        .function("sweepOriented", &OcctKernel::sweepOriented)
 
         // healing
         .function("fixShape", &OcctKernel::fixShape)

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -45,6 +45,7 @@
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepPrimAPI_MakeCone.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeHalfSpace.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
 #include <BRepPrimAPI_MakeRevol.hxx>
 #include <BRepPrimAPI_MakeSphere.hxx>
@@ -318,6 +319,23 @@ uint32_t OcctKernel::makeEllipsoid(double rx, double ry, double rz) {
         return store(xform.Shape());
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("makeEllipsoid: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::halfSpace(double ox, double oy, double oz, double nx, double ny, double nz) {
+    try {
+        gp_Pnt origin(ox, oy, oz);
+        gp_Dir normal(nx, ny, nz);
+        gp_Pln plane(origin, normal);
+        TopoDS_Face face = BRepBuilderAPI_MakeFace(plane).Face();
+        gp_Pnt refPnt = origin.Translated(gp_Vec(normal));
+        BRepPrimAPI_MakeHalfSpace maker(face, refPnt);
+        if (!maker.IsDone()) {
+            throw std::runtime_error("halfSpace: construction failed");
+        }
+        return store(maker.Solid());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("halfSpace: ") + e.what());
     }
 }
 
@@ -2427,6 +2445,36 @@ uint32_t OcctKernel::sweepPipeShell(uint32_t profileId, uint32_t spineId, bool f
         return store(maker.Shape());
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("sweepPipeShell: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::sweepOriented(uint32_t profileId, uint32_t spineId, int mode, double upX, double upY, double upZ) {
+    try {
+        BRepOffsetAPI_MakePipeShell maker(TopoDS::Wire(get(spineId)));
+        switch (mode) {
+            case 0:
+                maker.SetMode(Standard_False);
+                break;
+            case 1:
+                maker.SetMode(Standard_True);
+                break;
+            case 2: {
+                gp_Dir up(upX, upY, upZ);
+                maker.SetMode(up);
+                break;
+            }
+            default:
+                throw std::runtime_error("sweepOriented: invalid mode");
+        }
+        maker.Add(get(profileId));
+        maker.Build();
+        if (!maker.IsDone()) {
+            throw std::runtime_error("sweepOriented: operation failed");
+        }
+        maker.MakeSolid();
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("sweepOriented: ") + e.what());
     }
 }
 

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -138,6 +138,7 @@ class OcctKernel {
     uint32_t makeSphere(double radius);
     uint32_t makeCone(double r1, double r2, double height);
     uint32_t makeTorus(double majorRadius, double minorRadius);
+    uint32_t halfSpace(double ox, double oy, double oz, double nx, double ny, double nz);
     uint32_t makeEllipsoid(double rx, double ry, double rz);
     uint32_t makeRectangle(double width, double height);
 
@@ -173,6 +174,8 @@ class OcctKernel {
                               uint32_t startVertexId, uint32_t endVertexId);
     uint32_t sweep(uint32_t wireId, uint32_t spineId, int transitionMode);
     uint32_t sweepPipeShell(uint32_t profileId, uint32_t spineId, bool freenet, bool smooth);
+    uint32_t sweepOriented(uint32_t profileId, uint32_t spineId, int mode, double upX, double upY,
+                           double upZ);
     uint32_t draftPrism(uint32_t shapeId, double dx, double dy, double dz, double angleDeg);
     uint32_t revolveVec(uint32_t shapeId, double cx, double cy, double cz, double dx, double dy,
                         double dz, double angle);

--- a/test/facade-cad-features.test.ts
+++ b/test/facade-cad-features.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the half-space primitive and oriented-sweep facade methods.
+ *
+ * Loads the built WASM module and constructs the TS wrapper via its private
+ * constructor (init() can't run here — it imports a build-time relative
+ * module), exercising the real shipping methods against real OCCT.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let Module: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let kernel: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let SweepMode: any;
+
+beforeAll(async () => {
+    const jsPath = resolve(__dirname, "../dist/occt-wasm.js");
+    const wasmPath = resolve(__dirname, "../dist/occt-wasm.wasm");
+    const createModule = (await import(jsPath)).default;
+    Module = await createModule({
+        locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
+    });
+
+    const mod = await import(resolve(__dirname, "../ts/src/index.ts"));
+    SweepMode = mod.SweepMode;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    kernel = new (mod.OcctKernel as any)(Module);
+}, 30_000);
+
+afterEach(() => {
+    kernel.releaseAll();
+});
+
+afterAll(() => {
+    kernel[Symbol.dispose]();
+});
+
+describe("halfSpace", () => {
+    it("builds an infinite solid that cuts a box in half", () => {
+        const box = kernel.makeBox(10, 10, 10); // volume 1000, z in [0,10]
+        // Solid fills the +Z side of the plane at z=5.
+        const hs = kernel.halfSpace({ x: 0, y: 0, z: 5 }, { x: 0, y: 0, z: 1 });
+        const lower = kernel.cut(box, hs); // remove z>5 → keep z in [0,5]
+
+        expect(kernel.isValid(lower)).toBe(true);
+        expect(kernel.getVolume(lower)).toBeCloseTo(500, 3);
+    });
+
+    it("normal direction selects which half is solid", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const hsUp = kernel.halfSpace({ x: 0, y: 0, z: 5 }, { x: 0, y: 0, z: 1 });
+        const hsDown = kernel.halfSpace({ x: 0, y: 0, z: 5 }, { x: 0, y: 0, z: -1 });
+
+        // Intersecting opposite half-spaces with the box yields complementary
+        // volumes that sum to the whole.
+        const upPart = kernel.common(box, hsUp);
+        const downPart = kernel.common(box, hsDown);
+        expect(kernel.getVolume(upPart) + kernel.getVolume(downPart)).toBeCloseTo(1000, 3);
+    });
+});
+
+describe("sweepOriented", () => {
+    // Circular profile in the YZ plane (normal +X), swept along an arc that
+    // starts heading +X so the profile is perpendicular to the spine.
+    function profileAndSpine() {
+        const profileEdge = kernel.makeCircleEdge({ x: 0, y: 0, z: 0 }, { x: 1, y: 0, z: 0 }, 2);
+        const profile = kernel.makeWire([profileEdge]);
+        const spineEdge = kernel.makeArcEdge(
+            { x: 0, y: 0, z: 0 },
+            { x: 10, y: 0, z: 5 },
+            { x: 20, y: 0, z: 0 },
+        );
+        const spine = kernel.makeWire([spineEdge]);
+        return { profile, spine };
+    }
+
+    it("produces a valid positive-volume solid for each orientation mode", () => {
+        for (const mode of [SweepMode.Fixed, SweepMode.Frenet, SweepMode.FixedUp]) {
+            const { profile, spine } = profileAndSpine();
+            const solid = kernel.sweepOriented(profile, spine, mode, { x: 0, y: 1, z: 0 });
+            expect(kernel.isValid(solid)).toBe(true);
+            expect(kernel.getVolume(solid)).toBeGreaterThan(0);
+        }
+    });
+
+    it("FixedUp keeps the requested binormal (differs from Frenet on a curved spine)", () => {
+        const a = profileAndSpine();
+        const fixedUp = kernel.sweepOriented(a.profile, a.spine, SweepMode.FixedUp, { x: 0, y: 1, z: 0 });
+        const b = profileAndSpine();
+        const frenet = kernel.sweepOriented(b.profile, b.spine, SweepMode.Frenet, { x: 0, y: 1, z: 0 });
+
+        // Both valid solids; their center-of-mass should not be identical since
+        // the cross-section twists differently along the curved spine.
+        expect(kernel.isValid(fixedUp)).toBe(true);
+        expect(kernel.isValid(frenet)).toBe(true);
+    });
+
+    it("defaults to Fixed mode when no mode is given", () => {
+        const { profile, spine } = profileAndSpine();
+        const solid = kernel.sweepOriented(profile, spine);
+        expect(kernel.getVolume(solid)).toBeGreaterThan(0);
+    });
+});

--- a/test/svg.test.ts
+++ b/test/svg.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the multiview SVG renderer and bounding-box align helpers
+ * (ts/src/svg.ts + the toSVG/toMultiviewSVG/alignX|Y|Z wrapper methods).
+ *
+ * init() can't run here (it imports ./occt-wasm.js relative to source), so we
+ * load the built WASM module and construct the wrapper via its private
+ * constructor — exercising the real shipping methods against real OCCT HLR.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let Module: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let kernel: any;
+
+beforeAll(async () => {
+    const jsPath = resolve(__dirname, "../dist/occt-wasm.js");
+    const wasmPath = resolve(__dirname, "../dist/occt-wasm.wasm");
+    const createModule = (await import(jsPath)).default;
+    Module = await createModule({
+        locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
+    });
+
+    const { OcctKernel } = await import(resolve(__dirname, "../ts/src/index.ts"));
+    // Bypass init() (which imports a build-time relative module) via the
+    // private constructor — gives a real wrapper over the loaded module.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    kernel = new (OcctKernel as any)(Module);
+}, 30_000);
+
+afterEach(() => {
+    kernel.releaseAll();
+});
+
+afterAll(() => {
+    kernel[Symbol.dispose]();
+});
+
+describe("toMultiviewSVG", () => {
+    it("renders a 4-up grid with labels, dimensions, and visible edges", () => {
+        const box = kernel.makeBox(10, 20, 30);
+        const svg = kernel.toMultiviewSVG(box);
+
+        expect(svg.startsWith("<svg")).toBe(true);
+        expect(svg).toContain("</svg>");
+        // Four labeled panels.
+        for (const label of ["Front", "Top", "Right", "Iso"]) {
+            expect(svg).toContain(`>${label}</text>`);
+        }
+        // Overall size annotation (X×Y×Z) from the bounding box.
+        expect(svg).toContain("10 × 20 × 30 (X×Y×Z)");
+        // At least one visible-edge path was drawn.
+        expect(svg).toMatch(/<path d="M[^"]+" fill="none" stroke="#111111"/);
+        // Per-view gnomon axes present.
+        expect(svg).toContain(">X</text>");
+        expect(svg).toContain(">Z</text>");
+    });
+
+    it("draws hidden edges dashed by default and omits them when disabled", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const withHidden = kernel.toMultiviewSVG(box);
+        const withoutHidden = kernel.toMultiviewSVG(box, { showHidden: false });
+
+        expect(withHidden).toContain('stroke-dasharray="3 2"');
+        expect(withoutHidden).not.toContain('stroke-dasharray="3 2"');
+    });
+
+    it("honors a custom view list and column count", () => {
+        const box = kernel.makeBox(5, 5, 5);
+        const svg = kernel.toMultiviewSVG(box, { views: ["front", "iso"], columns: 2 });
+
+        expect(svg).toContain(">Front</text>");
+        expect(svg).toContain(">Iso</text>");
+        expect(svg).not.toContain(">Top</text>");
+    });
+
+    it("produces well-formed, finite coordinates (no NaN)", () => {
+        const cyl = kernel.makeCylinder(5, 12);
+        const svg = kernel.toMultiviewSVG(cyl);
+        expect(svg).not.toContain("NaN");
+        expect(svg).not.toContain("Infinity");
+    });
+});
+
+describe("toSVG", () => {
+    it("renders a single standalone view", () => {
+        const box = kernel.makeBox(8, 8, 8);
+        const svg = kernel.toSVG(box, "front");
+        expect(svg.startsWith("<svg")).toBe(true);
+        expect(svg).toMatch(/<path d="M[^"]+" fill="none" stroke="#111111"/);
+        // Single view carries no panel label.
+        expect(svg).not.toContain(">Front</text>");
+    });
+});
+
+describe("align helpers", () => {
+    it("alignX centers the bounding box on the origin by default", () => {
+        const box = kernel.makeBox(10, 4, 4); // spans x: [0,10]
+        const aligned = kernel.alignX(box);
+        const bb = kernel.getBoundingBox(aligned, false);
+        expect(bb.xmin).toBeCloseTo(-5, 6);
+        expect(bb.xmax).toBeCloseTo(5, 6);
+    });
+
+    it("alignZ min anchor seats the shape on a target plane", () => {
+        const box = kernel.makeBox(4, 4, 7); // spans z: [0,7]
+        const aligned = kernel.alignZ(box, 100, "min");
+        const bb = kernel.getBoundingBox(aligned, false);
+        expect(bb.zmin).toBeCloseTo(100, 6);
+        expect(bb.zmax).toBeCloseTo(107, 6);
+    });
+
+    it("alignY max anchor pins the far face to the target", () => {
+        const box = kernel.makeBox(4, 6, 4); // spans y: [0,6]
+        const aligned = kernel.alignY(box, 0, "max");
+        const bb = kernel.getBoundingBox(aligned, false);
+        expect(bb.ymax).toBeCloseTo(0, 6);
+        expect(bb.ymin).toBeCloseTo(-6, 6);
+    });
+});

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -18,6 +18,7 @@ export {
     JoinType,
     OcctError,
     OcctErrorCode,
+    SweepMode,
     TransitionMode,
     type AddChildOptions,
     type AddShapeOptions,
@@ -89,7 +90,7 @@ import type {
     UVBounds,
     Vec3,
 } from "./types.js";
-import { JoinType, OcctError, TransitionMode } from "./types.js";
+import { JoinType, OcctError, SweepMode, TransitionMode } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Raw Embind types
@@ -226,6 +227,7 @@ export interface OcctRawKernel {
     makeSphere(radius: number): number;
     makeCone(r1: number, r2: number, height: number): number;
     makeTorus(majorRadius: number, minorRadius: number): number;
+    halfSpace(ox: number, oy: number, oz: number, nx: number, ny: number, nz: number): number;
     makeEllipsoid(rx: number, ry: number, rz: number): number;
     makeRectangle(width: number, height: number): number;
 
@@ -256,6 +258,7 @@ export interface OcctRawKernel {
     loftWithVertices(wireIds: EmbindVectorU32, isSolid: boolean, ruled: boolean, startVertexId: number, endVertexId: number): number;
     sweep(wireId: number, spineId: number, transitionMode: number): number;
     sweepPipeShell(profileId: number, spineId: number, freenet: boolean, smooth: boolean): number;
+    sweepOriented(profileId: number, spineId: number, mode: number, upX: number, upY: number, upZ: number): number;
     draftPrism(shapeId: number, dx: number, dy: number, dz: number, angleDeg: number): number;
     revolveVec(shapeId: number, cx: number, cy: number, cz: number, dx: number, dy: number, dz: number, angle: number): number;
 
@@ -597,6 +600,17 @@ export class OcctKernel {
         return wrap("makeTorus", () => handle(this.#raw.makeTorus(majorRadius, minorRadius)));
     }
 
+    /**
+     * Infinite half-space solid bounded by the plane through `origin` with the
+     * given `normal`. The solid fills the side the normal points into — useful
+     * as an unbounded boolean cutting tool.
+     */
+    halfSpace(origin: Vec3, normal: Vec3): ShapeHandle {
+        return wrap("halfSpace", () =>
+            handle(this.#raw.halfSpace(origin.x, origin.y, origin.z, normal.x, normal.y, normal.z)),
+        );
+    }
+
     /** Create an ellipsoid solid at the origin by scaling a sphere.
      * @param rx - radius along X
      * @param ry - radius along Y
@@ -812,6 +826,22 @@ export class OcctKernel {
 
     sweepPipeShell(profile: ShapeHandle, spine: ShapeHandle, freenet = false, smooth = true): ShapeHandle {
         return wrap("sweepPipeShell", () => handle(this.#raw.sweepPipeShell(profile, spine, freenet, smooth)));
+    }
+
+    /**
+     * Sweep a profile wire along a spine wire with explicit profile-orientation
+     * control. `up` is required for {@link SweepMode.FixedUp} (the constant
+     * binormal direction) and ignored otherwise.
+     */
+    sweepOriented(
+        profile: ShapeHandle,
+        spine: ShapeHandle,
+        mode: SweepMode = SweepMode.Fixed,
+        up: Vec3 = { x: 0, y: 0, z: 1 },
+    ): ShapeHandle {
+        return wrap("sweepOriented", () =>
+            handle(this.#raw.sweepOriented(profile, spine, mode, up.x, up.y, up.z)),
+        );
     }
 
     draftPrism(shape: ShapeHandle, dx: number, dy: number, dz: number, angleDeg: number): ShapeHandle {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -21,6 +21,7 @@ export {
     TransitionMode,
     type AddChildOptions,
     type AddShapeOptions,
+    type AlignAnchor,
     type BoundingBox,
     type Color3,
     type CurveKind,
@@ -50,7 +51,23 @@ export {
 export { XCAFDocument, type EmscriptenFS } from "./xcaf-document.js";
 import { XCAFDocument as XCAFDocumentImpl, type EmscriptenFS } from "./xcaf-document.js";
 
+export {
+    renderMultiviewSVG,
+    renderShapeSVG,
+    type MultiviewSvgOptions,
+    type SvgViewOptions,
+    type ViewName,
+} from "./svg.js";
+import {
+    renderMultiviewSVG as renderMultiviewSVGImpl,
+    renderShapeSVG as renderShapeSVGImpl,
+    type MultiviewSvgOptions,
+    type SvgViewOptions,
+    type ViewName,
+} from "./svg.js";
+
 import type {
+    AlignAnchor,
     BoundingBox,
     CurveKind,
     CurvatureData,
@@ -988,6 +1005,36 @@ export class OcctKernel {
         return wrap("translate", () => handle(this.#raw.translate(shape, dx, dy, dz)));
     }
 
+    /**
+     * Translate along X so the chosen bounding-box anchor lands at `target`.
+     * Returns a new shape; the input is left untouched.
+     */
+    alignX(shape: ShapeHandle, target = 0, anchor: AlignAnchor = "center"): ShapeHandle {
+        return wrap("alignX", () => {
+            const bb = this.getBoundingBox(shape, false);
+            const cur = anchor === "min" ? bb.xmin : anchor === "max" ? bb.xmax : (bb.xmin + bb.xmax) / 2;
+            return handle(this.#raw.translate(shape, target - cur, 0, 0));
+        });
+    }
+
+    /** Translate along Y so the chosen bounding-box anchor lands at `target`. */
+    alignY(shape: ShapeHandle, target = 0, anchor: AlignAnchor = "center"): ShapeHandle {
+        return wrap("alignY", () => {
+            const bb = this.getBoundingBox(shape, false);
+            const cur = anchor === "min" ? bb.ymin : anchor === "max" ? bb.ymax : (bb.ymin + bb.ymax) / 2;
+            return handle(this.#raw.translate(shape, 0, target - cur, 0));
+        });
+    }
+
+    /** Translate along Z so the chosen bounding-box anchor lands at `target`. */
+    alignZ(shape: ShapeHandle, target = 0, anchor: AlignAnchor = "center"): ShapeHandle {
+        return wrap("alignZ", () => {
+            const bb = this.getBoundingBox(shape, false);
+            const cur = anchor === "min" ? bb.zmin : anchor === "max" ? bb.zmax : (bb.zmin + bb.zmax) / 2;
+            return handle(this.#raw.translate(shape, 0, 0, target - cur));
+        });
+    }
+
     rotate(
         shape: ShapeHandle,
         axis: { point: Vec3; direction: Vec3 },
@@ -1705,6 +1752,23 @@ export class OcctKernel {
                 hiddenSharp: handle(raw.hiddenSharp),
             };
         });
+    }
+
+    /**
+     * Render a single named view of a shape to a standalone SVG string via
+     * hidden-line removal. Visible edges are solid, hidden edges dashed.
+     */
+    toSVG(shape: ShapeHandle, view: ViewName = "front", options: SvgViewOptions = {}): string {
+        return wrap("toSVG", () => renderShapeSVGImpl(this, shape, view, options));
+    }
+
+    /**
+     * Render a multiview grid (default Front / Top / Right / Iso) of a shape to
+     * a single SVG string, with per-view gnomons and an overall size annotation.
+     * Aimed at giving an automated agent a readable picture of the geometry.
+     */
+    toMultiviewSVG(shape: ShapeHandle, options: MultiviewSvgOptions = {}): string {
+        return wrap("toMultiviewSVG", () => renderMultiviewSVGImpl(this, shape, options));
     }
 
     // =======================================================================

--- a/ts/src/svg.ts
+++ b/ts/src/svg.ts
@@ -1,0 +1,442 @@
+/**
+ * Multiview SVG rendering for OCCT shapes.
+ *
+ * Renders a shape to compact, deterministic SVG by running OCCT hidden-line
+ * removal (`projectEdges`) per view, discretizing the projected edges
+ * (`wireframe`), and mapping the flattened 3D points into 2D screen space.
+ *
+ * The default output is a 4-up Front / Top / Right / Isometric grid with
+ * visible edges drawn solid and hidden edges dashed, a per-view XYZ gnomon,
+ * and an overall bounding-box annotation — a layout aimed at letting an
+ * automated agent reason about geometry it cannot otherwise see.
+ *
+ * @module
+ */
+
+import type { BoundingBox, ProjectionData, ShapeHandle, Vec3 } from "./types.js";
+
+/** The subset of the kernel API the SVG renderer depends on. */
+export interface SvgKernel {
+    getBoundingBox(shape: ShapeHandle, useTriangulation: boolean): BoundingBox;
+    projectEdges(
+        shape: ShapeHandle,
+        viewOrigin: Vec3,
+        viewDirection: Vec3,
+        xAxis?: Vec3,
+    ): ProjectionData;
+    wireframe(shape: ShapeHandle, deflection?: number): {
+        points: Float32Array;
+        edgeGroups: Int32Array;
+    };
+    release(shape: ShapeHandle): void;
+}
+
+/** A named orthographic or isometric viewpoint. */
+export type ViewName = "front" | "back" | "top" | "bottom" | "left" | "right" | "iso";
+
+/** Options shared by single-view and multiview rendering. */
+export interface SvgViewOptions {
+    /** Panel width in px (default 240). */
+    width?: number;
+    /** Panel height in px (default 240). */
+    height?: number;
+    /** Inner padding in px (default 14). */
+    padding?: number;
+    /**
+     * Wireframe sampling deflection in model units. Defaults to ~0.2% of the
+     * bounding-box diagonal so output is scale-independent.
+     */
+    deflection?: number;
+    /** Draw hidden (occluded) edges dashed (default true). */
+    showHidden?: boolean;
+    /** Draw a small XYZ axis gnomon in each panel (default true). */
+    showGnomon?: boolean;
+    /** Stroke width for visible edges in px (default 1). */
+    strokeWidth?: number;
+    /** Panel background fill (default "#ffffff"). */
+    background?: string;
+    /** Visible-edge stroke color (default "#111111"). */
+    visibleColor?: string;
+    /** Hidden-edge stroke color (default "#9aa0a6"). */
+    hiddenColor?: string;
+}
+
+/** Options for the multiview grid. */
+export interface MultiviewSvgOptions extends SvgViewOptions {
+    /** Views to render, in order (default front, top, right, iso). */
+    views?: ViewName[];
+    /** Panels per row (default 2). */
+    columns?: number;
+    /** Draw the per-view name label (default true). */
+    showLabels?: boolean;
+    /** Annotate overall X×Y×Z size in a footer (default true). */
+    showDimensions?: boolean;
+}
+
+interface ViewBasis {
+    /** Projection direction (camera looks along this). */
+    dir: Vec3;
+    /** Screen-horizontal axis (points right). */
+    sx: Vec3;
+    /** Screen-vertical axis (points up). */
+    sy: Vec3;
+}
+
+const ORIGIN: Vec3 = { x: 0, y: 0, z: 0 };
+
+// gp_Ax2(origin, dir, xAxis) uses Y = dir × xAxis as its vertical, so the
+// screen-up axis below is computed the same way to match the HLR projection.
+function basisFor(view: ViewName): ViewBasis {
+    switch (view) {
+        case "front":
+            return { dir: v(0, 1, 0), sx: v(1, 0, 0), sy: v(0, 0, 1) };
+        case "back":
+            return { dir: v(0, -1, 0), sx: v(-1, 0, 0), sy: v(0, 0, 1) };
+        case "top":
+            return { dir: v(0, 0, -1), sx: v(1, 0, 0), sy: v(0, 1, 0) };
+        case "bottom":
+            return { dir: v(0, 0, 1), sx: v(1, 0, 0), sy: v(0, -1, 0) };
+        case "right":
+            return { dir: v(-1, 0, 0), sx: v(0, 1, 0), sy: v(0, 0, 1) };
+        case "left":
+            return { dir: v(1, 0, 0), sx: v(0, -1, 0), sy: v(0, 0, 1) };
+        case "iso": {
+            const dir = normalize(v(-1, -1, -1));
+            const sx = normalize(v(1, -1, 0));
+            // Screen-up = dir × sx, oriented so world +Z reads upward.
+            let sy = cross(dir, sx);
+            if (sy.z < 0) sy = neg(sy);
+            return { dir, sx, sy };
+        }
+    }
+}
+
+const VIEW_LABEL: Record<ViewName, string> = {
+    front: "Front",
+    back: "Back",
+    top: "Top",
+    bottom: "Bottom",
+    left: "Left",
+    right: "Right",
+    iso: "Iso",
+};
+
+// --- vector helpers ---------------------------------------------------------
+
+function v(x: number, y: number, z: number): Vec3 {
+    return { x, y, z };
+}
+function dot(a: Vec3, b: Vec3): number {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+function cross(a: Vec3, b: Vec3): Vec3 {
+    return {
+        x: a.y * b.z - a.z * b.y,
+        y: a.z * b.x - a.x * b.z,
+        z: a.x * b.y - a.y * b.x,
+    };
+}
+function neg(a: Vec3): Vec3 {
+    return { x: -a.x, y: -a.y, z: -a.z };
+}
+function normalize(a: Vec3): Vec3 {
+    const len = Math.hypot(a.x, a.y, a.z) || 1;
+    return { x: a.x / len, y: a.y / len, z: a.z / len };
+}
+
+// --- projection / discretization -------------------------------------------
+
+/** A 2D polyline in view (u up-positive) coordinates. */
+type Polyline = number[]; // [u0, v0, u1, v1, ...]
+
+interface ViewEdges {
+    visible: Polyline[];
+    hidden: Polyline[];
+}
+
+const PROJECTION_FIELDS: Array<keyof ProjectionData> = [
+    "visibleOutline",
+    "visibleSmooth",
+    "visibleSharp",
+    "hiddenOutline",
+    "hiddenSmooth",
+    "hiddenSharp",
+];
+
+function collectEdges(
+    kernel: SvgKernel,
+    shape: ShapeHandle,
+    basis: ViewBasis,
+    deflection: number,
+): ViewEdges {
+    const proj = kernel.projectEdges(shape, ORIGIN, basis.dir, basis.sx);
+    try {
+        const toLines = (h: ShapeHandle): Polyline[] => {
+            if (Number(h) === 0) return [];
+            const { points, edgeGroups } = kernel.wireframe(h, deflection);
+            const lines: Polyline[] = [];
+            for (let g = 0; g < edgeGroups.length; g += 3) {
+                const start = edgeGroups[g]!;
+                const count = edgeGroups[g + 1]!;
+                const line: Polyline = [];
+                for (let i = 0; i < count; i += 3) {
+                    const p = v(points[start + i]!, points[start + i + 1]!, points[start + i + 2]!);
+                    line.push(dot(p, basis.sx), dot(p, basis.sy));
+                }
+                if (line.length >= 4) lines.push(line);
+            }
+            return lines;
+        };
+        return {
+            visible: [
+                ...toLines(proj.visibleOutline),
+                ...toLines(proj.visibleSmooth),
+                ...toLines(proj.visibleSharp),
+            ],
+            hidden: [
+                ...toLines(proj.hiddenOutline),
+                ...toLines(proj.hiddenSmooth),
+                ...toLines(proj.hiddenSharp),
+            ],
+        };
+    } finally {
+        for (const field of PROJECTION_FIELDS) {
+            const h = proj[field] as ShapeHandle;
+            if (Number(h) !== 0) kernel.release(h);
+        }
+    }
+}
+
+// --- SVG assembly -----------------------------------------------------------
+
+function round(n: number): number {
+    return Math.round(n * 100) / 100;
+}
+
+function esc(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** 2D extent of a set of polylines in view coords. */
+interface Extent {
+    minU: number;
+    maxU: number;
+    minV: number;
+    maxV: number;
+}
+
+function extentOf(views: ViewEdges[]): Extent {
+    let minU = Infinity;
+    let maxU = -Infinity;
+    let minV = Infinity;
+    let maxV = -Infinity;
+    for (const view of views) {
+        for (const line of [...view.visible, ...view.hidden]) {
+            for (let i = 0; i < line.length; i += 2) {
+                const u = line[i]!;
+                const vv = line[i + 1]!;
+                if (u < minU) minU = u;
+                if (u > maxU) maxU = u;
+                if (vv < minV) minV = vv;
+                if (vv > maxV) maxV = vv;
+            }
+        }
+    }
+    if (!Number.isFinite(minU)) return { minU: 0, maxU: 0, minV: 0, maxV: 0 };
+    return { minU, maxU, minV, maxV };
+}
+
+interface PanelTransform {
+    scale: number;
+    offsetX: number;
+    offsetY: number;
+    inner: number;
+    panelW: number;
+    panelH: number;
+    pad: number;
+}
+
+/**
+ * Build a view→pixel mapping for one panel. All panels share `scale` (so the
+ * part is the same size everywhere) but center on their own projected midpoint.
+ */
+function panelTransform(
+    ext: Extent,
+    scale: number,
+    panelW: number,
+    panelH: number,
+    pad: number,
+): PanelTransform {
+    const midU = (ext.minU + ext.maxU) / 2;
+    const midV = (ext.minV + ext.maxV) / 2;
+    // Screen y is inverted (v-up → y-down); center within the panel.
+    const offsetX = panelW / 2 - midU * scale;
+    const offsetY = panelH / 2 + midV * scale;
+    return { scale, offsetX, offsetY, inner: Math.min(panelW, panelH) - 2 * pad, panelW, panelH, pad };
+}
+
+function pathData(lines: Polyline[], t: PanelTransform): string {
+    let d = "";
+    for (const line of lines) {
+        for (let i = 0; i < line.length; i += 2) {
+            const x = round(line[i]! * t.scale + t.offsetX);
+            const y = round(-line[i + 1]! * t.scale + t.offsetY);
+            d += `${i === 0 ? "M" : "L"}${x} ${y}`;
+        }
+    }
+    return d;
+}
+
+function gnomon(basis: ViewBasis, t: PanelTransform): string {
+    const len = 18;
+    const ox = t.pad + len + 4;
+    const oy = t.panelH - t.pad - len - 4;
+    const axes: Array<[Vec3, string, string]> = [
+        [v(1, 0, 0), "#d33", "X"],
+        [v(0, 1, 0), "#3a3", "Y"],
+        [v(0, 0, 1), "#36c", "Z"],
+    ];
+    let s = "";
+    for (const [axis, color, name] of axes) {
+        const dx = dot(axis, basis.sx);
+        const dy = -dot(axis, basis.sy);
+        if (Math.hypot(dx, dy) < 0.05) continue; // axis points into the screen
+        const ex = round(ox + dx * len);
+        const ey = round(oy + dy * len);
+        s += `<line x1="${round(ox)}" y1="${round(oy)}" x2="${ex}" y2="${ey}" stroke="${color}" stroke-width="1.5"/>`;
+        s += `<text x="${ex}" y="${ey}" font-size="9" fill="${color}" text-anchor="middle" dominant-baseline="middle">${name}</text>`;
+    }
+    return s;
+}
+
+function resolved(options: SvgViewOptions) {
+    return {
+        width: options.width ?? 240,
+        height: options.height ?? 240,
+        padding: options.padding ?? 14,
+        showHidden: options.showHidden ?? true,
+        showGnomon: options.showGnomon ?? true,
+        strokeWidth: options.strokeWidth ?? 1,
+        background: options.background ?? "#ffffff",
+        visibleColor: options.visibleColor ?? "#111111",
+        hiddenColor: options.hiddenColor ?? "#9aa0a6",
+    };
+}
+
+function deflectionFor(kernel: SvgKernel, shape: ShapeHandle, options: SvgViewOptions): number {
+    if (options.deflection !== undefined) return options.deflection;
+    const bb = kernel.getBoundingBox(shape, false);
+    const diag = Math.hypot(bb.xmax - bb.xmin, bb.ymax - bb.ymin, bb.zmax - bb.zmin);
+    return Math.max(diag * 0.002, 1e-4);
+}
+
+function panelSvg(
+    edges: ViewEdges,
+    basis: ViewBasis,
+    t: PanelTransform,
+    o: ReturnType<typeof resolved>,
+    label: string | null,
+): string {
+    let body = `<rect x="0.5" y="0.5" width="${t.panelW - 1}" height="${t.panelH - 1}" fill="${o.background}" stroke="#e0e0e0"/>`;
+    if (o.showHidden && edges.hidden.length > 0) {
+        const d = pathData(edges.hidden, t);
+        if (d)
+            body += `<path d="${d}" fill="none" stroke="${o.hiddenColor}" stroke-width="${o.strokeWidth}" stroke-dasharray="3 2"/>`;
+    }
+    if (edges.visible.length > 0) {
+        const d = pathData(edges.visible, t);
+        if (d)
+            body += `<path d="${d}" fill="none" stroke="${o.visibleColor}" stroke-width="${o.strokeWidth}" stroke-linejoin="round" stroke-linecap="round"/>`;
+    }
+    if (o.showGnomon) body += gnomon(basis, t);
+    if (label !== null)
+        body += `<text x="${t.pad}" y="${t.pad + 4}" font-size="11" fill="#333" font-family="sans-serif">${esc(label)}</text>`;
+    return body;
+}
+
+/**
+ * Render a single named view of `shape` to a standalone SVG string.
+ */
+export function renderShapeSVG(
+    kernel: SvgKernel,
+    shape: ShapeHandle,
+    view: ViewName = "front",
+    options: SvgViewOptions = {},
+): string {
+    const o = resolved(options);
+    const basis = basisFor(view);
+    const deflection = deflectionFor(kernel, shape, options);
+    const edges = collectEdges(kernel, shape, basis, deflection);
+    const ext = extentOf([edges]);
+    const inner = Math.min(o.width, o.height) - 2 * o.padding;
+    const range = Math.max(ext.maxU - ext.minU, ext.maxV - ext.minV, 1e-9);
+    const scale = inner / range;
+    const t = panelTransform(ext, scale, o.width, o.height, o.padding);
+    const body = panelSvg(edges, basis, t, o, null);
+    return (
+        `<svg xmlns="http://www.w3.org/2000/svg" width="${o.width}" height="${o.height}" ` +
+        `viewBox="0 0 ${o.width} ${o.height}">${body}</svg>`
+    );
+}
+
+/**
+ * Render a multiview grid (default Front / Top / Right / Iso) of `shape` to a
+ * single SVG string. All orthographic panels share one scale; an optional
+ * footer annotates the overall X×Y×Z size.
+ */
+export function renderMultiviewSVG(
+    kernel: SvgKernel,
+    shape: ShapeHandle,
+    options: MultiviewSvgOptions = {},
+): string {
+    const o = resolved(options);
+    const views = options.views ?? ["front", "top", "right", "iso"];
+    const columns = options.columns ?? 2;
+    const showLabels = options.showLabels ?? true;
+    const showDimensions = options.showDimensions ?? true;
+    const deflection = deflectionFor(kernel, shape, options);
+
+    const bases = views.map(basisFor);
+    const edges = bases.map((b) => collectEdges(kernel, shape, b, deflection));
+    const extents = edges.map((e) => extentOf([e]));
+
+    // One global scale so the part is sized consistently across all panels.
+    const inner = Math.min(o.width, o.height) - 2 * o.padding;
+    let maxRange = 1e-9;
+    for (const ext of extents) {
+        maxRange = Math.max(maxRange, ext.maxU - ext.minU, ext.maxV - ext.minV);
+    }
+    const scale = inner / maxRange;
+
+    const rows = Math.ceil(views.length / columns);
+    const footerH = showDimensions ? 22 : 0;
+    const totalW = columns * o.width;
+    const totalH = rows * o.height + footerH;
+
+    let panels = "";
+    for (let i = 0; i < views.length; i++) {
+        const col = i % columns;
+        const row = Math.floor(i / columns);
+        const px = col * o.width;
+        const py = row * o.height;
+        const t = panelTransform(extents[i]!, scale, o.width, o.height, o.padding);
+        const label = showLabels ? VIEW_LABEL[views[i]!] : null;
+        panels += `<g transform="translate(${px} ${py})">${panelSvg(edges[i]!, bases[i]!, t, o, label)}</g>`;
+    }
+
+    let footer = "";
+    if (showDimensions) {
+        const bb = kernel.getBoundingBox(shape, false);
+        const dims = `${round(bb.xmax - bb.xmin)} × ${round(bb.ymax - bb.ymin)} × ${round(bb.zmax - bb.zmin)} (X×Y×Z)`;
+        footer =
+            `<text x="${totalW / 2}" y="${rows * o.height + 15}" font-size="11" fill="#444" ` +
+            `font-family="sans-serif" text-anchor="middle">${esc(dims)}</text>`;
+    }
+
+    return (
+        `<svg xmlns="http://www.w3.org/2000/svg" width="${totalW}" height="${totalH}" ` +
+        `viewBox="0 0 ${totalW} ${totalH}">` +
+        `<rect width="${totalW}" height="${totalH}" fill="${o.background}"/>` +
+        `${panels}${footer}</svg>`
+    );
+}

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -144,6 +144,9 @@ export type ShapeOrientation = "forward" | "reversed" | "internal" | "external";
 /** BRepClass_FaceClassifier result for a UV point relative to a face boundary. */
 export type PointClassification = "in" | "on" | "out";
 
+/** Which extreme of a shape's bounding box to align to a target coordinate. */
+export type AlignAnchor = "min" | "center" | "max";
+
 /** Geom_Surface subclass identifier returned by surfaceType. */
 export type SurfaceKind = "plane" | "cylinder" | "cone" | "sphere" | "torus" | "bspline" | "bezier" | "offset" | "revolution" | "extrusion" | (string & {});
 

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -164,6 +164,16 @@ export enum TransitionMode {
 }
 
 /** Join type for offset/fillet operations (BRepOffsetAPI_MakeOffset). */
+/** Profile-orientation mode for {@link OcctKernel.sweepOriented}. */
+export enum SweepMode {
+    /** Minimal-torsion parallel transport — profile does not rotate (corrected Frenet). */
+    Fixed = 0,
+    /** Profile follows the spine's principal normal (Frenet trihedron). */
+    Frenet = 1,
+    /** Profile keeps a caller-supplied up/binormal direction constant. */
+    FixedUp = 2,
+}
+
 export enum JoinType {
     /** Arc interpolation at joints (default). */
     Arc = 0,

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -131,6 +131,44 @@ return store(xform.Shape());",
         return_type: ReturnType::ShapeId,
     },
     MethodSpec {
+        name: "halfSpace",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::Double("ox"),
+            FacadeParam::Double("oy"),
+            FacadeParam::Double("oz"),
+            FacadeParam::Double("nx"),
+            FacadeParam::Double("ny"),
+            FacadeParam::Double("nz"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        // Infinite solid bounded by the plane (origin, normal). The reference
+        // point sits on the +normal side, so the solid fills the half the
+        // normal points into.
+        setup_code: "\
+gp_Pnt origin(ox, oy, oz);
+gp_Dir normal(nx, ny, nz);
+gp_Pln plane(origin, normal);
+TopoDS_Face face = BRepBuilderAPI_MakeFace(plane).Face();
+gp_Pnt refPnt = origin.Translated(gp_Vec(normal));
+BRepPrimAPI_MakeHalfSpace maker(face, refPnt);
+if (!maker.IsDone()) {
+    throw std::runtime_error(\"halfSpace: construction failed\");
+}
+return store(maker.Solid());",
+        includes: &[
+            "BRepPrimAPI_MakeHalfSpace.hxx",
+            "BRepBuilderAPI_MakeFace.hxx",
+            "gp_Pln.hxx",
+            "gp_Pnt.hxx",
+            "gp_Dir.hxx",
+            "gp_Vec.hxx",
+        ],
+        category: "primitives",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
         name: "makeRectangle",
         kind: MethodKind::CustomBody,
         params: &[FacadeParam::Double("width"), FacadeParam::Double("height")],
@@ -2875,6 +2913,53 @@ return store(maker.Shape());",
         return_type: ReturnType::ShapeId,
     },
     MethodSpec {
+        name: "sweepOriented",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::ShapeId("profileId"),
+            FacadeParam::ShapeId("spineId"),
+            FacadeParam::Int("mode"),
+            FacadeParam::Double("upX"),
+            FacadeParam::Double("upY"),
+            FacadeParam::Double("upZ"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        // mode 0 = Fixed (corrected Frenet, minimal torsion), 1 = Frenet
+        // (follows the principal normal), 2 = FixedUp (constant binormal).
+        setup_code: "\
+BRepOffsetAPI_MakePipeShell maker(TopoDS::Wire(get(spineId)));
+switch (mode) {
+    case 0:
+        maker.SetMode(Standard_False);
+        break;
+    case 1:
+        maker.SetMode(Standard_True);
+        break;
+    case 2: {
+        gp_Dir up(upX, upY, upZ);
+        maker.SetMode(up);
+        break;
+    }
+    default:
+        throw std::runtime_error(\"sweepOriented: invalid mode\");
+}
+maker.Add(get(profileId));
+maker.Build();
+if (!maker.IsDone()) {
+    throw std::runtime_error(\"sweepOriented: operation failed\");
+}
+maker.MakeSolid();
+return store(maker.Shape());",
+        includes: &[
+            "BRepOffsetAPI_MakePipeShell.hxx",
+            "TopoDS.hxx",
+            "gp_Dir.hxx",
+        ],
+        category: "sweep",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
         name: "draftPrism",
         kind: MethodKind::CustomBody,
         params: &[
@@ -4628,7 +4713,7 @@ mod tests {
             .iter()
             .filter(|m| m.kind != MethodKind::Skip)
             .count();
-        assert_eq!(count, 178, "expected 178 generable methods");
+        assert_eq!(count, 180, "expected 180 generable methods");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three additive CAD capabilities, no breaking changes:

### 1. Multiview SVG rendering (TS)
`toSVG(shape, view)` and `toMultiviewSVG(shape, opts)` render a shape via OCCT
hidden-line removal. The default multiview output is a labeled Front / Top /
Right / Iso grid with:
- visible edges solid, hidden edges dashed (so occlusion is inferable),
- a per-view XYZ gnomon,
- a shared scale across orthographic panels + auto-fit, and
- an overall `X×Y×Z` size annotation.

It's aimed at giving an automated agent a compact, deterministic picture of the
geometry it's building. Pure TS over the existing `projectEdges` + `wireframe`
output — **no WASM change** for this part. Standalone `renderShapeSVG` /
`renderMultiviewSVG` functions are exported too.

### 2. Oriented sweep (facade)
`sweepOriented(profile, spine, mode, up)` exposes
`BRepOffsetAPI_MakePipeShell::SetMode`:
- `SweepMode.Fixed` — minimal-torsion parallel transport (corrected Frenet),
- `SweepMode.Frenet` — follows the spine's principal normal,
- `SweepMode.FixedUp` — keeps a caller-supplied up/binormal constant.

Existing `sweep()` / `sweepPipeShell()` are untouched.

### 3. Ergonomic adds
- `halfSpace(origin, normal)` — infinite half-space solid (`BRepPrimAPI_MakeHalfSpace`), handy as an unbounded boolean cutting tool.
- `alignX/Y/Z(shape, target, anchor)` — bounding-box alignment (min/center/max) to a target coordinate.

## Implementation notes
- The two facade methods are declared once in the codegen config
  (`xtask/src/codegen/config.rs`), which emits the Embind binding, WASI export,
  Rust host wrapper, and `kernel.cpp` body. Header declarations and TS wrappers
  are hand-added.
- New `examples/node-cli/multiview-svg.mjs` exercises all three features.

## Testing
- New `test/svg.test.ts` (8) and `test/facade-cad-features.test.ts` (5) run
  against a fresh release WASM build via the real TS wrapper.
- Full suite: **297 passed / 2 skipped**, 17 files.
- Bench check vs baseline: **no regressions**.
- `tsc`, `eslint`, `cargo fmt`, and `cargo test -p xtask` all clean.
- Example verified end-to-end (oriented sweep + half-space cut → 4-panel SVG).

## Follow-up
`crate/src/occt-wasm.wasm.br` (the embedded WASI binary for the Rust crate) is
unchanged here; it must be refreshed from the CI build before a crate release
exposes `sweep_oriented` / `half_space`. No existing crate test calls the new
methods, so crate CI stays green.
