### PR TITLE
fix(docker): align standalone Dockerfile OCCT flags with builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,8 @@ RUN --mount=type=cache,target=/cache/ccache \
         -DUSE_FREETYPE=OFF \
         -DUSE_RAPIDJSON=ON \
         -D3RDPARTY_RAPIDJSON_INCLUDE_DIR=/workspace/3rdparty/rapidjson \
-        -DCMAKE_C_FLAGS="-fwasm-exceptions -O2 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
-        -DCMAKE_CXX_FLAGS="-fwasm-exceptions -O2 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
+        -DCMAKE_C_FLAGS="-fwasm-exceptions -O3 -msimd128 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
+        -DCMAKE_CXX_FLAGS="-fwasm-exceptions -O3 -msimd128 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS" \
         -Wno-dev \
     && cmake --build . --parallel \
     && echo "OCCT build complete: $(ls -1 lin32/clang/lib/*.a 2>/dev/null | wc -l) static libs"


### PR DESCRIPTION
## Problem

The standalone `Dockerfile` (used by `npm run docker:build` / `docker:dist`) compiled OCCT with:

```
-DCMAKE_C_FLAGS="-fwasm-exceptions -O2 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS"
```

— i.e. **`-O2` and no `-msimd128`** — while `Dockerfile.builder` (the CI builder image) and `xtask/src/build.rs` use `-O3 -msimd128`. So local/dev docker builds produced OCCT static libs that diverged from the published CI artifact (different optimization level, no baseline SIMD).

Surfaced while fixing the Safari/iOS relaxed-SIMD engine-load bug (#148) — the published path goes through the builder image, so this drift wasn't shipping, but it makes `docker:dist` an unfaithful local reproduction.

## Fix

Match the builder flags exactly:

```
-fwasm-exceptions -O3 -msimd128 -DIGNORE_NO_ATOMICS=1 -DOCCT_NO_PLUGINS
```

Baseline SIMD, no relaxed-SIMD (consistent with the post-#148 build). The facade layer already builds via `cargo xtask build --release`, so it inherits `build.rs` flags and needed no change.