### PR TITLE
fix(ts): validate closed-union enums from the kernel instead of blind casts

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -91,6 +91,7 @@ import type {
     Vec3,
 } from "./types.js";
 import { JoinType, SweepMode, TransitionMode, wrap } from "./types.js";
+import { SHAPE_TYPES, SHAPE_ORIENTATIONS, POINT_CLASSIFICATIONS } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Raw Embind types
@@ -464,14 +465,13 @@ function handle(id: number): ShapeHandle {
     return id as ShapeHandle;
 }
 
-// Allowed values for the closed string-union enums returned by the kernel.
+// Allowed values for the closed string-union enums returned by the kernel,
+// derived from the single source of truth in types.ts so they can't drift.
 // (SurfaceKind/CurveKind are open unions — `string & {}` — so any string is
 // valid by design and needs no check.)
-const SHAPE_TYPE_VALUES = new Set<string>([
-    "compound", "compsolid", "solid", "shell", "face", "wire", "edge", "vertex", "shape",
-]);
-const SHAPE_ORIENTATION_VALUES = new Set<string>(["forward", "reversed", "internal", "external"]);
-const POINT_CLASSIFICATION_VALUES = new Set<string>(["in", "on", "out"]);
+const SHAPE_TYPE_VALUES = new Set<string>(SHAPE_TYPES);
+const SHAPE_ORIENTATION_VALUES = new Set<string>(SHAPE_ORIENTATIONS);
+const POINT_CLASSIFICATION_VALUES = new Set<string>(POINT_CLASSIFICATIONS);
 
 /**
  * Coerce a raw kernel string into a closed union, throwing if the kernel ever
@@ -1216,7 +1216,6 @@ export class OcctKernel {
                 const raw = this.#raw.queryBatch(ids);
                 const arr = this.#drainVector(raw, Float64Array);
                 const STRIDE = 14;
-                const SHAPE_TYPES: ShapeType[] = ["compound", "compsolid", "solid", "shell", "face", "wire", "edge", "vertex", "shape"];
                 const results: ShapeQueryResult[] = [];
                 for (let i = 0; i < shapes.length; i++) {
                     const o = i * STRIDE;

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -464,6 +464,27 @@ function handle(id: number): ShapeHandle {
     return id as ShapeHandle;
 }
 
+// Allowed values for the closed string-union enums returned by the kernel.
+// (SurfaceKind/CurveKind are open unions — `string & {}` — so any string is
+// valid by design and needs no check.)
+const SHAPE_TYPE_VALUES = new Set<string>([
+    "compound", "compsolid", "solid", "shell", "face", "wire", "edge", "vertex", "shape",
+]);
+const SHAPE_ORIENTATION_VALUES = new Set<string>(["forward", "reversed", "internal", "external"]);
+const POINT_CLASSIFICATION_VALUES = new Set<string>(["in", "on", "out"]);
+
+/**
+ * Coerce a raw kernel string into a closed union, throwing if the kernel ever
+ * returns an unexpected value instead of silently casting it into a lie. Called
+ * inside `wrap(...)`, so the throw surfaces as a classified `OcctError`.
+ */
+function asEnum<T extends string>(value: string, allowed: ReadonlySet<string>, label: string): T {
+    if (!allowed.has(value)) {
+        throw new Error(`unexpected ${label} from kernel: "${value}"`);
+    }
+    return value as T;
+}
+
 /**
  * Safety net: releases the raw Embind kernel if an OcctKernel instance is
  * garbage-collected without being disposed. Prefer `using` or explicit
@@ -1277,7 +1298,9 @@ export class OcctKernel {
     // =======================================================================
 
     getShapeType(shape: ShapeHandle): ShapeType {
-        return wrap("getShapeType", () => this.#raw.getShapeType(shape) as ShapeType);
+        return wrap("getShapeType", () =>
+            asEnum<ShapeType>(this.#raw.getShapeType(shape), SHAPE_TYPE_VALUES, "shape type"),
+        );
     }
 
     /** True if the shape is a compound. */
@@ -1333,7 +1356,13 @@ export class OcctKernel {
     }
 
     shapeOrientation(shape: ShapeHandle): ShapeOrientation {
-        return wrap("shapeOrientation", () => this.#raw.shapeOrientation(shape) as ShapeOrientation);
+        return wrap("shapeOrientation", () =>
+            asEnum<ShapeOrientation>(
+                this.#raw.shapeOrientation(shape),
+                SHAPE_ORIENTATION_VALUES,
+                "shape orientation",
+            ),
+        );
     }
 
     sharedEdges(faceA: ShapeHandle, faceB: ShapeHandle): ShapeHandle[] {
@@ -1695,7 +1724,13 @@ export class OcctKernel {
 
     /** Classify a UV point relative to a face boundary. */
     classifyPointOnFace(face: ShapeHandle, u: number, v: number): PointClassification {
-        return wrap("classifyPointOnFace", () => this.#raw.classifyPointOnFace(face, u, v) as PointClassification);
+        return wrap("classifyPointOnFace", () =>
+            asEnum<PointClassification>(
+                this.#raw.classifyPointOnFace(face, u, v),
+                POINT_CLASSIFICATION_VALUES,
+                "point classification",
+            ),
+        );
     }
 
     /** Create a BSpline surface from a grid of control points. */

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -140,14 +140,26 @@ export interface GLTFExportOptions {
     angularDeflection?: number | undefined;
 }
 
+/**
+ * TopAbs_ShapeEnum values returned by getShapeType, in TopAbs ordinal order
+ * (queryBatch indexes this array by the raw enum value). Single source of truth
+ * for both the {@link ShapeType} union and runtime validation.
+ */
+export const SHAPE_TYPES = [
+    "compound", "compsolid", "solid", "shell", "face", "wire", "edge", "vertex", "shape",
+] as const;
 /** TopAbs_ShapeEnum value returned by getShapeType. */
-export type ShapeType = "compound" | "compsolid" | "solid" | "shell" | "face" | "wire" | "edge" | "vertex" | "shape";
+export type ShapeType = (typeof SHAPE_TYPES)[number];
 
+/** TopAbs_Orientation values returned by shapeOrientation. */
+export const SHAPE_ORIENTATIONS = ["forward", "reversed", "internal", "external"] as const;
 /** TopAbs_Orientation value returned by shapeOrientation. */
-export type ShapeOrientation = "forward" | "reversed" | "internal" | "external";
+export type ShapeOrientation = (typeof SHAPE_ORIENTATIONS)[number];
 
+/** BRepClass_FaceClassifier results for a UV point relative to a face boundary. */
+export const POINT_CLASSIFICATIONS = ["in", "on", "out"] as const;
 /** BRepClass_FaceClassifier result for a UV point relative to a face boundary. */
-export type PointClassification = "in" | "on" | "out";
+export type PointClassification = (typeof POINT_CLASSIFICATIONS)[number];
 
 /** Which extreme of a shape's bounding box to align to a target coordinate. */
 export type AlignAnchor = "min" | "center" | "max";


### PR DESCRIPTION
## Summary

`getShapeType`, `shapeOrientation`, and `classifyPointOnFace` cast the raw kernel string straight into a **closed** string-union (`as ShapeType`, `as ShapeOrientation`, `as PointClassification`). If the kernel ever returned an unexpected value, it would become a value that type-checks but is a runtime lie.

Added an `asEnum(value, allowed, label)` helper that checks membership and throws on a miss. Because these calls already run inside `wrap(...)`, the throw surfaces as a classified `OcctError` instead of propagating a bogus enum.

`surfaceType`/`curveType` are deliberately left as direct casts — `SurfaceKind`/`CurveKind` are **open** unions (`… | (string & {})`), so any string is valid by design and a check would be meaningless.

## Risk
Behavior is unchanged in practice (the facade maps these directly from stable OCCT `TopAbs`/classifier enums, so values are always valid); the happy path is covered by the existing `getShapeType` tests. The only new behavior is a loud error on a value that previously would have been a silent lie.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint src/` clean
- [x] Full vitest suite: 306 passed, 2 skipped

Note: the cosmetic raw-Embind-type extraction (`raw-types.ts`) from the original audit item is intentionally split out into a follow-up to keep this focused on the safety fix.