### PR TITLE
fix: drop relaxed-SIMD so Safari/iOS can load the kernel

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -38,8 +38,8 @@ RUN mkdir -p occt/build && cd occt/build \
         -DUSE_FREETYPE=OFF \
         -DUSE_RAPIDJSON=ON \
         -D3RDPARTY_RAPIDJSON_INCLUDE_DIR=/workspace/3rdparty/rapidjson \
-        "-DCMAKE_C_FLAGS=-fwasm-exceptions -O3 -msimd128 -mrelaxed-simd -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
-        "-DCMAKE_CXX_FLAGS=-fwasm-exceptions -O3 -msimd128 -mrelaxed-simd -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
+        "-DCMAKE_C_FLAGS=-fwasm-exceptions -O3 -msimd128 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
+        "-DCMAKE_CXX_FLAGS=-fwasm-exceptions -O3 -msimd128 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
         -Wno-dev \
     && cmake --build . --parallel \
     && echo "OCCT: $(ls -1 lin32/clang/lib/*.a 2>/dev/null | wc -l) static libs"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To set expectations, this library deliberately does not:
 
 - **Provide a higher-level CAD modeling API** — parametric sketching, constraints, feature trees, and ergonomic modeling belong in [brepjs](https://github.com/andymai/brepjs), which wraps occt-wasm for that purpose
 - **Manage memory automatically beyond arena handles** — shapes are freed when the kernel is disposed or you call `release()`; there is no per-shape garbage collection
-- **Support Firefox or other non-WASM-SIMD browsers** — the build requires WASM SIMD, relaxed-SIMD, tail calls, and wasm exceptions; Firefox lacks tail call support as of v130
+- **Support non-WASM-SIMD browsers** — the build requires WASM SIMD (baseline `-msimd128`), tail calls, and wasm exceptions; Firefox lacks tail call support as of v130. Relaxed-SIMD is intentionally not used: some Safari/iOS WebKit builds fail to compile relaxed-SIMD modules, and it made geometry non-reproducible across CPUs
 - **Include OCCT visualization or display modules** — TKV3d, TKHLR (except the HLR facade), and the AIS interactive context are excluded; bring your own renderer (Three.js, Babylon.js, etc.)
 - **Support IGES import/export** -- TKDEIGES is excluded from the link; use STEP for interchange
 

--- a/crate/src/kernel.rs
+++ b/crate/src/kernel.rs
@@ -149,7 +149,6 @@ impl OcctKernel {
         let mut config = wasmtime::Config::new();
         config.wasm_simd(true);
         config.wasm_tail_call(true);
-        config.wasm_relaxed_simd(true);
         // The WASM binary uses wasm-opt --experimental-new-eh to convert
         // Emscripten's legacy exceptions to the new (exnref) encoding.
         config.wasm_exceptions(true);

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -52,7 +52,7 @@ pub fn build_occt() -> Result<()> {
     } else {
         eprintln!("Step 1a: Configuring OCCT with emcmake cmake...");
 
-        let c_flags = "-fwasm-exceptions -O3 -msimd128 -mrelaxed-simd -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS";
+        let c_flags = "-fwasm-exceptions -O3 -msimd128 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS";
         let cxx_flags = c_flags;
         let rapidjson_inc = root.join("3rdparty/rapidjson").display().to_string();
 
@@ -159,7 +159,7 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
         let obj_str = obj.display().to_string();
         cmd!(
             sh,
-            "em++ -std=c++17 -fwasm-exceptions -O3 -msimd128 -mrelaxed-simd
+            "em++ -std=c++17 -fwasm-exceptions -O3 -msimd128
             -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS
             -I{occt_inc_str} -I{facade_inc_str}
             -w -c {src_str} -o {obj_str}"
@@ -254,7 +254,6 @@ fn link_wasm(
         "-lembind".into(),
         "-fwasm-exceptions".into(),
         "-msimd128".into(),
-        "-mrelaxed-simd".into(),
         "-mtail-call".into(),
         opt_level.into(),
         "-sINITIAL_MEMORY=134217728".into(),
@@ -323,7 +322,6 @@ fn optimize_wasm(sh: &Shell, root: &Path) -> Result<()> {
         --enable-bulk-memory --enable-sign-ext
         --enable-nontrapping-float-to-int --enable-mutable-globals
         --enable-exception-handling --enable-simd --enable-tail-call
-        --enable-relaxed-simd
         {wasm_str} -o {wasm_str}"
     )
     .run()?;

--- a/xtask/src/build_wasi.rs
+++ b/xtask/src/build_wasi.rs
@@ -86,7 +86,7 @@ fn compile_facade(sh: &Shell, root: &Path) -> Result<Vec<PathBuf>> {
         eprintln!("  Compiling {name}.cpp...");
         cmd!(
             sh,
-            "em++ -std=c++17 -fwasm-exceptions -O3 -msimd128 -mrelaxed-simd
+            "em++ -std=c++17 -fwasm-exceptions -O3 -msimd128
             -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS
             -I{occt_inc} -I{facade_inc}
             -w -c {src} -o {obj}"
@@ -127,7 +127,6 @@ fn link(root: &Path, objects: &[PathBuf], release: bool) -> Result<PathBuf> {
     cmd.args([
         "-fwasm-exceptions",
         "-msimd128",
-        "-mrelaxed-simd",
         opt_level,
         "-sSTANDALONE_WASM=1",
         "-sALLOW_MEMORY_GROWTH=1",
@@ -210,7 +209,7 @@ fn convert_eh(sh: &Shell, wasm: &Path) -> Result<()> {
         --enable-bulk-memory --enable-sign-ext
         --enable-nontrapping-float-to-int --enable-mutable-globals
         --enable-exception-handling --enable-reference-types --enable-multivalue
-        --enable-simd --enable-tail-call --enable-relaxed-simd
+        --enable-simd --enable-tail-call
         -o {wasm}"
     )
     .run()?;


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a 100%-Safari/iOS cluster: **\`Kernel init failed: WebAssembly.Module doesn't parse … relaxed simd instructions not supported\`** (28 occ / 21 sessions / 14 users in ~7h, all Safari / Mobile Safari). Affected WebKit builds cannot compile WASM modules containing relaxed-SIMD instructions, so kernel init aborts and the 3D engine fails to load entirely on those browsers.

Confirmed by opcode-scanning the artifacts: \`occt-wasm.wasm\` carried thousands of \`f64x2.relaxed_madd\` (0x107); the alternative draft kernel (manifold) had zero and loads fine on Safari.

## Fix

Remove \`-mrelaxed-simd\` / \`--enable-relaxed-simd\` / \`wasm_relaxed_simd(true)\` everywhere, keeping baseline \`-msimd128\` (supported since Safari 16.4):

- \`Dockerfile.builder\` — OCCT static-lib CMAKE C/CXX flags
- \`xtask/src/build.rs\` — OCCT cmake flags, per-file \`em++\`, link args, \`wasm-opt\` pass
- \`xtask/src/build_wasi.rs\` — \`em++\` compile, link args, \`wasm-opt\` pass
- \`crate/src/kernel.rs\` — native wasmtime host config
- \`README.md\` — corrected the "requires relaxed-SIMD" note

\`relaxed_madd\` is a fuse-allowed multiply-add; dropping to baseline \`mul\`+\`add\` is negligible for an OCCT boolean-bound workload. **Bonus:** also removes the cross-CPU geometry non-reproducibility that relaxed FMA introduced.

## ⚠️ Required to land the fix in published artifacts

CI links pre-built OCCT libs from \`ghcr.io/andymai/occt-wasm-builder:latest\` (built from \`Dockerfile.builder\`), and there is **no workflow that rebuilds/pushes that image** — it's manual. After merge, the builder image must be **rebuilt and pushed** so the OCCT static libs are relaxed-SIMD-free; otherwise the npm package still ships relaxed-SIMD OCCT even though the facade flags changed.

\`\`\`
docker build -f Dockerfile.builder -t ghcr.io/andymai/occt-wasm-builder:latest .
docker push ghcr.io/andymai/occt-wasm-builder:latest
\`\`\`

## Verification

Local OCCT rebuild with the new flags in progress; em++ invocations confirmed \`-O3 -msimd128\` with no \`-mrelaxed-simd\`. Will confirm the rebuilt \`dist/occt-wasm.wasm\` scans to **zero** relaxed-SIMD opcodes and passes the integration suite.

## Note (out of scope)

The standalone \`Dockerfile\` (\`docker:build\`/\`docker:dist\`) has drifted — its OCCT cmake flags omit \`-msimd128\` entirely and use \`-O2\`. Not the published path (CI uses the builder image), but worth reconciling separately.