### PR TITLE
refactor(xtask): share build helpers between WASM and WASI pipelines

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -4,30 +4,7 @@ use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
 use xshell::{Shell, cmd};
 
-use crate::util::project_root;
-
-/// Locate OCCT static lib directory (varies by platform detection).
-fn find_occt_lib_dir(occt_build: &Path) -> Result<PathBuf> {
-    // emsdk wasm32 is detected as 32-bit Linux → lin32/clang/lib/
-    let candidates = [
-        occt_build.join("lin32/clang/lib"),
-        occt_build.join("lin/clang/lib"),
-        occt_build.join("lib"),
-    ];
-    for dir in &candidates {
-        if dir.exists() {
-            return Ok(dir.clone());
-        }
-    }
-    bail!(
-        "OCCT static libs not found in any of: {}",
-        candidates
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
-}
+use crate::util::{bytes_to_mb, find_occt_lib_dir, find_wasm_opt, project_root};
 
 /// Step 1: Build OCCT static libraries via emcmake cmake.
 pub fn build_occt() -> Result<()> {
@@ -302,17 +279,7 @@ fn optimize_wasm(sh: &Shell, root: &Path) -> Result<()> {
     let wasm = root.join("dist/occt-wasm.wasm");
     let wasm_str = wasm.display().to_string();
 
-    // Try emsdk's wasm-opt first (has correct feature support), fall back to PATH
-    let wasm_opt_bin = std::env::var("EMSDK")
-        .ok()
-        .map(|e| PathBuf::from(e).join("upstream/bin/wasm-opt"))
-        .filter(|p| p.exists())
-        .or_else(|| {
-            home_dir()
-                .map(|h| h.join("emsdk/upstream/bin/wasm-opt"))
-                .filter(|p| p.exists())
-        })
-        .map_or_else(|| "wasm-opt".into(), |p| p.display().to_string());
+    let wasm_opt_bin = find_wasm_opt();
 
     eprintln!("Step 4: Running wasm-opt...");
     cmd!(
@@ -327,10 +294,6 @@ fn optimize_wasm(sh: &Shell, root: &Path) -> Result<()> {
     .run()?;
 
     Ok(())
-}
-
-fn home_dir() -> Option<PathBuf> {
-    std::env::var("HOME").ok().map(PathBuf::from)
 }
 
 /// Find the newest mtime among all `.h`, `.hxx`, and `.hpp` files in a
@@ -399,8 +362,7 @@ pub fn build(release: bool, size: bool) -> Result<()> {
     // Report
     let wasm_path = root.join("dist/occt-wasm.wasm");
     if wasm_path.exists() {
-        #[allow(clippy::cast_precision_loss)] // file size fits in f64 mantissa
-        let size_mb = std::fs::metadata(&wasm_path)?.len() as f64 / 1_048_576.0;
+        let size_mb = bytes_to_mb(std::fs::metadata(&wasm_path)?.len());
         eprintln!("Build complete: dist/occt-wasm.wasm ({size_mb:.1}MB)");
     }
 

--- a/xtask/src/build_wasi.rs
+++ b/xtask/src/build_wasi.rs
@@ -26,16 +26,12 @@ use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
 use xshell::{Shell, cmd};
 
-use crate::util::project_root;
-
-#[allow(clippy::cast_precision_loss)]
-fn bytes_to_mb(n: u64) -> f64 {
-    n as f64 / 1_048_576.0
-}
+use crate::util::{bytes_to_mb, find_occt_lib_dir, find_wasm_opt, project_root};
 
 /// OCCT static libs not exercised by the WASI build's call graph. Excluding
-/// them shrinks the .wasm output without affecting functionality. Mirrors the
-/// exclusion list in `xtask::build` to keep the two paths in sync.
+/// them shrinks the .wasm output without affecting functionality. This list is
+/// intentionally much smaller than `xtask::build`'s — the WASI link prunes far
+/// fewer libs — so the two are NOT kept in sync.
 const EXCLUDED_LIBS: &[&str] = &["libTKDraw.a"];
 
 /// Step 1: Compile facade C++ files for the C-ABI WASI build.
@@ -180,22 +176,6 @@ fn extract_export_names(wasi_exports_path: &Path) -> Result<Vec<String>> {
     Ok(names)
 }
 
-/// Locate the OCCT static-lib directory in an Emscripten build tree.
-fn find_occt_lib_dir(occt_build: &Path) -> Result<PathBuf> {
-    let candidates = ["lib", "lin32/clang/lib", "wasm32/clang/lib"];
-    candidates
-        .iter()
-        .map(|c| occt_build.join(c))
-        .find(|p| p.exists())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "OCCT static libs not found under {}; tried: {}",
-                occt_build.display(),
-                candidates.join(", "),
-            )
-        })
-}
-
 /// Step 3: Run wasm-opt to convert emcc's legacy exception encoding to the
 /// new exnref encoding that wasmtime accepts when `wasm_exceptions(true)` is set.
 fn convert_eh(sh: &Shell, wasm: &Path) -> Result<()> {
@@ -214,22 +194,6 @@ fn convert_eh(sh: &Shell, wasm: &Path) -> Result<()> {
     )
     .run()?;
     Ok(())
-}
-
-fn find_wasm_opt() -> PathBuf {
-    let candidate = std::env::var("EMSDK")
-        .ok()
-        .map(|e| PathBuf::from(e).join("upstream/bin/wasm-opt"));
-    if let Some(p) = candidate.filter(|p| p.exists()) {
-        return p;
-    }
-    if let Some(home) = std::env::var("HOME").ok().map(PathBuf::from) {
-        let p = home.join("emsdk/upstream/bin/wasm-opt");
-        if p.exists() {
-            return p;
-        }
-    }
-    PathBuf::from("wasm-opt")
 }
 
 /// Step 4: Brotli-compress and install into crate/src/.

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -13,3 +13,64 @@ pub fn project_root() -> Result<PathBuf> {
         .to_path_buf();
     Ok(root)
 }
+
+/// Locate the OCCT static-lib directory in an Emscripten build tree.
+///
+/// emsdk's wasm32 target is detected by OCCT's build as 32-bit Linux, so the
+/// libs land in `lin32/clang/lib`. The other entries are fallbacks for alternate
+/// layouts; the specific clang paths are tried before the bare `lib/` so a stray
+/// top-level `lib/` can't shadow the real build output. The npm and WASI builds
+/// share this one ordering so they always resolve to the same directory.
+pub fn find_occt_lib_dir(occt_build: &Path) -> Result<PathBuf> {
+    let candidates = [
+        occt_build.join("lin32/clang/lib"),
+        occt_build.join("lin/clang/lib"),
+        occt_build.join("wasm32/clang/lib"),
+        occt_build.join("lib"),
+    ];
+    candidates
+        .iter()
+        .find(|p| p.exists())
+        .cloned()
+        .with_context(|| {
+            format!(
+                "OCCT static libs not found under {}; tried: {}",
+                occt_build.display(),
+                candidates
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })
+}
+
+/// Path to `wasm-opt`, preferring emsdk's bundled copy (which has the correct
+/// feature flags) over whatever happens to be on `PATH`.
+pub fn find_wasm_opt() -> PathBuf {
+    if let Some(p) = std::env::var("EMSDK")
+        .ok()
+        .map(|e| PathBuf::from(e).join("upstream/bin/wasm-opt"))
+        .filter(|p| p.exists())
+    {
+        return p;
+    }
+    if let Some(p) = home_dir()
+        .map(|h| h.join("emsdk/upstream/bin/wasm-opt"))
+        .filter(|p| p.exists())
+    {
+        return p;
+    }
+    PathBuf::from("wasm-opt")
+}
+
+/// The user's home directory from `$HOME`, if set.
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+/// Convert a byte count to mebibytes for human-readable build output.
+#[allow(clippy::cast_precision_loss)] // file sizes fit in an f64 mantissa
+pub fn bytes_to_mb(n: u64) -> f64 {
+    n as f64 / 1_048_576.0
+}


### PR DESCRIPTION
## Summary

`build.rs` and `build_wasi.rs` carried copy-pasted, silently-drifted helpers. Hoisted the shared logic into `util.rs`.

### The real bug: `find_occt_lib_dir` divergence
The two copies had different candidate lists **and order**:
- `build.rs`: `lin32/clang/lib`, `lin/clang/lib`, `lib`
- `build_wasi.rs`: `lib`, `lin32/clang/lib`, `wasm32/clang/lib`

On a tree with a stray top-level `occt/build/lib`, the npm and WASI builds could resolve OCCT libs from **different directories**. Unified to one ordering that tries the clang paths before bare `lib`. In the CI/builder layout (libs in `lin32/clang/lib`) both pipelines resolve to the same directory as before — confirmed byte-identical by the WASI stale-check.

### Other dedup
- `find_wasm_opt` + `home_dir`: emsdk-first `wasm-opt` discovery was implemented twice.
- `bytes_to_mb`: `build.rs` inlined arithmetic `build_wasi` already factored out.

### Doc fix
`build_wasi`'s `EXCLUDED_LIBS` comment falsely claimed it *mirrors* build.rs *to keep the two paths in sync* — they deliberately differ. Corrected.

## Why it's safe
No build-flag or generated-code changes. clippy/fmt/test pass and the codegen drift check is clean. Build behavior is exercised end-to-end by **build-test** (WASM) and **WASI build + stale-check** (fails if the produced `.wasm.br` drifts a byte).

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -p xtask` passes
- [x] Codegen drift check clean