### PR TITLE
ci: cache npm deps in WASM build and guard publish concurrency

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -32,6 +32,10 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            ts/package-lock.json
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -29,6 +29,11 @@ on:
 permissions:
   contents: read
 
+# Never cancel an in-flight crate publish: a half-run cargo publish must finish.
+concurrency:
+  group: publish-crate-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: cargo publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,11 @@ on:
         required: true
         type: string
 
+# Never cancel an in-flight publish: a half-run npm publish must finish.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     uses: ./.github/workflows/build-wasm.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Never cancel an in-flight release: a half-run publish must finish.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please


### PR DESCRIPTION
## Summary

Two low-risk CI hygiene fixes from the infra audit.

### npm caching
`build-wasm.yml` ran `actions/setup-node` with no `cache: npm`, so every reusable build (CI, release, publish all call it) re-downloaded the full dependency tree. Enabled caching keyed on both `package-lock.json` and `ts/package-lock.json` (the build does `npm ci` in both), matching what the lint job in `ci.yml` already does. This is exercised by this PR's own `build-test` run.

### Publish concurrency
`release.yml`, `publish.yml`, and `publish-crate.yml` had no `concurrency` control (only `ci.yml`/`build-wasi.yml`/`osv-scan.yml` did). A rapid double-merge or a release-event + dispatch could run two publishes at once. Added `concurrency` with **`cancel-in-progress: false`** to each — serialize per ref, and never cancel a publish mid-flight.

## Risk
- npm cache: verified by this PR's build.
- Concurrency: standard top-level additions, YAML-validated; the publish workflows only run on release/tag/dispatch so they can't be exercised by PR CI, but the change is additive and conventional.

## Test plan
- [x] All four workflow files validate as YAML
- [x] build-test job runs with caching enabled