### PR TITLE
refactor(ts): unify OcctError wrapping in one place

### DIFF
--- a/test/new-features.test.ts
+++ b/test/new-features.test.ts
@@ -122,6 +122,26 @@ describe("OcctErrorCode classification", () => {
         expect(err.code).toBe(OcctErrorCode.DocumentClosed);
     });
 
+    it("preserves the inner code when wrap re-tags an OcctError", async () => {
+        // A passthrough method (e.g. loadCached) wraps an already-wrapped inner
+        // call (fromBREP -> ImportExportFailed). Re-wrapping under an operation
+        // name that isn't in IO_OPS must not downgrade the code to KernelError.
+        const { wrap } = await import(resolve(__dirname, "../ts/src/types.ts"));
+        const thrown = (() => {
+            try {
+                wrap("loadCached", () => {
+                    throw new OcctError("fromBREP", "bad data");
+                });
+            } catch (e) {
+                return e as InstanceType<typeof OcctError>;
+            }
+            return undefined;
+        })();
+        expect(thrown).toBeInstanceOf(OcctError);
+        expect(thrown.operation).toBe("loadCached");
+        expect(thrown.code).toBe(OcctErrorCode.ImportExportFailed);
+    });
+
     it("preserves Error inheritance", () => {
         const err = new OcctError("op", "msg");
         expect(err instanceof Error).toBe(true);

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -90,7 +90,7 @@ import type {
     UVBounds,
     Vec3,
 } from "./types.js";
-import { JoinType, OcctError, SweepMode, TransitionMode } from "./types.js";
+import { JoinType, SweepMode, TransitionMode, wrap } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Raw Embind types
@@ -462,17 +462,6 @@ export interface OcctRawKernel {
 
 function handle(id: number): ShapeHandle {
     return id as ShapeHandle;
-}
-
-function wrap<T>(operation: string, fn: () => T): T {
-    try {
-        return fn();
-    } catch (e: unknown) {
-        if (e instanceof Error) {
-            throw new OcctError(operation, e.message);
-        }
-        throw new OcctError(operation, String(e));
-    }
 }
 
 /**
@@ -1530,16 +1519,18 @@ export class OcctKernel {
     }
 
     cacheStep(stepData: string | ArrayBuffer): string {
-        const shape = this.importStep(stepData);
-        try {
-            return this.toBREP(shape);
-        } finally {
-            this.release(shape);
-        }
+        return wrap("cacheStep", () => {
+            const shape = this.importStep(stepData);
+            try {
+                return this.toBREP(shape);
+            } finally {
+                this.release(shape);
+            }
+        });
     }
 
     loadCached(brep: string): ShapeHandle {
-        return this.fromBREP(brep);
+        return wrap("loadCached", () => this.fromBREP(brep));
     }
 
     // =======================================================================

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -417,6 +417,13 @@ export function wrap<T>(operation: string, fn: () => T): T {
     try {
         return fn();
     } catch (e: unknown) {
+        if (e instanceof OcctError) {
+            // Already classified by an inner wrapped call. Preserve the original
+            // (most-specific) code and just retag the operation, so re-wrapping
+            // a passthrough like cacheStep/loadCached doesn't reclassify e.g.
+            // ImportExportFailed down to KernelError.
+            throw new OcctError(operation, e.message, e.code);
+        }
         if (e instanceof Error) {
             throw new OcctError(operation, e.message);
         }

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -407,3 +407,19 @@ function classifyError(operation: string, message: string): OcctErrorCode {
 
     return OcctErrorCode.Unknown;
 }
+
+/**
+ * Run `fn`, re-throwing any failure as an {@link OcctError} tagged with the
+ * given operation name. Shared by the kernel and the XCAF document so error
+ * classification stays in one place.
+ */
+export function wrap<T>(operation: string, fn: () => T): T {
+    try {
+        return fn();
+    } catch (e: unknown) {
+        if (e instanceof Error) {
+            throw new OcctError(operation, e.message);
+        }
+        throw new OcctError(operation, String(e));
+    }
+}

--- a/ts/src/xcaf-document.ts
+++ b/ts/src/xcaf-document.ts
@@ -25,7 +25,7 @@ import type {
     AddChildOptions,
     GLTFExportOptions,
 } from "./types.js";
-import { OcctError, OcctErrorCode } from "./types.js";
+import { OcctError, OcctErrorCode, wrap } from "./types.js";
 
 /** Raw XCAF methods on the Embind kernel (internal). */
 export interface RawXCAFKernel {
@@ -78,14 +78,6 @@ export interface EmscriptenFS {
 
 function tag(n: number): LabelTag {
     return n as LabelTag;
-}
-
-function wrap<T>(op: string, fn: () => T): T {
-    try {
-        return fn();
-    } catch (e: unknown) {
-        throw e instanceof Error ? new OcctError(op, e.message) : new OcctError(op, String(e));
-    }
 }
 
 export class XCAFDocument {


### PR DESCRIPTION
## Summary

`index.ts` and `xcaf-document.ts` each defined their own identical `wrap()` helper — both catch and re-throw as `new OcctError(op, msg)` (which classifies the error code in its constructor). Two copies means the error-classification path can silently drift between the kernel and the XCAF document.

### Changes
- Promote a single `wrap` into `types.ts`, next to `OcctError`/`classifyError`, and import it in both consumers. Removes both local copies. (`wrap` stays internal — it is not part of the re-exported public surface.)
- Wrap the two passthrough methods `cacheStep` and `loadCached`, so a failure carries the accurate operation label (`"cacheStep"`/`"loadCached"`) instead of the inner call's (`"importStep"`/`"fromBREP"`).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint src/` clean
- [x] Full vitest suite: 305 passed, 2 skipped (no behavior change)