### PR TITLE
fix(bench): make the regression gate read results from a file

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Run benchmarks & check for regressions
         if: ${{ !inputs.release }}
         shell: bash
-        run: set -o pipefail; npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
+        run: |
+          npx vitest run test/bench.test.ts
+          node scripts/bench-check.js
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ ts/docs/
 # Env
 .env
 .env.local
+
+# Per-run benchmark medians (written by test/bench.test.ts)
+benchmarks/last-run.json

--- a/scripts/bench-check.js
+++ b/scripts/bench-check.js
@@ -65,14 +65,15 @@ if (!existsSync(BASELINE_PATH)) {
 
 const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8'));
 
-// Every benchmark in the baseline must appear in the output. A missing one means
-// the table was empty or partial, so the regression gate never actually ran for
-// it — fail loudly instead of passing silently.
+// Every benchmark in the baseline must appear in the results. A missing one
+// means the run was empty or partial, so the regression gate never actually ran
+// for it — fail loudly (on stderr, like the missing-file error) instead of
+// passing silently.
 const missing = Object.keys(baseline).filter((name) => !(name in results));
 if (missing.length > 0) {
-    console.log(`\nERROR: ${missing.length} baseline benchmark(s) missing from output:`);
-    for (const name of missing) console.log(`  - ${name}`);
-    console.log('The benchmark table was empty or partial; the regression gate cannot run. Failing.');
+    console.error(`\nERROR: ${missing.length} baseline benchmark(s) missing from results:`);
+    for (const name of missing) console.error(`  - ${name}`);
+    console.error('The benchmark run was empty or partial; the regression gate cannot run. Failing.');
     process.exit(1);
 }
 

--- a/scripts/bench-check.js
+++ b/scripts/bench-check.js
@@ -1,17 +1,19 @@
 #!/usr/bin/env node
 /**
- * Compare benchmark output against a stored baseline.
+ * Compare benchmark results against a stored baseline.
  * Fails with exit code 1 if a benchmark regresses by more than BOTH a relative
  * (15%) and an absolute (0.5ms) margin. The absolute floor keeps sub-millisecond
  * benchmarks (e.g. mesh sphere ~0.6ms) from flake-failing on timer/scheduling
  * jitter, where a 0.1ms swing is already +17% but is pure noise.
  *
- * Usage:
- *   npx vitest run test/bench.test.ts 2>&1 | node scripts/bench-check.js
- *   node scripts/bench-check.js < bench-output.txt
+ * Reads results from benchmarks/last-run.json, which test/bench.test.ts writes
+ * directly via fs. (It used to parse the markdown table from vitest's stdout,
+ * but the default reporter suppresses per-test console.log when piped, so the
+ * gate received zero rows and passed silently.)
  *
- * To update the baseline:
- *   node scripts/bench-check.js --update-baseline < bench-output.txt
+ * Usage:
+ *   npx vitest run test/bench.test.ts && node scripts/bench-check.js
+ *   node scripts/bench-check.js --update-baseline   # after a run
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
@@ -20,29 +22,26 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BASELINE_PATH = resolve(__dirname, '../benchmarks/baseline.json');
+const RESULTS_PATH = resolve(__dirname, '../benchmarks/last-run.json');
 const THRESHOLD = 0.15; // 15% relative regression threshold
 const MIN_ABSOLUTE_MS = 0.5; // ignore regressions smaller than this in absolute terms (sub-ms noise)
 
-// Read stdin
-let input = '';
-process.stdin.setEncoding('utf-8');
-for await (const chunk of process.stdin) {
-    input += chunk;
+if (!existsSync(RESULTS_PATH)) {
+    console.error(
+        `No benchmark results at ${RESULTS_PATH}.\n` +
+        'Run `npx vitest run test/bench.test.ts` first (it writes that file).'
+    );
+    process.exit(1);
 }
 
-// Parse benchmark table from vitest output
-const lines = input.split('\n').filter(l => l.startsWith('|') && !l.includes('---') && !l.includes('Benchmark'));
-const results = {};
-for (const line of lines) {
-    const cols = line.split('|').map(c => c.trim()).filter(Boolean);
-    if (cols.length < 3) continue;
-    const name = cols[0];
-    const median = parseFloat(cols[2]);
-    if (!isNaN(median)) results[name] = median;
-}
+const results = JSON.parse(readFileSync(RESULTS_PATH, 'utf-8'));
 
-if (Object.keys(results).length === 0) {
-    console.log('No benchmark results found in input.');
+// With no baseline there is nothing to gate against — note and exit cleanly.
+// With a baseline, empty/partial results are a FAILURE, not a pass: it usually
+// means the suite didn't fully run (a crash or filter), and the missing-benchmark
+// check below turns that into a hard failure.
+if (Object.keys(results).length === 0 && !existsSync(BASELINE_PATH)) {
+    console.log('No benchmark results recorded (and no baseline to check).');
     process.exit(0);
 }
 
@@ -65,6 +64,18 @@ if (!existsSync(BASELINE_PATH)) {
 }
 
 const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8'));
+
+// Every benchmark in the baseline must appear in the output. A missing one means
+// the table was empty or partial, so the regression gate never actually ran for
+// it — fail loudly instead of passing silently.
+const missing = Object.keys(baseline).filter((name) => !(name in results));
+if (missing.length > 0) {
+    console.log(`\nERROR: ${missing.length} baseline benchmark(s) missing from output:`);
+    for (const name of missing) console.log(`  - ${name}`);
+    console.log('The benchmark table was empty or partial; the regression gate cannot run. Failing.');
+    process.exit(1);
+}
+
 let regressions = 0;
 
 console.log(`\nRegression check (fails at >${THRESHOLD * 100}% AND >${MIN_ABSOLUTE_MS}ms):`);

--- a/test/bench.test.ts
+++ b/test/bench.test.ts
@@ -40,10 +40,14 @@ afterAll(() => {
     // benchmark `it` fails, so a partial run yields a partial file that
     // scripts/bench-check.js then rejects via its missing-benchmark check.
     const medians = Object.fromEntries(ALL_RESULTS.map((r) => [r.name, r.median]));
-    writeFileSync(
-        resolve(__dirname, "../benchmarks/last-run.json"),
-        JSON.stringify(medians, null, 2) + "\n"
-    );
+    try {
+        writeFileSync(
+            resolve(__dirname, "../benchmarks/last-run.json"),
+            JSON.stringify(medians, null, 2) + "\n"
+        );
+    } catch (err) {
+        console.error("bench.test.ts: failed to write benchmarks/last-run.json:", err);
+    }
 });
 
 // ---------------------------------------------------------------------------

--- a/test/bench.test.ts
+++ b/test/bench.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { resolve } from "node:path";
+import { writeFileSync } from "node:fs";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let Module: any;
@@ -34,6 +35,15 @@ afterAll(() => {
         kernel.releaseAll();
         kernel.delete();
     }
+    // Write medians to a file (not console) so the regression gate doesn't depend
+    // on vitest's reporter replaying per-test console.log. Runs even when a
+    // benchmark `it` fails, so a partial run yields a partial file that
+    // scripts/bench-check.js then rejects via its missing-benchmark check.
+    const medians = Object.fromEntries(ALL_RESULTS.map((r) => [r.name, r.median]));
+    writeFileSync(
+        resolve(__dirname, "../benchmarks/last-run.json"),
+        JSON.stringify(medians, null, 2) + "\n"
+    );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The benchmark regression gate has been **silently never running** in CI.

`bench-check.js` parsed the markdown table from vitest's stdout, but vitest's **default reporter suppresses per-test `console.log` when piped** (the table only appears under `--reporter=verbose`). So in CI the gate received zero rows and hit the `'No benchmark results found' → exit 0` path — a regression gate that always passed regardless of performance.

### Fix
- **test/bench.test.ts**: writes medians to `benchmarks/last-run.json` via `fs` in `afterAll`. This is independent of the reporter, and `afterAll` runs even if a benchmark `it` fails, so a crashed/partial run produces a partial file.
- **scripts/bench-check.js**: reads that JSON instead of stdin, and **hard-fails if any baseline benchmark is missing** from the results — turning an empty/partial run into a loud failure instead of a silent pass.
- **build-wasm.yml**: runs the bench then the check as two commands (no pipe).
- **.gitignore**: ignores the per-run `last-run.json`.

## Test plan (all local)
- [x] Full run → `last-run.json` written, gate passes (no regressions vs baseline)
- [x] Missing results file → exit 1
- [x] Partial results (1 of 10 benchmarks) → exit 1
- [x] This PR's own `build-test` bench step now exercises the real gate

Note: this is the highest-impact slice of the test-suite audit; the broader shared-fixtures/coverage-gap work is left as a follow-up.