### PR TITLE
fix(facade): guard meshBatch allocations and drop dead sweep branch

### DIFF
--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -2538,9 +2538,7 @@ uint32_t OcctKernel::sweep(uint32_t wireId, uint32_t spineId, int transitionMode
         if (!maker.IsDone()) {
             throw std::runtime_error("sweep: operation failed");
         }
-        if (maker.MakeSolid()) {
-            return store(maker.Shape());
-        }
+        maker.MakeSolid();
         return store(maker.Shape());
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("sweep: ") + e.what());
@@ -3193,6 +3191,13 @@ MeshBatchData OcctKernel::meshBatch(std::vector<uint32_t> ids, double linearDefl
         result.indices = static_cast<uint32_t*>(std::malloc(result.indexCount * sizeof(uint32_t)));
         result.shapeOffsets =
             static_cast<int32_t*>(std::malloc(result.shapeCount * 4 * sizeof(int32_t)));
+        
+        if ((!result.positions && result.positionCount > 0) ||
+            (!result.normals && result.normalCount > 0) ||
+            (!result.indices && result.indexCount > 0) ||
+            (!result.shapeOffsets && result.shapeCount > 0)) {
+            throw std::runtime_error("meshBatch: memory allocation failed");
+        }
         
         // Second pass: extract geometry from cached face data
         int vertexOffset = 0;

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -3052,9 +3052,7 @@ maker.Build();
 if (!maker.IsDone()) {
     throw std::runtime_error(\"sweep: operation failed\");
 }
-if (maker.MakeSolid()) {
-    return store(maker.Shape());
-}
+maker.MakeSolid();
 return store(maker.Shape());",
         includes: &[
             "BRepOffsetAPI_MakePipeShell.hxx",
@@ -4020,6 +4018,13 @@ result.normals = static_cast<float*>(std::malloc(result.normalCount * sizeof(flo
 result.indices = static_cast<uint32_t*>(std::malloc(result.indexCount * sizeof(uint32_t)));
 result.shapeOffsets =
     static_cast<int32_t*>(std::malloc(result.shapeCount * 4 * sizeof(int32_t)));
+
+if ((!result.positions && result.positionCount > 0) ||
+    (!result.normals && result.normalCount > 0) ||
+    (!result.indices && result.indexCount > 0) ||
+    (!result.shapeOffsets && result.shapeCount > 0)) {
+    throw std::runtime_error(\"meshBatch: memory allocation failed\");
+}
 
 // Second pass: extract geometry from cached face data
 int vertexOffset = 0;


### PR DESCRIPTION
## Summary

Two facade safety fixes from the C++ audit.

### meshBatch: unchecked allocations (memory-safety)
`meshBatch` `malloc`s four buffers (positions/normals/indices/shapeOffsets) and writes through all of them in the second pass **without checking for null**. `buildMeshData` and `wireframe` both guard their allocations and throw; `meshBatch` didn't, so an OOM allocation (null) would corrupt memory / abort instead of raising a catchable error. Added the same guard `buildMeshData` uses.

### sweep: dead branch
```cpp
if (maker.MakeSolid()) { return store(maker.Shape()); }
return store(maker.Shape());   // identical
```
Both branches were identical — the conditional was pointless. Now calls `maker.MakeSolid();` unconditionally then stores, matching `sweepPipeShell`.

These edit the `CustomBody` C++ in `config.rs`; `facade/generated/kernel.cpp` is regenerated. Method signatures are unchanged, so the Embind/WASI/Rust bindings are untouched.

## Verification
- [x] `cargo xtask codegen` regenerates cleanly (incl. the new spec validator); drift limited to `kernel.cpp`.
- [ ] **build-test (WASM)** compiles the facade + runs the full vitest suite — the real correctness gate (I can't compile OCCT locally).
- [ ] **WASI build + stale-check** will flag the embedded `crate/src/occt-wasm.wasm.br` as stale; I'll refresh it from the CI artifact in a follow-up commit.