### PR TITLE
feat: inertia, point-in-solid, binary BREP, clamped B-splines, curve projection, relative meshing, aux-spine sweep, intersection cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,17 +303,17 @@ Generate full docs locally: `cd ts && npm run docs` (TypeDoc output).
 | Category         | What's covered                                                                                                 |
 | ---------------- | -------------------------------------------------------------------------------------------------------------- |
 | **Primitives**   | Box, cylinder, sphere, cone, torus, ellipsoid, rectangle, half-space                                           |
-| **Booleans**     | Fuse, cut, common, intersect, section + multi-shape variants                                                   |
+| **Booleans**     | Fuse, cut, common, intersect, section + multi-shape variants, intersection cells                               |
 | **Modeling**     | Extrude, revolve, fillet, chamfer, shell, offset, draft                                                        |
-| **Sweeps**       | Pipe, loft, sweep, oriented sweep (fixed/Frenet/up-axis), draft prism, extrusion laws                          |
+| **Sweeps**       | Pipe, loft, sweep, oriented sweep (fixed/Frenet/up-axis/auxiliary), draft prism, extrusion laws                |
 | **Construction** | Vertices, edges (line/arc/circle/ellipse/bezier/helix), wires, faces, solids, compounds, sewing                |
 | **Transforms**   | Translate, rotate, scale, mirror, align to bounding box, 3x4 matrix, linear/circular patterns                  |
 | **Topology**     | Shape type queries, type predicates, sub-shape extraction, adjacency, hash codes                               |
-| **Tessellation** | Triangle meshes, wireframe polylines, per-face groups, batched multi-shape meshing                             |
-| **I/O**          | STEP, STL, BREP import/export                                                                                  |
-| **Query**        | Bounding box, volume, surface area, length, center of mass, curvature                                          |
+| **Tessellation** | Triangle meshes (absolute or relative deflection), wireframe polylines, per-face groups, batched meshing       |
+| **I/O**          | STEP, STL, BREP (text + binary) import/export                                                                  |
+| **Query**        | Bounding box, volume, surface area, length, center of mass, inertia tensor, point-in-solid, curvature          |
 | **Surfaces**     | Type, normal, UV bounds, point classification, B-spline construction                                           |
-| **Curves**       | Type, point/tangent evaluation, parameters, NURBS data extraction, interpolation                               |
+| **Curves**       | Type, point/tangent eval, parameters, NURBS data, interpolation (incl. clamped tangents), project point        |
 | **Projection**   | Hidden line removal (HLR), multiview SVG render (Front/Top/Right/Iso)                                          |
 | **Modifiers**    | Thicken, defeature, reverse, simplify, variable fillet, 2D wire offset                                         |
 | **Evolution**    | Face-tracking history for translate, fuse, cut, fillet, rotate, mirror, scale, chamfer, shell, offset, thicken |

--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -40,6 +40,7 @@ pub(crate) struct GeneratedFuncs {
     fn_section: TypedFunc<(u32, u32), u32>,
     fn_intersect: TypedFunc<(u32, u32), u32>,
     fn_fuse_all: TypedFunc<(i32, i32), u32>,
+    fn_intersection_cells: TypedFunc<(i32, i32), u32>,
     fn_cut_all: TypedFunc<(u32, i32, i32), u32>,
     fn_boolean_pipeline: TypedFunc<(u32, i32, i32, i32, i32), u32>,
     fn_split: TypedFunc<(u32, i32, i32), u32>,
@@ -116,6 +117,8 @@ pub(crate) struct GeneratedFuncs {
     fn_get_surface_area: TypedFunc<(u32,), f64>,
     fn_get_length: TypedFunc<(u32,), f64>,
     fn_get_center_of_mass: TypedFunc<(u32,), i32>,
+    fn_get_inertia: TypedFunc<(u32,), i32>,
+    fn_contains_point: TypedFunc<(u32, f64, f64, f64, f64), i32>,
     fn_get_surface_center_of_mass: TypedFunc<(u32,), i32>,
     fn_vertex_position: TypedFunc<(u32,), i32>,
     fn_surface_type: TypedFunc<(u32,), i32>,
@@ -136,6 +139,8 @@ pub(crate) struct GeneratedFuncs {
     fn_curve_is_closed: TypedFunc<(u32,), i32>,
     fn_curve_length: TypedFunc<(u32,), f64>,
     fn_interpolate_points: TypedFunc<(i32, i32, i32), u32>,
+    fn_interpolate_points_with_tangents: TypedFunc<(i32, i32, f64, f64, f64, f64, f64, f64), u32>,
+    fn_project_point_on_edge: TypedFunc<(u32, f64, f64, f64), i32>,
     fn_curve_is_periodic: TypedFunc<(u32,), i32>,
     fn_approximate_points: TypedFunc<(i32, i32, f64), u32>,
     fn_lift_curve2d_to_plane:
@@ -150,7 +155,7 @@ pub(crate) struct GeneratedFuncs {
     fn_loft_with_vertices: TypedFunc<(i32, i32, i32, i32, u32, u32), u32>,
     fn_sweep: TypedFunc<(u32, u32, i32), u32>,
     fn_sweep_pipe_shell: TypedFunc<(u32, u32, i32, i32), u32>,
-    fn_sweep_oriented: TypedFunc<(u32, u32, i32, f64, f64, f64), u32>,
+    fn_sweep_oriented: TypedFunc<(u32, u32, i32, f64, f64, f64, u32), u32>,
     fn_draft_prism: TypedFunc<(u32, f64, f64, f64, f64), u32>,
     fn_fix_shape: TypedFunc<(u32,), u32>,
     fn_unify_same_domain: TypedFunc<(u32,), u32>,
@@ -168,6 +173,8 @@ pub(crate) struct GeneratedFuncs {
     fn_import_stl: TypedFunc<(i32, i32), u32>,
     fn_to_brep: TypedFunc<(u32,), i32>,
     fn_from_brep: TypedFunc<(i32, i32), u32>,
+    fn_export_brep_binary: TypedFunc<(u32,), i32>,
+    fn_import_brep_binary: TypedFunc<(i32, i32), u32>,
     fn_translate_with_history: TypedFunc<(u32, f64, f64, f64, i32, i32, i32), i32>,
     fn_fuse_with_history: TypedFunc<(u32, u32, i32, i32, i32), i32>,
     fn_cut_with_history: TypedFunc<(u32, u32, i32, i32, i32), i32>,
@@ -181,6 +188,7 @@ pub(crate) struct GeneratedFuncs {
     fn_offset_with_history: TypedFunc<(u32, f64, f64, i32, i32, i32), i32>,
     fn_thicken_with_history: TypedFunc<(u32, f64, f64, i32, i32, i32), i32>,
     fn_tessellate: TypedFunc<(u32, f64, f64), i32>,
+    fn_tessellate_relative: TypedFunc<(u32, f64, f64), i32>,
     fn_mesh_shape: TypedFunc<(u32, f64, f64), i32>,
     fn_mesh_batch: TypedFunc<(i32, i32, f64, f64), i32>,
     fn_wireframe: TypedFunc<(u32, f64), i32>,
@@ -226,6 +234,8 @@ impl GeneratedFuncs {
             fn_section: instance.get_typed_func(&mut store, "occt_section")?,
             fn_intersect: instance.get_typed_func(&mut store, "occt_intersect")?,
             fn_fuse_all: instance.get_typed_func(&mut store, "occt_fuse_all")?,
+            fn_intersection_cells: instance
+                .get_typed_func(&mut store, "occt_intersection_cells")?,
             fn_cut_all: instance.get_typed_func(&mut store, "occt_cut_all")?,
             fn_boolean_pipeline: instance.get_typed_func(&mut store, "occt_boolean_pipeline")?,
             fn_split: instance.get_typed_func(&mut store, "occt_split")?,
@@ -308,6 +318,8 @@ impl GeneratedFuncs {
             fn_get_length: instance.get_typed_func(&mut store, "occt_get_length")?,
             fn_get_center_of_mass: instance
                 .get_typed_func(&mut store, "occt_get_center_of_mass")?,
+            fn_get_inertia: instance.get_typed_func(&mut store, "occt_get_inertia")?,
+            fn_contains_point: instance.get_typed_func(&mut store, "occt_contains_point")?,
             fn_get_surface_center_of_mass: instance
                 .get_typed_func(&mut store, "occt_get_surface_center_of_mass")?,
             fn_vertex_position: instance.get_typed_func(&mut store, "occt_vertex_position")?,
@@ -335,6 +347,10 @@ impl GeneratedFuncs {
             fn_curve_length: instance.get_typed_func(&mut store, "occt_curve_length")?,
             fn_interpolate_points: instance
                 .get_typed_func(&mut store, "occt_interpolate_points")?,
+            fn_interpolate_points_with_tangents: instance
+                .get_typed_func(&mut store, "occt_interpolate_points_with_tangents")?,
+            fn_project_point_on_edge: instance
+                .get_typed_func(&mut store, "occt_project_point_on_edge")?,
             fn_curve_is_periodic: instance.get_typed_func(&mut store, "occt_curve_is_periodic")?,
             fn_approximate_points: instance
                 .get_typed_func(&mut store, "occt_approximate_points")?,
@@ -372,6 +388,10 @@ impl GeneratedFuncs {
             fn_import_stl: instance.get_typed_func(&mut store, "occt_import_stl")?,
             fn_to_brep: instance.get_typed_func(&mut store, "occt_to_brep")?,
             fn_from_brep: instance.get_typed_func(&mut store, "occt_from_brep")?,
+            fn_export_brep_binary: instance
+                .get_typed_func(&mut store, "occt_export_brep_binary")?,
+            fn_import_brep_binary: instance
+                .get_typed_func(&mut store, "occt_import_brep_binary")?,
             fn_translate_with_history: instance
                 .get_typed_func(&mut store, "occt_translate_with_history")?,
             fn_fuse_with_history: instance.get_typed_func(&mut store, "occt_fuse_with_history")?,
@@ -395,6 +415,8 @@ impl GeneratedFuncs {
             fn_thicken_with_history: instance
                 .get_typed_func(&mut store, "occt_thicken_with_history")?,
             fn_tessellate: instance.get_typed_func(&mut store, "occt_tessellate")?,
+            fn_tessellate_relative: instance
+                .get_typed_func(&mut store, "occt_tessellate_relative")?,
             fn_mesh_shape: instance.get_typed_func(&mut store, "occt_mesh_shape")?,
             fn_mesh_batch: instance.get_typed_func(&mut store, "occt_mesh_batch")?,
             fn_wireframe: instance.get_typed_func(&mut store, "occt_wireframe")?,
@@ -616,6 +638,23 @@ impl crate::kernel::OcctKernel {
         self.check_error("fuse_all")?;
         if result == 0 {
             return Err(self.read_last_error("fuse_all"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn intersection_cells(&mut self, shape_ids: &[ShapeHandle]) -> OcctResult<ShapeHandle> {
+        let shape_ids_bytes: Vec<u8> = shape_ids.iter().flat_map(|h| h.0.to_le_bytes()).collect();
+        let shape_ids_ptr = self.write_bytes(&shape_ids_bytes)?;
+        let shape_ids_len = shape_ids.len() as u32;
+        let result = self.generated.fn_intersection_cells.call(
+            &mut self.store,
+            (shape_ids_ptr as i32, shape_ids_len as i32),
+        );
+        self.free_bytes(shape_ids_ptr)?;
+        let result = result?;
+        self.check_error("intersection_cells")?;
+        if result == 0 {
+            return Err(self.read_last_error("intersection_cells"));
         }
         Ok(ShapeHandle(result))
     }
@@ -2103,6 +2142,35 @@ impl crate::kernel::OcctKernel {
         self.read_vec_f64_result()
     }
 
+    pub fn get_inertia(&mut self, id: ShapeHandle) -> OcctResult<Vec<f64>> {
+        let len = self
+            .generated
+            .fn_get_inertia
+            .call(&mut self.store, (id.0,))?;
+        if len < 0 {
+            return Err(self.read_last_error("get_inertia"));
+        }
+        self.read_vec_f64_result()
+    }
+
+    pub fn contains_point(
+        &mut self,
+        id: ShapeHandle,
+        x: f64,
+        y: f64,
+        z: f64,
+        tolerance: f64,
+    ) -> OcctResult<bool> {
+        let result = self
+            .generated
+            .fn_contains_point
+            .call(&mut self.store, (id.0, x, y, z, tolerance))?;
+        if result < 0 {
+            return Err(self.read_last_error("contains_point"));
+        }
+        Ok(result != 0)
+    }
+
     pub fn get_surface_center_of_mass(&mut self, face_id: ShapeHandle) -> OcctResult<Vec<f64>> {
         let len = self
             .generated
@@ -2361,6 +2429,58 @@ impl crate::kernel::OcctKernel {
             return Err(self.read_last_error("interpolate_points"));
         }
         Ok(ShapeHandle(result))
+    }
+
+    pub fn interpolate_points_with_tangents(
+        &mut self,
+        flat_points: &[f64],
+        start_tan_x: f64,
+        start_tan_y: f64,
+        start_tan_z: f64,
+        end_tan_x: f64,
+        end_tan_y: f64,
+        end_tan_z: f64,
+    ) -> OcctResult<ShapeHandle> {
+        let flat_points_bytes: Vec<u8> = flat_points.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let flat_points_ptr = self.write_bytes(&flat_points_bytes)?;
+        let flat_points_len = flat_points.len() as u32;
+        let result = self.generated.fn_interpolate_points_with_tangents.call(
+            &mut self.store,
+            (
+                flat_points_ptr as i32,
+                flat_points_len as i32,
+                start_tan_x,
+                start_tan_y,
+                start_tan_z,
+                end_tan_x,
+                end_tan_y,
+                end_tan_z,
+            ),
+        );
+        self.free_bytes(flat_points_ptr)?;
+        let result = result?;
+        self.check_error("interpolate_points_with_tangents")?;
+        if result == 0 {
+            return Err(self.read_last_error("interpolate_points_with_tangents"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn project_point_on_edge(
+        &mut self,
+        edge_id: ShapeHandle,
+        x: f64,
+        y: f64,
+        z: f64,
+    ) -> OcctResult<Vec<f64>> {
+        let len = self
+            .generated
+            .fn_project_point_on_edge
+            .call(&mut self.store, (edge_id.0, x, y, z))?;
+        if len < 0 {
+            return Err(self.read_last_error("project_point_on_edge"));
+        }
+        self.read_vec_f64_result()
     }
 
     pub fn curve_is_periodic(&mut self, id: ShapeHandle) -> OcctResult<bool> {
@@ -2635,10 +2755,19 @@ impl crate::kernel::OcctKernel {
         up_x: f64,
         up_y: f64,
         up_z: f64,
+        aux_spine_id: ShapeHandle,
     ) -> OcctResult<ShapeHandle> {
         let result = self.generated.fn_sweep_oriented.call(
             &mut self.store,
-            (profile_id.0, spine_id.0, mode, up_x, up_y, up_z),
+            (
+                profile_id.0,
+                spine_id.0,
+                mode,
+                up_x,
+                up_y,
+                up_z,
+                aux_spine_id.0,
+            ),
         )?;
         self.check_error("sweep_oriented")?;
         if result == 0 {
@@ -2862,6 +2991,33 @@ impl crate::kernel::OcctKernel {
         self.check_error("from_brep")?;
         if result == 0 {
             return Err(self.read_last_error("from_brep"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn export_brep_binary(&mut self, id: ShapeHandle) -> OcctResult<String> {
+        let len = self
+            .generated
+            .fn_export_brep_binary
+            .call(&mut self.store, (id.0,))?;
+        if len < 0 {
+            return Err(self.read_last_error("export_brep_binary"));
+        }
+        self.read_string_result()
+    }
+
+    pub fn import_brep_binary(&mut self, path: &str) -> OcctResult<ShapeHandle> {
+        let path_ptr = self.write_bytes(path.as_bytes())?;
+        let path_len = path.len() as u32;
+        let result = self
+            .generated
+            .fn_import_brep_binary
+            .call(&mut self.store, (path_ptr as i32, path_len as i32));
+        self.free_bytes(path_ptr)?;
+        let result = result?;
+        self.check_error("import_brep_binary")?;
+        if result == 0 {
+            return Err(self.read_last_error("import_brep_binary"));
         }
         Ok(ShapeHandle(result))
     }
@@ -3327,6 +3483,22 @@ impl crate::kernel::OcctKernel {
         )?;
         if status < 0 {
             return Err(self.read_last_error("tessellate"));
+        }
+        self.read_mesh_result()
+    }
+
+    pub fn tessellate_relative(
+        &mut self,
+        id: ShapeHandle,
+        linear_deflection: f64,
+        angular_deflection: f64,
+    ) -> OcctResult<Mesh> {
+        let status = self.generated.fn_tessellate_relative.call(
+            &mut self.store,
+            (id.0, linear_deflection, angular_deflection),
+        )?;
+        if status < 0 {
+            return Err(self.read_last_error("tessellate_relative"));
         }
         self.read_mesh_result()
     }

--- a/examples/node-cli/measure-and-cells.mjs
+++ b/examples/node-cli/measure-and-cells.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * occt-wasm measurement + cells example
+ *
+ * Demonstrates the inertia tensor, point-in-solid testing, intersection cells
+ * (the overlap region of two solids), and a binary-BREP round-trip.
+ *
+ * Requires the TS package to be built first:
+ *   cd ts && npm run build
+ *
+ * Usage:
+ *   node examples/node-cli/measure-and-cells.mjs
+ */
+
+import { OcctKernel } from "../../ts/dist/index.js";
+
+const kernel = await OcctKernel.init();
+
+try {
+    const box = kernel.makeBox(10, 20, 30);
+
+    // Mass properties.
+    const inertia = kernel.getInertia(box);
+    console.log("Inertia tensor (row-major, about origin):");
+    for (let r = 0; r < 3; r++) {
+        console.log("  " + inertia.slice(r * 3, r * 3 + 3).map((n) => n.toFixed(1)).join("  "));
+    }
+
+    // Containment.
+    console.log("contains (5,10,15):", kernel.containsPoint(box, { x: 5, y: 10, z: 15 }));
+    console.log("contains (50,0,0): ", kernel.containsPoint(box, { x: 50, y: 0, z: 0 }));
+
+    // Intersection cells: overlap region of two offset boxes.
+    const a = kernel.makeBox(10, 10, 10);
+    const b = kernel.translate(kernel.makeBox(10, 10, 10), 6, 6, 6);
+    const overlap = kernel.intersectionCells([a, b]);
+    console.log(`overlap volume: ${kernel.getVolume(overlap).toFixed(1)} mm^3 (expected 64)`);
+
+    // Binary BREP round-trip.
+    const bytes = kernel.toBREPBinary(box);
+    const restored = kernel.fromBREPBinary(bytes);
+    console.log(
+        `binary BREP: ${bytes.length} bytes, volume preserved = ` +
+            `${Math.abs(kernel.getVolume(box) - kernel.getVolume(restored)) < 1e-6}`,
+    );
+} finally {
+    kernel[Symbol.dispose]();
+}

--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -121,6 +121,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("section", &OcctKernel::section)
         .function("intersect", &OcctKernel::intersect)
         .function("fuseAll", &OcctKernel::fuseAll)
+        .function("intersectionCells", &OcctKernel::intersectionCells)
         .function("cutAll", &OcctKernel::cutAll)
         .function("booleanPipeline", &OcctKernel::booleanPipeline)
         .function("split", &OcctKernel::split)
@@ -208,6 +209,8 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("getSurfaceArea", &OcctKernel::getSurfaceArea)
         .function("getLength", &OcctKernel::getLength)
         .function("getCenterOfMass", &OcctKernel::getCenterOfMass)
+        .function("getInertia", &OcctKernel::getInertia)
+        .function("containsPoint", &OcctKernel::containsPoint)
         .function("getSurfaceCenterOfMass", &OcctKernel::getSurfaceCenterOfMass)
         .function("vertexPosition", &OcctKernel::vertexPosition)
         .function("surfaceType", &OcctKernel::surfaceType)
@@ -232,6 +235,8 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("curveIsClosed", &OcctKernel::curveIsClosed)
         .function("curveLength", &OcctKernel::curveLength)
         .function("interpolatePoints", &OcctKernel::interpolatePoints)
+        .function("interpolatePointsWithTangents", &OcctKernel::interpolatePointsWithTangents)
+        .function("projectPointOnEdge", &OcctKernel::projectPointOnEdge)
         .function("curveIsPeriodic", &OcctKernel::curveIsPeriodic)
         .function("approximatePoints", &OcctKernel::approximatePoints)
         .function("liftCurve2dToPlane", &OcctKernel::liftCurve2dToPlane)
@@ -266,6 +271,8 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("importStl", &OcctKernel::importStl)
         .function("toBREP", &OcctKernel::toBREP)
         .function("fromBREP", &OcctKernel::fromBREP)
+        .function("exportBrepBinary", &OcctKernel::exportBrepBinary)
+        .function("importBrepBinary", &OcctKernel::importBrepBinary)
 
         // evolution
         .function("translateWithHistory", &OcctKernel::translateWithHistory)
@@ -283,6 +290,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
 
         // tessellate
         .function("tessellate", &OcctKernel::tessellate)
+        .function("tessellateRelative", &OcctKernel::tessellateRelative)
         .function("meshShape", &OcctKernel::meshShape)
         .function("meshBatch", &OcctKernel::meshBatch)
         .function("wireframe", &OcctKernel::wireframe)

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -2,6 +2,7 @@
 
 #include "occt_kernel.h"
 
+#include <BOPAlgo_CellsBuilder.hxx>
 #include <BRepAdaptor_CompCurve.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepAdaptor_Surface.hxx>
@@ -23,6 +24,7 @@
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRepBuilderAPI_TransitionMode.hxx>
 #include <BRepCheck_Analyzer.hxx>
+#include <BRepClass3d_SolidClassifier.hxx>
 #include <BRepClass_FaceClassifier.hxx>
 #include <BRepExtrema_DistShapeShape.hxx>
 #include <BRepFilletAPI_MakeChamfer.hxx>
@@ -53,6 +55,7 @@
 #include <BRepTools.hxx>
 #include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
+#include <BinTools.hxx>
 #include <Bnd_Box.hxx>
 #include <GCPnts_AbscissaPoint.hxx>
 #include <GCPnts_TangentialDeflection.hxx>
@@ -64,6 +67,7 @@
 #include <GeomAPI_Interpolate.hxx>
 #include <GeomAPI_PointsToBSpline.hxx>
 #include <GeomAPI_PointsToBSplineSurface.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
 #include <GeomAPI_ProjectPointOnSurf.hxx>
 #include <GeomAbs_CurveType.hxx>
 #include <GeomAbs_JoinType.hxx>
@@ -73,6 +77,7 @@
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_BezierCurve.hxx>
 #include <Geom_Circle.hxx>
+#include <Geom_Curve.hxx>
 #include <Geom_CylindricalSurface.hxx>
 #include <Geom_Ellipse.hxx>
 #include <Geom_Plane.hxx>
@@ -143,6 +148,7 @@
 #include <gp_Dir2d.hxx>
 #include <gp_Elips.hxx>
 #include <gp_GTrsf.hxx>
+#include <gp_Mat.hxx>
 #include <gp_Pln.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Pnt2d.hxx>
@@ -445,6 +451,41 @@ uint32_t OcctKernel::fuseAll(std::vector<uint32_t> shapeIds) {
         return store(builder.Shape());
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("fuseAll: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::intersectionCells(std::vector<uint32_t> shapeIds) {
+    try {
+        if (shapeIds.size() < 2) {
+            throw std::runtime_error("intersectionCells: need at least 2 shapes");
+        }
+        std::vector<TopoDS_Shape> shapes;
+        NCollection_List<TopoDS_Shape> args;
+        for (uint32_t sid : shapeIds) {
+            const auto& s = get(sid);
+            shapes.push_back(s);
+            args.Append(s);
+        }
+        BOPAlgo_CellsBuilder builder;
+        builder.SetArguments(args);
+        builder.Perform();
+        if (builder.HasErrors()) {
+            throw std::runtime_error("intersectionCells: build failed");
+        }
+        builder.RemoveAllFromResult();
+        for (size_t i = 0; i < shapes.size(); ++i) {
+            for (size_t j = i + 1; j < shapes.size(); ++j) {
+                NCollection_List<TopoDS_Shape> take;
+                take.Append(shapes[i]);
+                take.Append(shapes[j]);
+                NCollection_List<TopoDS_Shape> avoid;
+                builder.AddToResult(take, avoid, 1, false);
+            }
+        }
+        builder.RemoveInternalBoundaries();
+        return store(builder.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("intersectionCells: ") + e.what());
     }
 }
 
@@ -1831,6 +1872,32 @@ std::vector<double> OcctKernel::getCenterOfMass(uint32_t id) {
     }
 }
 
+std::vector<double> OcctKernel::getInertia(uint32_t id) {
+    try {
+        const auto& shape = get(id);
+        GProp_GProps props;
+        BRepGProp::VolumeProperties(shape, props);
+        gp_Mat m = props.MatrixOfInertia();
+        return {m(1, 1), m(1, 2), m(1, 3),
+                m(2, 1), m(2, 2), m(2, 3),
+                m(3, 1), m(3, 2), m(3, 3)};
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("getInertia: ") + e.what());
+    }
+}
+
+bool OcctKernel::containsPoint(uint32_t id, double x, double y, double z, double tolerance) {
+    try {
+        const auto& shape = get(id);
+        BRepClass3d_SolidClassifier classifier(shape);
+        classifier.Perform(gp_Pnt(x, y, z), tolerance);
+        TopAbs_State state = classifier.State();
+        return state == TopAbs_IN || state == TopAbs_ON;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("containsPoint: ") + e.what());
+    }
+}
+
 std::vector<double> OcctKernel::getSurfaceCenterOfMass(uint32_t faceId) {
     try {
         const auto& face = get(faceId);
@@ -2213,6 +2280,57 @@ uint32_t OcctKernel::interpolatePoints(std::vector<double> flatPoints, bool peri
     }
 }
 
+uint32_t OcctKernel::interpolatePointsWithTangents(std::vector<double> flatPoints, double startTanX, double startTanY, double startTanZ, double endTanX, double endTanY, double endTanZ) {
+    try {
+        int nPts = static_cast<int>(flatPoints.size()) / 3;
+        if (nPts < 2) {
+            throw std::runtime_error("interpolatePointsWithTangents: need at least 2 points");
+        }
+        Handle(NCollection_HArray1<gp_Pnt>) pts = new NCollection_HArray1<gp_Pnt>(1, nPts);
+        for (int i = 0; i < nPts; i++) {
+            pts->SetValue(i + 1,
+                          gp_Pnt(flatPoints[i * 3], flatPoints[i * 3 + 1], flatPoints[i * 3 + 2]));
+        }
+        GeomAPI_Interpolate interp(pts, false, 1e-6);
+        gp_Vec startTan(startTanX, startTanY, startTanZ);
+        gp_Vec endTan(endTanX, endTanY, endTanZ);
+        interp.Load(startTan, endTan, Standard_True);
+        interp.Perform();
+        if (!interp.IsDone()) {
+            throw std::runtime_error("interpolatePointsWithTangents: interpolation failed");
+        }
+        BRepBuilderAPI_MakeEdge edgeMaker(interp.Curve());
+        if (!edgeMaker.IsDone()) {
+            throw std::runtime_error("interpolatePointsWithTangents: edge construction failed");
+        }
+        return store(edgeMaker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("interpolatePointsWithTangents: ") + e.what());
+    }
+}
+
+std::vector<double> OcctKernel::projectPointOnEdge(uint32_t edgeId, double x, double y, double z) {
+    try {
+        TopoDS_Edge edge = TopoDS::Edge(get(edgeId));
+        double first, last;
+        Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, first, last);
+        if (curve.IsNull()) {
+            throw std::runtime_error("projectPointOnEdge: edge has no 3D curve");
+        }
+        GeomAPI_ProjectPointOnCurve proj(gp_Pnt(x, y, z), curve, first, last);
+        if (proj.NbPoints() < 1) {
+            throw std::runtime_error("projectPointOnEdge: no projection found");
+        }
+        double param = proj.LowerDistanceParameter();
+        gp_Pnt cp;
+        gp_Vec tan;
+        curve->D1(param, cp, tan);
+        return {cp.X(), cp.Y(), cp.Z(), tan.X(), tan.Y(), tan.Z(), param};
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("projectPointOnEdge: ") + e.what());
+    }
+}
+
 bool OcctKernel::curveIsPeriodic(uint32_t id) {
     try {
         const auto& shape = get(id);
@@ -2448,7 +2566,7 @@ uint32_t OcctKernel::sweepPipeShell(uint32_t profileId, uint32_t spineId, bool f
     }
 }
 
-uint32_t OcctKernel::sweepOriented(uint32_t profileId, uint32_t spineId, int mode, double upX, double upY, double upZ) {
+uint32_t OcctKernel::sweepOriented(uint32_t profileId, uint32_t spineId, int mode, double upX, double upY, double upZ, uint32_t auxSpineId) {
     try {
         BRepOffsetAPI_MakePipeShell maker(TopoDS::Wire(get(spineId)));
         switch (mode) {
@@ -2463,6 +2581,9 @@ uint32_t OcctKernel::sweepOriented(uint32_t profileId, uint32_t spineId, int mod
                 maker.SetMode(up);
                 break;
             }
+            case 3:
+                maker.SetMode(TopoDS::Wire(get(auxSpineId)), Standard_True);
+                break;
             default:
                 throw std::runtime_error("sweepOriented: invalid mode");
         }
@@ -2737,6 +2858,29 @@ uint32_t OcctKernel::fromBREP(const std::string& data) {
     }
 }
 
+std::string OcctKernel::exportBrepBinary(uint32_t id) {
+    try {
+        std::string path = "/tmp/export.brep.bin";
+        BinTools::Write(get(id), path.c_str());
+        return path;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("exportBrepBinary: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::importBrepBinary(const std::string& path) {
+    try {
+        TopoDS_Shape shape;
+        BinTools::Read(shape, path.c_str());
+        if (shape.IsNull()) {
+            throw std::runtime_error("importBrepBinary: failed to read shape");
+        }
+        return store(shape);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("importBrepBinary: ") + e.what());
+    }
+}
+
 // === evolution ===
 
 EvolutionData OcctKernel::translateWithHistory(uint32_t id, double dx, double dy, double dz, std::vector<int> inputFaceHashes, int hashUpperBound) {
@@ -2970,157 +3114,17 @@ EvolutionData OcctKernel::thickenWithHistory(uint32_t shapeId, double thickness,
 
 MeshData OcctKernel::tessellate(uint32_t id, double linearDeflection, double angularDeflection) {
     try {
-        const auto& shape = get(id);
-        
-        BRepMesh_IncrementalMesh mesher(shape, linearDeflection, false, angularDeflection, false);
-        if (!mesher.IsDone()) {
-            throw std::runtime_error("tessellate: meshing failed");
-        }
-        
-        // Count totals
-        int totalNodes = 0;
-        int totalTris = 0;
-        int totalFaces = 0;
-        for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
-            TopLoc_Location loc;
-            auto tri = BRep_Tool::Triangulation(TopoDS::Face(ex.Current()), loc);
-            if (tri.IsNull())
-                continue;
-            totalNodes += tri->NbNodes();
-            totalTris += tri->NbTriangles();
-            totalFaces++;
-        }
-        
-        MeshData result;
-        result.positionCount = totalNodes * 3;
-        result.normalCount = totalNodes * 3;
-        result.uvCount = totalNodes * 2;
-        result.indexCount = totalTris * 3;
-        
-        result.positions = static_cast<float*>(std::malloc(result.positionCount * sizeof(float)));
-        result.normals = static_cast<float*>(std::malloc(result.normalCount * sizeof(float)));
-        result.uvs = static_cast<float*>(std::malloc(result.uvCount * sizeof(float)));
-        result.indices = static_cast<uint32_t*>(std::malloc(result.indexCount * sizeof(uint32_t)));
-        result.faceGroupCount = totalFaces * 3;
-        result.faceGroups =
-            static_cast<int32_t*>(std::malloc(result.faceGroupCount * sizeof(int32_t)));
-        
-        if ((!result.positions && result.positionCount > 0) ||
-            (!result.normals && result.normalCount > 0) ||
-            (!result.uvs && result.uvCount > 0) ||
-            (!result.indices && result.indexCount > 0) ||
-            (!result.faceGroups && result.faceGroupCount > 0)) {
-            throw std::runtime_error("tessellate: memory allocation failed");
-        }
-        
-        int vertexOffset = 0;
-        int triOffset = 0;
-        int faceGroupIdx = 0;
-        
-        for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
-            const auto& face = TopoDS::Face(ex.Current());
-            TopLoc_Location loc;
-            auto tri = BRep_Tool::Triangulation(face, loc);
-            if (tri.IsNull())
-                continue;
-        
-            const auto& trsf = loc.Transformation();
-            // Faces from primitives/booleans usually carry an identity location;
-            // skipping the per-vertex affine multiply there is the common-case win.
-            bool identityLoc = loc.IsIdentity();
-            int nbNodes = tri->NbNodes();
-            int nbTri = tri->NbTriangles();
-        
-            // Positions
-            if (identityLoc) {
-                for (int i = 1; i <= nbNodes; i++) {
-                    const gp_Pnt& p = tri->Node(i);
-                    int base = (vertexOffset + i - 1) * 3;
-                    result.positions[base + 0] = static_cast<float>(p.X());
-                    result.positions[base + 1] = static_cast<float>(p.Y());
-                    result.positions[base + 2] = static_cast<float>(p.Z());
-                }
-            } else {
-                for (int i = 1; i <= nbNodes; i++) {
-                    gp_Pnt p = tri->Node(i).Transformed(trsf);
-                    int base = (vertexOffset + i - 1) * 3;
-                    result.positions[base + 0] = static_cast<float>(p.X());
-                    result.positions[base + 1] = static_cast<float>(p.Y());
-                    result.positions[base + 2] = static_cast<float>(p.Z());
-                }
-            }
-        
-            // UV parameters (zero-filled where the triangulation carries no UV nodes)
-            bool hasUV = tri->HasUVNodes();
-            for (int i = 1; i <= nbNodes; i++) {
-                int uvBase = (vertexOffset + i - 1) * 2;
-                if (hasUV) {
-                    const gp_Pnt2d& uv = tri->UVNode(i);
-                    result.uvs[uvBase + 0] = static_cast<float>(uv.X());
-                    result.uvs[uvBase + 1] = static_cast<float>(uv.Y());
-                } else {
-                    result.uvs[uvBase + 0] = 0.0f;
-                    result.uvs[uvBase + 1] = 0.0f;
-                }
-            }
-        
-            // Normals
-            if (!tri->HasNormals()) {
-                BRepLib_ToolTriangulatedShape::ComputeNormals(face, tri);
-            }
-            bool hasNormals = tri->HasNormals();
-            for (int i = 1; i <= nbNodes; i++) {
-                gp_Dir d(0, 0, 1);
-                if (hasNormals) {
-                    NCollection_Vec3<float> nv;
-                    tri->Normal(i, nv);
-                    if (nv.x() != 0.0f || nv.y() != 0.0f || nv.z() != 0.0f) {
-                        d = gp_Dir(nv.x(), nv.y(), nv.z());
-                    }
-                }
-                if (!identityLoc) {
-                    d = d.Transformed(trsf);
-                }
-                int base = (vertexOffset + i - 1) * 3;
-                result.normals[base + 0] = static_cast<float>(d.X());
-                result.normals[base + 1] = static_cast<float>(d.Y());
-                result.normals[base + 2] = static_cast<float>(d.Z());
-            }
-        
-            // Triangles (with winding correction for reversed faces)
-            bool isReversed = (face.Orientation() != TopAbs_FORWARD);
-            for (int t = 1; t <= nbTri; t++) {
-                const auto& triangle = tri->Triangle(t);
-                int n1 = triangle.Value(1);
-                int n2 = triangle.Value(2);
-                int n3 = triangle.Value(3);
-        
-                if (isReversed) {
-                    int tmp = n1;
-                    n1 = n2;
-                    n2 = tmp;
-                }
-        
-                result.indices[triOffset + 0] = static_cast<uint32_t>(n1 - 1 + vertexOffset);
-                result.indices[triOffset + 1] = static_cast<uint32_t>(n2 - 1 + vertexOffset);
-                result.indices[triOffset + 2] = static_cast<uint32_t>(n3 - 1 + vertexOffset);
-                triOffset += 3;
-            }
-        
-            // Record face group: [triStart (in index units), triCount (indices), faceHash]
-            int faceTriStart = triOffset - nbTri * 3;
-            int faceHash = static_cast<int>(TopTools_ShapeMapHasher{}(face) % 2147483647);
-            result.faceGroups[faceGroupIdx + 0] = faceTriStart;
-            result.faceGroups[faceGroupIdx + 1] = nbTri * 3;
-            result.faceGroups[faceGroupIdx + 2] = faceHash;
-            faceGroupIdx += 3;
-        
-            vertexOffset += nbNodes;
-        }
-        
-        return result;
+        return buildMeshData(get(id), linearDeflection, angularDeflection, false);
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("tessellate: ") + e.what());
+    }
+}
+
+MeshData OcctKernel::tessellateRelative(uint32_t id, double linearDeflection, double angularDeflection) {
+    try {
+        return buildMeshData(get(id), linearDeflection, angularDeflection, true);
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("tessellateRelative: ") + e.what());
     }
 }
 

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -151,6 +151,7 @@ class OcctKernel {
     uint32_t fuseAll(std::vector<uint32_t> shapeIds);
     uint32_t cutAll(uint32_t shapeId, std::vector<uint32_t> toolIds);
     uint32_t split(uint32_t shapeId, std::vector<uint32_t> toolIds);
+    uint32_t intersectionCells(std::vector<uint32_t> shapeIds);
 
     // --- Modeling operations ---
     uint32_t extrude(uint32_t shapeId, double dx, double dy, double dz);
@@ -175,7 +176,7 @@ class OcctKernel {
     uint32_t sweep(uint32_t wireId, uint32_t spineId, int transitionMode);
     uint32_t sweepPipeShell(uint32_t profileId, uint32_t spineId, bool freenet, bool smooth);
     uint32_t sweepOriented(uint32_t profileId, uint32_t spineId, int mode, double upX, double upY,
-                           double upZ);
+                           double upZ, uint32_t auxSpineId);
     uint32_t draftPrism(uint32_t shapeId, double dx, double dy, double dz, double angleDeg);
     uint32_t revolveVec(uint32_t shapeId, double cx, double cy, double cz, double dx, double dy,
                         double dz, double angle);
@@ -257,6 +258,7 @@ class OcctKernel {
 
     // --- Tessellation / Mesh ---
     MeshData tessellate(uint32_t id, double linearDeflection, double angularDeflection);
+    MeshData tessellateRelative(uint32_t id, double linearDeflection, double angularDeflection);
     EdgeData wireframe(uint32_t id, double deflection);
     bool hasTriangulation(uint32_t id);
     MeshData meshShape(uint32_t id, double linearDeflection, double angularDeflection);
@@ -270,6 +272,8 @@ class OcctKernel {
     std::string exportStl(uint32_t id, double linearDeflection, bool ascii);
     std::string toBREP(uint32_t id);
     uint32_t fromBREP(const std::string& data);
+    std::string exportBrepBinary(uint32_t id);
+    uint32_t importBrepBinary(const std::string& path);
 
     // --- Query / Measure ---
     BBoxData getBoundingBox(uint32_t id, bool useTriangulation);
@@ -280,6 +284,8 @@ class OcctKernel {
     std::vector<double> getSurfaceCenterOfMass(uint32_t faceId);
     std::vector<double> getLinearCenterOfMass(uint32_t id);
     std::vector<double> surfaceCurvature(uint32_t faceId, double u, double v);
+    std::vector<double> getInertia(uint32_t id);
+    bool containsPoint(uint32_t id, double x, double y, double z, double tolerance);
 
     // --- Vertex/Surface query ---
     std::vector<double> vertexPosition(uint32_t vertexId);
@@ -302,6 +308,10 @@ class OcctKernel {
     bool curveIsPeriodic(uint32_t edgeId);
     double curveLength(uint32_t edgeId);
     uint32_t interpolatePoints(std::vector<double> flatPoints, bool periodic);
+    uint32_t interpolatePointsWithTangents(std::vector<double> flatPoints, double startTanX,
+                                           double startTanY, double startTanZ, double endTanX,
+                                           double endTanY, double endTanZ);
+    std::vector<double> projectPointOnEdge(uint32_t edgeId, double x, double y, double z);
     uint32_t approximatePoints(std::vector<double> flatPoints, double tolerance);
 
     // --- Modifier (expanded) ---
@@ -411,6 +421,8 @@ class OcctKernel {
   private:
     uint32_t store(const TopoDS_Shape& shape);
     const TopoDS_Shape& get(uint32_t id) const;
+    MeshData buildMeshData(const TopoDS_Shape& shape, double linearDeflection,
+                           double angularDeflection, bool relative);
 
     std::unordered_map<uint32_t, TopoDS_Shape> arena_;
     uint32_t nextId_ = 1;

--- a/facade/src/kernel.cpp
+++ b/facade/src/kernel.cpp
@@ -1,8 +1,22 @@
 #include "occt_kernel.h"
 
+#include <BRepLib_ToolTriangulatedShape.hxx>
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <BRep_Tool.hxx>
+#include <NCollection_Vec3.hxx>
 #include <OSD.hxx>
+#include <Poly_Triangulation.hxx>
+#include <TopAbs_Orientation.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopLoc_Location.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
 #include <XCAFApp_Application.hxx>
 #include <cstdlib>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 #include <stdexcept>
 
 // --- XCAF helpers (used by generated xcaf methods) ---
@@ -88,6 +102,149 @@ const TopoDS_Shape& OcctKernel::get(uint32_t id) const {
         throw std::runtime_error("Invalid shape ID: " + std::to_string(id));
     }
     return it->second;
+}
+
+// Shared mesh builder for tessellate() and tessellateRelative(). `relative`
+// selects per-edge size-relative deflection vs. absolute.
+MeshData OcctKernel::buildMeshData(const TopoDS_Shape& shape, double linearDeflection,
+                                   double angularDeflection, bool relative) {
+    BRepMesh_IncrementalMesh mesher(shape, linearDeflection, relative, angularDeflection, false);
+    if (!mesher.IsDone()) {
+        throw std::runtime_error("tessellate: meshing failed");
+    }
+
+    int totalNodes = 0;
+    int totalTris = 0;
+    int totalFaces = 0;
+    for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
+        TopLoc_Location loc;
+        auto tri = BRep_Tool::Triangulation(TopoDS::Face(ex.Current()), loc);
+        if (tri.IsNull())
+            continue;
+        totalNodes += tri->NbNodes();
+        totalTris += tri->NbTriangles();
+        totalFaces++;
+    }
+
+    MeshData result;
+    result.positionCount = totalNodes * 3;
+    result.normalCount = totalNodes * 3;
+    result.uvCount = totalNodes * 2;
+    result.indexCount = totalTris * 3;
+
+    result.positions = static_cast<float*>(std::malloc(result.positionCount * sizeof(float)));
+    result.normals = static_cast<float*>(std::malloc(result.normalCount * sizeof(float)));
+    result.uvs = static_cast<float*>(std::malloc(result.uvCount * sizeof(float)));
+    result.indices = static_cast<uint32_t*>(std::malloc(result.indexCount * sizeof(uint32_t)));
+    result.faceGroupCount = totalFaces * 3;
+    result.faceGroups = static_cast<int32_t*>(std::malloc(result.faceGroupCount * sizeof(int32_t)));
+
+    if ((!result.positions && result.positionCount > 0) ||
+        (!result.normals && result.normalCount > 0) || (!result.uvs && result.uvCount > 0) ||
+        (!result.indices && result.indexCount > 0) ||
+        (!result.faceGroups && result.faceGroupCount > 0)) {
+        throw std::runtime_error("tessellate: memory allocation failed");
+    }
+
+    int vertexOffset = 0;
+    int triOffset = 0;
+    int faceGroupIdx = 0;
+
+    for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
+        const auto& face = TopoDS::Face(ex.Current());
+        TopLoc_Location loc;
+        auto tri = BRep_Tool::Triangulation(face, loc);
+        if (tri.IsNull())
+            continue;
+
+        const auto& trsf = loc.Transformation();
+        bool identityLoc = loc.IsIdentity();
+        int nbNodes = tri->NbNodes();
+        int nbTri = tri->NbTriangles();
+
+        if (identityLoc) {
+            for (int i = 1; i <= nbNodes; i++) {
+                const gp_Pnt& p = tri->Node(i);
+                int base = (vertexOffset + i - 1) * 3;
+                result.positions[base + 0] = static_cast<float>(p.X());
+                result.positions[base + 1] = static_cast<float>(p.Y());
+                result.positions[base + 2] = static_cast<float>(p.Z());
+            }
+        } else {
+            for (int i = 1; i <= nbNodes; i++) {
+                gp_Pnt p = tri->Node(i).Transformed(trsf);
+                int base = (vertexOffset + i - 1) * 3;
+                result.positions[base + 0] = static_cast<float>(p.X());
+                result.positions[base + 1] = static_cast<float>(p.Y());
+                result.positions[base + 2] = static_cast<float>(p.Z());
+            }
+        }
+
+        bool hasUV = tri->HasUVNodes();
+        for (int i = 1; i <= nbNodes; i++) {
+            int uvBase = (vertexOffset + i - 1) * 2;
+            if (hasUV) {
+                const gp_Pnt2d& uv = tri->UVNode(i);
+                result.uvs[uvBase + 0] = static_cast<float>(uv.X());
+                result.uvs[uvBase + 1] = static_cast<float>(uv.Y());
+            } else {
+                result.uvs[uvBase + 0] = 0.0f;
+                result.uvs[uvBase + 1] = 0.0f;
+            }
+        }
+
+        if (!tri->HasNormals()) {
+            BRepLib_ToolTriangulatedShape::ComputeNormals(face, tri);
+        }
+        bool hasNormals = tri->HasNormals();
+        for (int i = 1; i <= nbNodes; i++) {
+            gp_Dir d(0, 0, 1);
+            if (hasNormals) {
+                NCollection_Vec3<float> nv;
+                tri->Normal(i, nv);
+                if (nv.x() != 0.0f || nv.y() != 0.0f || nv.z() != 0.0f) {
+                    d = gp_Dir(nv.x(), nv.y(), nv.z());
+                }
+            }
+            if (!identityLoc) {
+                d = d.Transformed(trsf);
+            }
+            int base = (vertexOffset + i - 1) * 3;
+            result.normals[base + 0] = static_cast<float>(d.X());
+            result.normals[base + 1] = static_cast<float>(d.Y());
+            result.normals[base + 2] = static_cast<float>(d.Z());
+        }
+
+        bool isReversed = (face.Orientation() != TopAbs_FORWARD);
+        for (int t = 1; t <= nbTri; t++) {
+            const auto& triangle = tri->Triangle(t);
+            int n1 = triangle.Value(1);
+            int n2 = triangle.Value(2);
+            int n3 = triangle.Value(3);
+
+            if (isReversed) {
+                int tmp = n1;
+                n1 = n2;
+                n2 = tmp;
+            }
+
+            result.indices[triOffset + 0] = static_cast<uint32_t>(n1 - 1 + vertexOffset);
+            result.indices[triOffset + 1] = static_cast<uint32_t>(n2 - 1 + vertexOffset);
+            result.indices[triOffset + 2] = static_cast<uint32_t>(n3 - 1 + vertexOffset);
+            triOffset += 3;
+        }
+
+        int faceTriStart = triOffset - nbTri * 3;
+        int faceHash = static_cast<int>(TopTools_ShapeMapHasher{}(face) % 2147483647);
+        result.faceGroups[faceGroupIdx + 0] = faceTriStart;
+        result.faceGroups[faceGroupIdx + 1] = nbTri * 3;
+        result.faceGroups[faceGroupIdx + 2] = faceHash;
+        faceGroupIdx += 3;
+
+        vertexOffset += nbNodes;
+    }
+
+    return result;
 }
 
 // --- MeshBatchData implementation ---

--- a/test/facade-features-2.test.ts
+++ b/test/facade-features-2.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the second batch of facade additions: inertia tensor,
+ * point-in-solid, binary BREP, clamped B-spline interpolation, project-point-
+ * on-edge, relative tessellation, auxiliary-spine sweep, and intersection cells.
+ *
+ * Constructs the TS wrapper via its private constructor (init() can't run here)
+ * to exercise the real shipping methods against real OCCT.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let Module: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let kernel: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let SweepMode: any;
+
+beforeAll(async () => {
+    const jsPath = resolve(__dirname, "../dist/occt-wasm.js");
+    const wasmPath = resolve(__dirname, "../dist/occt-wasm.wasm");
+    const createModule = (await import(jsPath)).default;
+    Module = await createModule({
+        locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
+    });
+    const mod = await import(resolve(__dirname, "../ts/src/index.ts"));
+    SweepMode = mod.SweepMode;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    kernel = new (mod.OcctKernel as any)(Module);
+}, 30_000);
+
+afterEach(() => kernel.releaseAll());
+afterAll(() => kernel[Symbol.dispose]());
+
+describe("getInertia", () => {
+    it("returns a symmetric 3x3 matrix with positive diagonal", () => {
+        const box = kernel.makeBox(10, 20, 30);
+        const m = kernel.getInertia(box);
+        expect(m).toHaveLength(9);
+        expect(m[1]).toBeCloseTo(m[3], 6); // symmetric
+        expect(m[2]).toBeCloseTo(m[6], 6);
+        expect(m[5]).toBeCloseTo(m[7], 6);
+        expect(m[0]).toBeGreaterThan(0);
+        expect(m[4]).toBeGreaterThan(0);
+        expect(m[8]).toBeGreaterThan(0);
+    });
+});
+
+describe("containsPoint", () => {
+    it("classifies points inside vs outside a solid", () => {
+        const box = kernel.makeBox(10, 10, 10); // [0,10]^3
+        expect(kernel.containsPoint(box, { x: 5, y: 5, z: 5 })).toBe(true);
+        expect(kernel.containsPoint(box, { x: 20, y: 5, z: 5 })).toBe(false);
+        expect(kernel.containsPoint(box, { x: -1, y: 5, z: 5 })).toBe(false);
+    });
+});
+
+describe("binary BREP I/O", () => {
+    it("round-trips a shape through binary BREP", () => {
+        const box = kernel.makeBox(12, 8, 6);
+        const bytes = kernel.toBREPBinary(box);
+        expect(bytes).toBeInstanceOf(Uint8Array);
+        expect(bytes.length).toBeGreaterThan(0);
+
+        const restored = kernel.fromBREPBinary(bytes);
+        expect(kernel.getVolume(restored)).toBeCloseTo(12 * 8 * 6, 3);
+    });
+});
+
+describe("interpolatePointsWithTangents", () => {
+    it("builds an edge through points with clamped end tangents", () => {
+        const pts = [
+            { x: 0, y: 0, z: 0 },
+            { x: 5, y: 5, z: 0 },
+            { x: 10, y: 0, z: 0 },
+        ];
+        const edge = kernel.interpolatePointsWithTangents(
+            pts,
+            { x: 0, y: 1, z: 0 },
+            { x: 0, y: -1, z: 0 },
+        );
+        expect(kernel.isEdge(edge)).toBe(true);
+        expect(kernel.curveLength(edge)).toBeGreaterThan(10);
+        // Start tangent should follow the requested +Y direction.
+        const t = kernel.curveTangent(edge, kernel.curveParameters(edge).first);
+        expect(t.y).toBeGreaterThan(0);
+    });
+});
+
+describe("projectPointOnEdge", () => {
+    it("finds the closest point, tangent, and parameter on a line edge", () => {
+        const edge = kernel.makeLineEdge({ x: 0, y: 0, z: 0 }, { x: 10, y: 0, z: 0 });
+        const r = kernel.projectPointOnEdge(edge, { x: 5, y: 4, z: 0 });
+        expect(r.point.x).toBeCloseTo(5, 6);
+        expect(r.point.y).toBeCloseTo(0, 6);
+        expect(Math.abs(r.tangent.x)).toBeCloseTo(1, 6);
+    });
+});
+
+describe("tessellate relative", () => {
+    it("produces a valid mesh with scale-independent deflection", () => {
+        const sphere = kernel.makeSphere(50);
+        const mesh = kernel.tessellate(sphere, { linearDeflection: 0.01, relative: true });
+        expect(mesh.triangleCount).toBeGreaterThan(0);
+        expect(mesh.positions.length).toBe(mesh.vertexCount * 3);
+    });
+});
+
+describe("sweepOriented auxiliary spine", () => {
+    it("sweeps with an auxiliary guide wire", () => {
+        const profile = kernel.makeWire([
+            kernel.makeCircleEdge({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 1 }, 2),
+        ]);
+        const spine = kernel.makeWire([
+            kernel.makeLineEdge({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 30 }),
+        ]);
+        const aux = kernel.makeWire([
+            kernel.makeLineEdge({ x: 5, y: 0, z: 0 }, { x: 5, y: 0, z: 30 }),
+        ]);
+        const solid = kernel.sweepOriented(profile, spine, SweepMode.Auxiliary, { x: 0, y: 1, z: 0 }, aux);
+        expect(kernel.isValid(solid)).toBe(true);
+        expect(kernel.getVolume(solid)).toBeGreaterThan(0);
+    });
+});
+
+describe("intersectionCells", () => {
+    it("extracts the overlap region of two boxes", () => {
+        const a = kernel.makeBox(10, 10, 10); // [0,10]^3
+        const b = kernel.translate(kernel.makeBox(10, 10, 10), 5, 5, 5); // [5,15]^3
+        const overlap = kernel.intersectionCells([a, b]);
+        // Overlap is [5,10]^3 = 125.
+        expect(kernel.getVolume(overlap)).toBeCloseTo(125, 2);
+    });
+});

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -240,6 +240,7 @@ export interface OcctRawKernel {
     fuseAll(shapeIds: EmbindVectorU32): number;
     cutAll(shapeId: number, toolIds: EmbindVectorU32): number;
     split(shapeId: number, toolIds: EmbindVectorU32): number;
+    intersectionCells(shapeIds: EmbindVectorU32): number;
 
     // Modeling
     extrude(id: number, dx: number, dy: number, dz: number): number;
@@ -258,7 +259,7 @@ export interface OcctRawKernel {
     loftWithVertices(wireIds: EmbindVectorU32, isSolid: boolean, ruled: boolean, startVertexId: number, endVertexId: number): number;
     sweep(wireId: number, spineId: number, transitionMode: number): number;
     sweepPipeShell(profileId: number, spineId: number, freenet: boolean, smooth: boolean): number;
-    sweepOriented(profileId: number, spineId: number, mode: number, upX: number, upY: number, upZ: number): number;
+    sweepOriented(profileId: number, spineId: number, mode: number, upX: number, upY: number, upZ: number, auxSpineId: number): number;
     draftPrism(shapeId: number, dx: number, dy: number, dz: number, angleDeg: number): number;
     revolveVec(shapeId: number, cx: number, cy: number, cz: number, dx: number, dy: number, dz: number, angle: number): number;
 
@@ -327,6 +328,7 @@ export interface OcctRawKernel {
 
     // Tessellation
     tessellate(id: number, linDefl: number, angDefl: number): RawMeshData;
+    tessellateRelative(id: number, linDefl: number, angDefl: number): RawMeshData;
     wireframe(id: number, deflection: number): RawEdgeData;
     hasTriangulation(id: number): boolean;
     meshShape(id: number, linDefl: number, angDefl: number): RawMeshData;
@@ -339,6 +341,8 @@ export interface OcctRawKernel {
     exportStl(id: number, linearDeflection: number, ascii: boolean): string;
     toBREP(id: number): string;
     fromBREP(data: string): number;
+    exportBrepBinary(id: number): string;
+    importBrepBinary(path: string): number;
 
     // Query
     getBoundingBox(id: number, useTriangulation: boolean): BoundingBox;
@@ -346,6 +350,8 @@ export interface OcctRawKernel {
     getSurfaceArea(id: number): number;
     getLength(id: number): number;
     getCenterOfMass(id: number): EmbindVectorF64;
+    getInertia(id: number): EmbindVectorF64;
+    containsPoint(id: number, x: number, y: number, z: number, tolerance: number): boolean;
     getSurfaceCenterOfMass(faceId: number): EmbindVectorF64;
     getLinearCenterOfMass(id: number): EmbindVectorF64;
     surfaceCurvature(faceId: number, u: number, v: number): EmbindVectorF64;
@@ -372,6 +378,8 @@ export interface OcctRawKernel {
     curveIsPeriodic(edgeId: number): boolean;
     curveLength(edgeId: number): number;
     interpolatePoints(flatPoints: EmbindVectorF64, periodic: boolean): number;
+    interpolatePointsWithTangents(flatPoints: EmbindVectorF64, startTanX: number, startTanY: number, startTanZ: number, endTanX: number, endTanY: number, endTanZ: number): number;
+    projectPointOnEdge(edgeId: number, x: number, y: number, z: number): EmbindVectorF64;
     approximatePoints(flatPoints: EmbindVectorF64, tolerance: number): number;
     getNurbsCurveData(edgeId: number): RawNurbsCurveData;
     liftCurve2dToPlane(flatPoints2d: EmbindVectorF64, planeOx: number, planeOy: number, planeOz: number, planeZx: number, planeZy: number, planeZz: number, planeXx: number, planeXy: number, planeXz: number): number;
@@ -692,6 +700,19 @@ export class OcctKernel {
         });
     }
 
+    /**
+     * General-fuse cell selection: the union of all regions covered by two or
+     * more of the inputs. Unlike {@link fuseAll} (which keeps every cell), this
+     * keeps only the overlap regions via BOPAlgo_CellsBuilder.
+     */
+    intersectionCells(shapes: ShapeHandle[]): ShapeHandle {
+        return wrap("intersectionCells", () => {
+            const vec = this.#makeVectorU32(shapes);
+            try { return handle(this.#raw.intersectionCells(vec)); }
+            finally { vec.delete(); }
+        });
+    }
+
     // =======================================================================
     // Modeling
     // =======================================================================
@@ -831,16 +852,18 @@ export class OcctKernel {
     /**
      * Sweep a profile wire along a spine wire with explicit profile-orientation
      * control. `up` is required for {@link SweepMode.FixedUp} (the constant
-     * binormal direction) and ignored otherwise.
+     * binormal direction); `auxSpine` is required for {@link SweepMode.Auxiliary}
+     * (the guide wire). Both are ignored for the other modes.
      */
     sweepOriented(
         profile: ShapeHandle,
         spine: ShapeHandle,
         mode: SweepMode = SweepMode.Fixed,
         up: Vec3 = { x: 0, y: 0, z: 1 },
+        auxSpine?: ShapeHandle,
     ): ShapeHandle {
         return wrap("sweepOriented", () =>
-            handle(this.#raw.sweepOriented(profile, spine, mode, up.x, up.y, up.z)),
+            handle(this.#raw.sweepOriented(profile, spine, mode, up.x, up.y, up.z, auxSpine ?? 0)),
         );
     }
 
@@ -1353,7 +1376,10 @@ export class OcctKernel {
         return wrap("tessellate", () => {
             const linDefl = options?.linearDeflection ?? 0.1;
             const angDefl = options?.angularDeflection ?? 0.5;
-            return this.#extractMesh(this.#raw.tessellate(shape, linDefl, angDefl));
+            const raw = options?.relative
+                ? this.#raw.tessellateRelative(shape, linDefl, angDefl)
+                : this.#raw.tessellate(shape, linDefl, angDefl);
+            return this.#extractMesh(raw);
         });
     }
 
@@ -1480,6 +1506,29 @@ export class OcctKernel {
         return wrap("fromBREP", () => handle(this.#raw.fromBREP(data)));
     }
 
+    /** Serialize a shape to binary BREP (smaller/faster than the text format). */
+    toBREPBinary(shape: ShapeHandle): Uint8Array {
+        return wrap("toBREPBinary", () => {
+            const path = this.#raw.exportBrepBinary(shape);
+            const bytes = this.#module.FS.readFile(path);
+            this.#module.FS.unlink(path);
+            return bytes;
+        });
+    }
+
+    /** Load a shape from binary BREP produced by {@link toBREPBinary}. */
+    fromBREPBinary(data: Uint8Array): ShapeHandle {
+        return wrap("fromBREPBinary", () => {
+            const path = "/tmp/occt-import.brep.bin";
+            this.#module.FS.writeFile(path, data);
+            try {
+                return handle(this.#raw.importBrepBinary(path));
+            } finally {
+                this.#module.FS.unlink(path);
+            }
+        });
+    }
+
     cacheStep(stepData: string | ArrayBuffer): string {
         const shape = this.importStep(stepData);
         try {
@@ -1533,6 +1582,23 @@ export class OcctKernel {
             const v = this.#raw.getCenterOfMass(shape);
             return this.#vec3FromEmbind(v);
         });
+    }
+
+    /**
+     * Matrix of inertia about the center of mass, as a row-major 3×3 array
+     * (length 9). Symmetric: `[1]==[3]`, `[2]==[6]`, `[5]==[7]`.
+     */
+    getInertia(shape: ShapeHandle): number[] {
+        return wrap("getInertia", () =>
+            Array.from(this.#drainVector(this.#raw.getInertia(shape), Float64Array)),
+        );
+    }
+
+    /** True if `point` lies inside (or on the boundary of) a solid. */
+    containsPoint(shape: ShapeHandle, point: Vec3, tolerance = 1e-7): boolean {
+        return wrap("containsPoint", () =>
+            this.#raw.containsPoint(shape, point.x, point.y, point.z, tolerance),
+        );
     }
 
     /**
@@ -1697,6 +1763,49 @@ export class OcctKernel {
             const flat = this.#flattenPoints(points);
             try { return handle(this.#raw.interpolatePoints(flat, periodic)); }
             finally { flat.delete(); }
+        });
+    }
+
+    /**
+     * Interpolate a cubic B-spline through the points with clamped start/end
+     * tangent directions.
+     */
+    interpolatePointsWithTangents(
+        points: Vec3[],
+        startTangent: Vec3,
+        endTangent: Vec3,
+    ): ShapeHandle {
+        return wrap("interpolatePointsWithTangents", () => {
+            const flat = this.#flattenPoints(points);
+            try {
+                return handle(
+                    this.#raw.interpolatePointsWithTangents(
+                        flat,
+                        startTangent.x, startTangent.y, startTangent.z,
+                        endTangent.x, endTangent.y, endTangent.z,
+                    ),
+                );
+            } finally {
+                flat.delete();
+            }
+        });
+    }
+
+    /** Closest point on an edge to `point`, with the curve tangent and parameter there. */
+    projectPointOnEdge(
+        edge: ShapeHandle,
+        point: Vec3,
+    ): { point: Vec3; tangent: Vec3; parameter: number } {
+        return wrap("projectPointOnEdge", () => {
+            const r = this.#drainVector(
+                this.#raw.projectPointOnEdge(edge, point.x, point.y, point.z),
+                Float64Array,
+            );
+            return {
+                point: { x: r[0]!, y: r[1]!, z: r[2]! },
+                tangent: { x: r[3]!, y: r[4]!, z: r[5]! },
+                parameter: r[6]!,
+            };
         });
     }
 

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -46,6 +46,11 @@ export interface TessellateOptions {
     linearDeflection?: number | undefined;
     /** Maximum angular deviation in radians. Default: 0.5 */
     angularDeflection?: number | undefined;
+    /**
+     * Interpret `linearDeflection` relative to each edge's length
+     * (scale-independent meshing) instead of as an absolute distance.
+     */
+    relative?: boolean | undefined;
 }
 
 /** Options for WASM module initialization. */
@@ -163,7 +168,6 @@ export enum TransitionMode {
     RoundCorner = 2,
 }
 
-/** Join type for offset/fillet operations (BRepOffsetAPI_MakeOffset). */
 /** Profile-orientation mode for {@link OcctKernel.sweepOriented}. */
 export enum SweepMode {
     /** Minimal-torsion parallel transport — profile does not rotate (corrected Frenet). */
@@ -172,8 +176,11 @@ export enum SweepMode {
     Frenet = 1,
     /** Profile keeps a caller-supplied up/binormal direction constant. */
     FixedUp = 2,
+    /** Orientation driven by an auxiliary guide spine (requires `auxSpine`). */
+    Auxiliary = 3,
 }
 
+/** Join type for offset/fillet operations (BRepOffsetAPI_MakeOffset). */
 export enum JoinType {
     /** Arc interpolation at joints (default). */
     Arc = 0,

--- a/ts/src/xcaf-document.ts
+++ b/ts/src/xcaf-document.ts
@@ -72,6 +72,7 @@ export interface RawXCAFKernel {
 /** Emscripten FS interface needed for binary glTF export. */
 export interface EmscriptenFS {
     readFile(path: string): Uint8Array;
+    writeFile(path: string, data: Uint8Array): void;
     unlink(path: string): void;
 }
 

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -285,6 +285,52 @@ return store(builder.Shape());",
         return_type: ReturnType::ShapeId,
     },
     MethodSpec {
+        name: "intersectionCells",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::VectorShapeIds("shapeIds")],
+        occt_class: "",
+        ctor_args: "",
+        // Union of all regions covered by two or more of the inputs, via
+        // BOPAlgo_CellsBuilder cell selection (each pairwise overlap is added
+        // with the same material, then internal boundaries are removed).
+        setup_code: "\
+if (shapeIds.size() < 2) {
+    throw std::runtime_error(\"intersectionCells: need at least 2 shapes\");
+}
+std::vector<TopoDS_Shape> shapes;
+NCollection_List<TopoDS_Shape> args;
+for (uint32_t sid : shapeIds) {
+    const auto& s = get(sid);
+    shapes.push_back(s);
+    args.Append(s);
+}
+BOPAlgo_CellsBuilder builder;
+builder.SetArguments(args);
+builder.Perform();
+if (builder.HasErrors()) {
+    throw std::runtime_error(\"intersectionCells: build failed\");
+}
+builder.RemoveAllFromResult();
+for (size_t i = 0; i < shapes.size(); ++i) {
+    for (size_t j = i + 1; j < shapes.size(); ++j) {
+        NCollection_List<TopoDS_Shape> take;
+        take.Append(shapes[i]);
+        take.Append(shapes[j]);
+        NCollection_List<TopoDS_Shape> avoid;
+        builder.AddToResult(take, avoid, 1, false);
+    }
+}
+builder.RemoveInternalBoundaries();
+return store(builder.Shape());",
+        includes: &[
+            "BOPAlgo_CellsBuilder.hxx",
+            "NCollection_List.hxx",
+            "TopoDS_Shape.hxx",
+        ],
+        category: "booleans",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
         name: "cutAll",
         kind: MethodKind::CustomBody,
         params: &[FacadeParam::ShapeId("shapeId"), FacadeParam::VectorShapeIds("toolIds")],
@@ -2073,6 +2119,52 @@ return {com.X(), com.Y(), com.Z()};",
         return_type: ReturnType::VectorDouble,
     },
     MethodSpec {
+        name: "getInertia",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("id")],
+        occt_class: "",
+        ctor_args: "",
+        // Row-major 3x3 matrix of inertia about the center of mass (gp_Mat is
+        // 1-indexed). Symmetric: result[1]==[3], [2]==[6], [5]==[7].
+        setup_code: "\
+const auto& shape = get(id);
+GProp_GProps props;
+BRepGProp::VolumeProperties(shape, props);
+gp_Mat m = props.MatrixOfInertia();
+return {m(1, 1), m(1, 2), m(1, 3),
+        m(2, 1), m(2, 2), m(2, 3),
+        m(3, 1), m(3, 2), m(3, 3)};",
+        includes: &["BRepGProp.hxx", "GProp_GProps.hxx", "gp_Mat.hxx"],
+        category: "query",
+        return_type: ReturnType::VectorDouble,
+    },
+    MethodSpec {
+        name: "containsPoint",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::ShapeId("id"),
+            FacadeParam::Double("x"),
+            FacadeParam::Double("y"),
+            FacadeParam::Double("z"),
+            FacadeParam::Double("tolerance"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+const auto& shape = get(id);
+BRepClass3d_SolidClassifier classifier(shape);
+classifier.Perform(gp_Pnt(x, y, z), tolerance);
+TopAbs_State state = classifier.State();
+return state == TopAbs_IN || state == TopAbs_ON;",
+        includes: &[
+            "BRepClass3d_SolidClassifier.hxx",
+            "gp_Pnt.hxx",
+            "TopAbs_State.hxx",
+        ],
+        category: "query",
+        return_type: ReturnType::Bool,
+    },
+    MethodSpec {
         name: "getSurfaceCenterOfMass",
         kind: MethodKind::CustomBody,
         params: &[FacadeParam::ShapeId("faceId")],
@@ -2529,6 +2621,86 @@ return store(edgeMaker.Shape());",
         return_type: ReturnType::ShapeId,
     },
     MethodSpec {
+        name: "interpolatePointsWithTangents",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::VectorDouble("flatPoints"),
+            FacadeParam::Double("startTanX"),
+            FacadeParam::Double("startTanY"),
+            FacadeParam::Double("startTanZ"),
+            FacadeParam::Double("endTanX"),
+            FacadeParam::Double("endTanY"),
+            FacadeParam::Double("endTanZ"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        // Cubic interpolation through the points with clamped end tangents.
+        setup_code: "\
+int nPts = static_cast<int>(flatPoints.size()) / 3;
+if (nPts < 2) {
+    throw std::runtime_error(\"interpolatePointsWithTangents: need at least 2 points\");
+}
+Handle(NCollection_HArray1<gp_Pnt>) pts = new NCollection_HArray1<gp_Pnt>(1, nPts);
+for (int i = 0; i < nPts; i++) {
+    pts->SetValue(i + 1,
+                  gp_Pnt(flatPoints[i * 3], flatPoints[i * 3 + 1], flatPoints[i * 3 + 2]));
+}
+GeomAPI_Interpolate interp(pts, false, 1e-6);
+gp_Vec startTan(startTanX, startTanY, startTanZ);
+gp_Vec endTan(endTanX, endTanY, endTanZ);
+interp.Load(startTan, endTan, Standard_True);
+interp.Perform();
+if (!interp.IsDone()) {
+    throw std::runtime_error(\"interpolatePointsWithTangents: interpolation failed\");
+}
+BRepBuilderAPI_MakeEdge edgeMaker(interp.Curve());
+if (!edgeMaker.IsDone()) {
+    throw std::runtime_error(\"interpolatePointsWithTangents: edge construction failed\");
+}
+return store(edgeMaker.Shape());",
+        includes: &[
+            "BRepBuilderAPI_MakeEdge.hxx", "GeomAPI_Interpolate.hxx",
+            "NCollection_HArray1.hxx", "gp_Pnt.hxx", "gp_Vec.hxx",
+        ],
+        category: "curve",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "projectPointOnEdge",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::ShapeId("edgeId"),
+            FacadeParam::Double("x"),
+            FacadeParam::Double("y"),
+            FacadeParam::Double("z"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        // Returns [cpX, cpY, cpZ, tangentX, tangentY, tangentZ, parameter].
+        setup_code: "\
+TopoDS_Edge edge = TopoDS::Edge(get(edgeId));
+double first, last;
+Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, first, last);
+if (curve.IsNull()) {
+    throw std::runtime_error(\"projectPointOnEdge: edge has no 3D curve\");
+}
+GeomAPI_ProjectPointOnCurve proj(gp_Pnt(x, y, z), curve, first, last);
+if (proj.NbPoints() < 1) {
+    throw std::runtime_error(\"projectPointOnEdge: no projection found\");
+}
+double param = proj.LowerDistanceParameter();
+gp_Pnt cp;
+gp_Vec tan;
+curve->D1(param, cp, tan);
+return {cp.X(), cp.Y(), cp.Z(), tan.X(), tan.Y(), tan.Z(), param};",
+        includes: &[
+            "BRep_Tool.hxx", "GeomAPI_ProjectPointOnCurve.hxx", "Geom_Curve.hxx",
+            "TopoDS.hxx", "gp_Pnt.hxx", "gp_Vec.hxx",
+        ],
+        category: "curve",
+        return_type: ReturnType::VectorDouble,
+    },
+    MethodSpec {
         name: "curveIsPeriodic",
         kind: MethodKind::CustomBody,
         params: &[FacadeParam::ShapeId("id")],
@@ -2922,11 +3094,13 @@ return store(maker.Shape());",
             FacadeParam::Double("upX"),
             FacadeParam::Double("upY"),
             FacadeParam::Double("upZ"),
+            FacadeParam::ShapeId("auxSpineId"),
         ],
         occt_class: "",
         ctor_args: "",
         // mode 0 = Fixed (corrected Frenet, minimal torsion), 1 = Frenet
-        // (follows the principal normal), 2 = FixedUp (constant binormal).
+        // (follows the principal normal), 2 = FixedUp (constant binormal),
+        // 3 = Auxiliary (orientation driven by the auxSpineId guide wire).
         setup_code: "\
 BRepOffsetAPI_MakePipeShell maker(TopoDS::Wire(get(spineId)));
 switch (mode) {
@@ -2941,6 +3115,9 @@ switch (mode) {
         maker.SetMode(up);
         break;
     }
+    case 3:
+        maker.SetMode(TopoDS::Wire(get(auxSpineId)), Standard_True);
+        break;
     default:
         throw std::runtime_error(\"sweepOriented: invalid mode\");
 }
@@ -3353,6 +3530,39 @@ return store(shape);",
         category: "io",
         return_type: ReturnType::ShapeId,
     },
+    MethodSpec {
+        name: "exportBrepBinary",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("id")],
+        occt_class: "",
+        ctor_args: "",
+        // Binary BREP is true binary (unlike the ASCII text format), so it goes
+        // through the virtual FS — JS reads the bytes via Module.FS.readFile().
+        setup_code: "\
+std::string path = \"/tmp/export.brep.bin\";
+BinTools::Write(get(id), path.c_str());
+return path;",
+        includes: &["BinTools.hxx"],
+        category: "io",
+        return_type: ReturnType::String,
+    },
+    MethodSpec {
+        name: "importBrepBinary",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::String("path")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+TopoDS_Shape shape;
+BinTools::Read(shape, path.c_str());
+if (shape.IsNull()) {
+    throw std::runtime_error(\"importBrepBinary: failed to read shape\");
+}
+return store(shape);",
+        includes: &["BinTools.hxx"],
+        category: "io",
+        return_type: ReturnType::ShapeId,
+    },
     // ── Evolution ──────────────────────────────────────────────────
     MethodSpec {
         name: "translateWithHistory",
@@ -3695,163 +3905,25 @@ return buildEvolution(maker, resultId, shape, inputFaceHashes, hashUpperBound);"
         ],
         occt_class: "",
         ctor_args: "",
-        setup_code: "\
-const auto& shape = get(id);
-
-BRepMesh_IncrementalMesh mesher(shape, linearDeflection, false, angularDeflection, false);
-if (!mesher.IsDone()) {
-    throw std::runtime_error(\"tessellate: meshing failed\");
-}
-
-// Count totals
-int totalNodes = 0;
-int totalTris = 0;
-int totalFaces = 0;
-for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
-    TopLoc_Location loc;
-    auto tri = BRep_Tool::Triangulation(TopoDS::Face(ex.Current()), loc);
-    if (tri.IsNull())
-        continue;
-    totalNodes += tri->NbNodes();
-    totalTris += tri->NbTriangles();
-    totalFaces++;
-}
-
-MeshData result;
-result.positionCount = totalNodes * 3;
-result.normalCount = totalNodes * 3;
-result.uvCount = totalNodes * 2;
-result.indexCount = totalTris * 3;
-
-result.positions = static_cast<float*>(std::malloc(result.positionCount * sizeof(float)));
-result.normals = static_cast<float*>(std::malloc(result.normalCount * sizeof(float)));
-result.uvs = static_cast<float*>(std::malloc(result.uvCount * sizeof(float)));
-result.indices = static_cast<uint32_t*>(std::malloc(result.indexCount * sizeof(uint32_t)));
-result.faceGroupCount = totalFaces * 3;
-result.faceGroups =
-    static_cast<int32_t*>(std::malloc(result.faceGroupCount * sizeof(int32_t)));
-
-if ((!result.positions && result.positionCount > 0) ||
-    (!result.normals && result.normalCount > 0) ||
-    (!result.uvs && result.uvCount > 0) ||
-    (!result.indices && result.indexCount > 0) ||
-    (!result.faceGroups && result.faceGroupCount > 0)) {
-    throw std::runtime_error(\"tessellate: memory allocation failed\");
-}
-
-int vertexOffset = 0;
-int triOffset = 0;
-int faceGroupIdx = 0;
-
-for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
-    const auto& face = TopoDS::Face(ex.Current());
-    TopLoc_Location loc;
-    auto tri = BRep_Tool::Triangulation(face, loc);
-    if (tri.IsNull())
-        continue;
-
-    const auto& trsf = loc.Transformation();
-    // Faces from primitives/booleans usually carry an identity location;
-    // skipping the per-vertex affine multiply there is the common-case win.
-    bool identityLoc = loc.IsIdentity();
-    int nbNodes = tri->NbNodes();
-    int nbTri = tri->NbTriangles();
-
-    // Positions
-    if (identityLoc) {
-        for (int i = 1; i <= nbNodes; i++) {
-            const gp_Pnt& p = tri->Node(i);
-            int base = (vertexOffset + i - 1) * 3;
-            result.positions[base + 0] = static_cast<float>(p.X());
-            result.positions[base + 1] = static_cast<float>(p.Y());
-            result.positions[base + 2] = static_cast<float>(p.Z());
-        }
-    } else {
-        for (int i = 1; i <= nbNodes; i++) {
-            gp_Pnt p = tri->Node(i).Transformed(trsf);
-            int base = (vertexOffset + i - 1) * 3;
-            result.positions[base + 0] = static_cast<float>(p.X());
-            result.positions[base + 1] = static_cast<float>(p.Y());
-            result.positions[base + 2] = static_cast<float>(p.Z());
-        }
-    }
-
-    // UV parameters (zero-filled where the triangulation carries no UV nodes)
-    bool hasUV = tri->HasUVNodes();
-    for (int i = 1; i <= nbNodes; i++) {
-        int uvBase = (vertexOffset + i - 1) * 2;
-        if (hasUV) {
-            const gp_Pnt2d& uv = tri->UVNode(i);
-            result.uvs[uvBase + 0] = static_cast<float>(uv.X());
-            result.uvs[uvBase + 1] = static_cast<float>(uv.Y());
-        } else {
-            result.uvs[uvBase + 0] = 0.0f;
-            result.uvs[uvBase + 1] = 0.0f;
-        }
-    }
-
-    // Normals
-    if (!tri->HasNormals()) {
-        BRepLib_ToolTriangulatedShape::ComputeNormals(face, tri);
-    }
-    bool hasNormals = tri->HasNormals();
-    for (int i = 1; i <= nbNodes; i++) {
-        gp_Dir d(0, 0, 1);
-        if (hasNormals) {
-            NCollection_Vec3<float> nv;
-            tri->Normal(i, nv);
-            if (nv.x() != 0.0f || nv.y() != 0.0f || nv.z() != 0.0f) {
-                d = gp_Dir(nv.x(), nv.y(), nv.z());
-            }
-        }
-        if (!identityLoc) {
-            d = d.Transformed(trsf);
-        }
-        int base = (vertexOffset + i - 1) * 3;
-        result.normals[base + 0] = static_cast<float>(d.X());
-        result.normals[base + 1] = static_cast<float>(d.Y());
-        result.normals[base + 2] = static_cast<float>(d.Z());
-    }
-
-    // Triangles (with winding correction for reversed faces)
-    bool isReversed = (face.Orientation() != TopAbs_FORWARD);
-    for (int t = 1; t <= nbTri; t++) {
-        const auto& triangle = tri->Triangle(t);
-        int n1 = triangle.Value(1);
-        int n2 = triangle.Value(2);
-        int n3 = triangle.Value(3);
-
-        if (isReversed) {
-            int tmp = n1;
-            n1 = n2;
-            n2 = tmp;
-        }
-
-        result.indices[triOffset + 0] = static_cast<uint32_t>(n1 - 1 + vertexOffset);
-        result.indices[triOffset + 1] = static_cast<uint32_t>(n2 - 1 + vertexOffset);
-        result.indices[triOffset + 2] = static_cast<uint32_t>(n3 - 1 + vertexOffset);
-        triOffset += 3;
-    }
-
-    // Record face group: [triStart (in index units), triCount (indices), faceHash]
-    int faceTriStart = triOffset - nbTri * 3;
-    int faceHash = static_cast<int>(TopTools_ShapeMapHasher{}(face) % 2147483647);
-    result.faceGroups[faceGroupIdx + 0] = faceTriStart;
-    result.faceGroups[faceGroupIdx + 1] = nbTri * 3;
-    result.faceGroups[faceGroupIdx + 2] = faceHash;
-    faceGroupIdx += 3;
-
-    vertexOffset += nbNodes;
-}
-
-return result;",
-        includes: &[
-            "BRepLib_ToolTriangulatedShape.hxx", "BRepMesh_IncrementalMesh.hxx",
-            "BRep_Tool.hxx", "NCollection_Vec3.hxx", "Poly_Triangulation.hxx",
-            "TopAbs_Orientation.hxx", "TopExp_Explorer.hxx", "TopLoc_Location.hxx",
-            "TopTools_ShapeMapHasher.hxx", "TopoDS.hxx", "TopoDS_Face.hxx",
-            "gp_Dir.hxx", "gp_Pnt.hxx", "gp_Pnt2d.hxx",
+        setup_code: "return buildMeshData(get(id), linearDeflection, angularDeflection, false);",
+        includes: &[],
+        category: "tessellate",
+        return_type: ReturnType::MeshData,
+    },
+    MethodSpec {
+        name: "tessellateRelative",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::ShapeId("id"),
+            FacadeParam::Double("linearDeflection"),
+            FacadeParam::Double("angularDeflection"),
         ],
+        occt_class: "",
+        ctor_args: "",
+        // Scale-independent meshing: linearDeflection is interpreted relative to
+        // each edge's length (OCCT isRelative).
+        setup_code: "return buildMeshData(get(id), linearDeflection, angularDeflection, true);",
+        includes: &[],
         category: "tessellate",
         return_type: ReturnType::MeshData,
     },
@@ -4713,7 +4785,7 @@ mod tests {
             .iter()
             .filter(|m| m.kind != MethodKind::Skip)
             .count();
-        assert_eq!(count, 180, "expected 180 generable methods");
+        assert_eq!(count, 188, "expected 188 generable methods");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Eight additive CAD capabilities, no breaking changes. Each facade method is
specced once in the codegen config and emitted to all four targets (Embind,
WASI C-ABI, Rust host, `kernel.cpp`).

### Query
- **`getInertia(shape)`** — 3×3 matrix of inertia about the center of mass (row-major, length 9), via `GProp_GProps::MatrixOfInertia`.
- **`containsPoint(shape, point, tolerance?)`** — point-in-solid test (`BRepClass3d_SolidClassifier`), complementing the existing face-only `classifyPointOnFace`.

### I/O
- **`toBREPBinary` / `fromBREPBinary`** — binary BREP via `BinTools` + the virtual FS (smaller/faster than the existing text BREP).

### Curves
- **`interpolatePointsWithTangents(points, startTangent, endTangent)`** — cubic B-spline interpolation with clamped end tangents (`GeomAPI_Interpolate::Load`).
- **`projectPointOnEdge(edge, point)`** — closest point + tangent + parameter on a curve (`GeomAPI_ProjectPointOnCurve`).

### Tessellation
- **`tessellate(shape, { relative: true })`** (and raw `tessellateRelative`) — scale-independent meshing. `tessellate` and `tessellateRelative` now share a `buildMeshData` helper in `kernel.cpp`, so the ~130-line mesh-extraction body is **not duplicated**.

### Sweeps
- **`SweepMode.Auxiliary`** + an `auxSpine` argument on `sweepOriented` — orientation driven by a guide wire (`MakePipeShell::SetMode(auxWire, …)`).

### Booleans
- **`intersectionCells(shapes)`** — union of all regions covered by ≥2 inputs, via `BOPAlgo_CellsBuilder` cell selection. Note: the plain *general fuse* was already available as `fuseAll` (`BRepAlgoAPI_BuilderAlgo`), so this lands the genuinely-missing cell-selection capability rather than a redundant method.

## Testing
- New `test/facade-features-2.test.ts` (8 tests) against a fresh release WASM build via the real TS wrapper.
- Full suite: **305 passed / 2 skipped**, 18 files.
- Bench check vs baseline: **no regressions**.
- Rust crate tests (WASI, against the refreshed `wasm.br`): **14 passed**.
- `tsc`, `eslint`, `cargo fmt`, `clang-format`, and `cargo test -p xtask` (method count 188) all clean.
- New `measure-and-cells` example verified end-to-end; README capability table updated.

## Notes
- `crate/src/occt-wasm.wasm.br` was regenerated locally via `cargo xtask build-wasi --release` so the WASI stale-check passes on the first CI run.
- A documentation fix landed alongside: OCCT's `MatrixOfInertia()` is about the center of mass, not the world origin (verified against a box's analytic centroidal moments).
