### PR TITLE
feat(facade): expose NURBS curve edit/construct + Bezier pole read

### DIFF
--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -88,6 +88,7 @@ pub(crate) struct GeneratedFuncs {
     fn_make_arc_edge: TypedFunc<(f64, f64, f64, f64, f64, f64, f64, f64, f64), u32>,
     fn_make_ellipse_edge: TypedFunc<(f64, f64, f64, f64, f64, f64, f64, f64), u32>,
     fn_make_bezier_edge: TypedFunc<(i32, i32), u32>,
+    fn_make_b_spline_edge: TypedFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32), u32>,
     fn_make_ellipse_arc: TypedFunc<(f64, f64, f64, f64, f64, f64, f64, f64, f64, f64), u32>,
     fn_make_helix_wire: TypedFunc<(f64, f64, f64, f64, f64, f64, f64, f64, f64), u32>,
     fn_make_non_planar_face: TypedFunc<(u32,), u32>,
@@ -146,6 +147,10 @@ pub(crate) struct GeneratedFuncs {
     fn_lift_curve2d_to_plane:
         TypedFunc<(i32, i32, f64, f64, f64, f64, f64, f64, f64, f64, f64), u32>,
     fn_get_nurbs_curve_data: TypedFunc<(u32,), i32>,
+    fn_curve_degree_elevate: TypedFunc<(u32, i32), u32>,
+    fn_curve_knot_insert: TypedFunc<(u32, f64, i32), u32>,
+    fn_curve_knot_remove: TypedFunc<(u32, f64, f64), u32>,
+    fn_curve_split: TypedFunc<(u32, f64), i32>,
     fn_has_triangulation: TypedFunc<(u32,), i32>,
     fn_query_batch: TypedFunc<(i32, i32), i32>,
     fn_pipe: TypedFunc<(u32, u32), u32>,
@@ -285,6 +290,8 @@ impl GeneratedFuncs {
             fn_make_arc_edge: instance.get_typed_func(&mut store, "occt_make_arc_edge")?,
             fn_make_ellipse_edge: instance.get_typed_func(&mut store, "occt_make_ellipse_edge")?,
             fn_make_bezier_edge: instance.get_typed_func(&mut store, "occt_make_bezier_edge")?,
+            fn_make_b_spline_edge: instance
+                .get_typed_func(&mut store, "occt_make_b_spline_edge")?,
             fn_make_ellipse_arc: instance.get_typed_func(&mut store, "occt_make_ellipse_arc")?,
             fn_make_helix_wire: instance.get_typed_func(&mut store, "occt_make_helix_wire")?,
             fn_make_non_planar_face: instance
@@ -358,6 +365,11 @@ impl GeneratedFuncs {
                 .get_typed_func(&mut store, "occt_lift_curve2d_to_plane")?,
             fn_get_nurbs_curve_data: instance
                 .get_typed_func(&mut store, "occt_get_nurbs_curve_data")?,
+            fn_curve_degree_elevate: instance
+                .get_typed_func(&mut store, "occt_curve_degree_elevate")?,
+            fn_curve_knot_insert: instance.get_typed_func(&mut store, "occt_curve_knot_insert")?,
+            fn_curve_knot_remove: instance.get_typed_func(&mut store, "occt_curve_knot_remove")?,
+            fn_curve_split: instance.get_typed_func(&mut store, "occt_curve_split")?,
             fn_has_triangulation: instance.get_typed_func(&mut store, "occt_has_triangulation")?,
             fn_query_batch: instance.get_typed_func(&mut store, "occt_query_batch")?,
             fn_pipe: instance.get_typed_func(&mut store, "occt_pipe")?,
@@ -1690,6 +1702,78 @@ impl crate::kernel::OcctKernel {
         Ok(ShapeHandle(result))
     }
 
+    pub fn make_b_spline_edge(
+        &mut self,
+        poles: &[f64],
+        weights: &[f64],
+        knots: &[f64],
+        multiplicities: &[i32],
+        degree: i32,
+        periodic: bool,
+    ) -> OcctResult<ShapeHandle> {
+        let poles_bytes: Vec<u8> = poles.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let poles_ptr = self.write_bytes(&poles_bytes)?;
+        let poles_len = poles.len() as u32;
+        let weights_bytes: Vec<u8> = weights.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let weights_ptr = match self.write_bytes(&weights_bytes) {
+            Ok(ptr) => ptr,
+            Err(e) => {
+                let _ = self.free_bytes(poles_ptr);
+                return Err(e);
+            }
+        };
+        let weights_len = weights.len() as u32;
+        let knots_bytes: Vec<u8> = knots.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let knots_ptr = match self.write_bytes(&knots_bytes) {
+            Ok(ptr) => ptr,
+            Err(e) => {
+                let _ = self.free_bytes(poles_ptr);
+                let _ = self.free_bytes(weights_ptr);
+                return Err(e);
+            }
+        };
+        let knots_len = knots.len() as u32;
+        let multiplicities_bytes: Vec<u8> = multiplicities
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        let multiplicities_ptr = match self.write_bytes(&multiplicities_bytes) {
+            Ok(ptr) => ptr,
+            Err(e) => {
+                let _ = self.free_bytes(poles_ptr);
+                let _ = self.free_bytes(weights_ptr);
+                let _ = self.free_bytes(knots_ptr);
+                return Err(e);
+            }
+        };
+        let multiplicities_len = multiplicities.len() as u32;
+        let result = self.generated.fn_make_b_spline_edge.call(
+            &mut self.store,
+            (
+                poles_ptr as i32,
+                poles_len as i32,
+                weights_ptr as i32,
+                weights_len as i32,
+                knots_ptr as i32,
+                knots_len as i32,
+                multiplicities_ptr as i32,
+                multiplicities_len as i32,
+                degree,
+                i32::from(periodic),
+            ),
+        );
+        self.free_bytes(poles_ptr)?;
+        self.free_bytes(weights_ptr)?;
+        self.free_bytes(knots_ptr)?;
+        self.free_bytes(multiplicities_ptr)?;
+        let result = result?;
+        self.check_error("make_b_spline_edge")?;
+        if result == 0 {
+            return Err(self.read_last_error("make_b_spline_edge"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
     pub fn make_ellipse_arc(
         &mut self,
         cx: f64,
@@ -2566,6 +2650,67 @@ impl crate::kernel::OcctKernel {
             return Err(self.read_last_error("get_nurbs_curve_data"));
         }
         self.read_nurbs_result()
+    }
+
+    pub fn curve_degree_elevate(
+        &mut self,
+        edge_id: ShapeHandle,
+        elevate_by: i32,
+    ) -> OcctResult<ShapeHandle> {
+        let result = self
+            .generated
+            .fn_curve_degree_elevate
+            .call(&mut self.store, (edge_id.0, elevate_by))?;
+        self.check_error("curve_degree_elevate")?;
+        if result == 0 {
+            return Err(self.read_last_error("curve_degree_elevate"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn curve_knot_insert(
+        &mut self,
+        edge_id: ShapeHandle,
+        knot: f64,
+        times: i32,
+    ) -> OcctResult<ShapeHandle> {
+        let result = self
+            .generated
+            .fn_curve_knot_insert
+            .call(&mut self.store, (edge_id.0, knot, times))?;
+        self.check_error("curve_knot_insert")?;
+        if result == 0 {
+            return Err(self.read_last_error("curve_knot_insert"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn curve_knot_remove(
+        &mut self,
+        edge_id: ShapeHandle,
+        knot: f64,
+        tolerance: f64,
+    ) -> OcctResult<ShapeHandle> {
+        let result = self
+            .generated
+            .fn_curve_knot_remove
+            .call(&mut self.store, (edge_id.0, knot, tolerance))?;
+        self.check_error("curve_knot_remove")?;
+        if result == 0 {
+            return Err(self.read_last_error("curve_knot_remove"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn curve_split(&mut self, edge_id: ShapeHandle, param: f64) -> OcctResult<Vec<u32>> {
+        let len = self
+            .generated
+            .fn_curve_split
+            .call(&mut self.store, (edge_id.0, param))?;
+        if len < 0 {
+            return Err(self.read_last_error("curve_split"));
+        }
+        self.read_vec_u32_result()
     }
 
     pub fn has_triangulation(&mut self, id: ShapeHandle) -> OcctResult<bool> {

--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -176,6 +176,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("makeArcEdge", &OcctKernel::makeArcEdge)
         .function("makeEllipseEdge", &OcctKernel::makeEllipseEdge)
         .function("makeBezierEdge", &OcctKernel::makeBezierEdge)
+        .function("makeBSplineEdge", &OcctKernel::makeBSplineEdge)
         .function("makeEllipseArc", &OcctKernel::makeEllipseArc)
         .function("makeHelixWire", &OcctKernel::makeHelixWire)
         .function("makeNonPlanarFace", &OcctKernel::makeNonPlanarFace)
@@ -241,6 +242,10 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("approximatePoints", &OcctKernel::approximatePoints)
         .function("liftCurve2dToPlane", &OcctKernel::liftCurve2dToPlane)
         .function("getNurbsCurveData", &OcctKernel::getNurbsCurveData)
+        .function("curveDegreeElevate", &OcctKernel::curveDegreeElevate)
+        .function("curveKnotInsert", &OcctKernel::curveKnotInsert)
+        .function("curveKnotRemove", &OcctKernel::curveKnotRemove)
+        .function("curveSplit", &OcctKernel::curveSplit)
 
         // sweep
         .function("pipe", &OcctKernel::pipe)

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -73,6 +73,7 @@
 #include <GeomAbs_JoinType.hxx>
 #include <GeomAbs_Shape.hxx>
 #include <GeomAbs_SurfaceType.hxx>
+#include <GeomConvert.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_BezierCurve.hxx>
@@ -97,6 +98,7 @@
 #include <NCollection_Sequence.hxx>
 #include <NCollection_Vec3.hxx>
 #include <Poly_Triangulation.hxx>
+#include <Precision.hxx>
 #include <Quantity_Color.hxx>
 #include <RWGltf_CafWriter.hxx>
 #include <STEPCAFControl_Reader.hxx>
@@ -138,6 +140,7 @@
 #include <XCAFDoc_ColorTool.hxx>
 #include <XCAFDoc_DocumentTool.hxx>
 #include <XCAFDoc_ShapeTool.hxx>
+#include <cmath>
 #include <cstdlib>
 #include <gp_Ax1.hxx>
 #include <gp_Ax2.hxx>
@@ -1354,6 +1357,56 @@ uint32_t OcctKernel::makeBezierEdge(std::vector<double> flatPoints) {
     }
 }
 
+uint32_t OcctKernel::makeBSplineEdge(std::vector<double> poles, std::vector<double> weights, std::vector<double> knots, std::vector<int> multiplicities, int degree, bool periodic) {
+    try {
+        int nPoles = static_cast<int>(poles.size()) / 3;
+        if (nPoles < 2) {
+            throw std::runtime_error("makeBSplineEdge: need at least 2 poles");
+        }
+        int nKnots = static_cast<int>(knots.size());
+        if (nKnots < 2 || static_cast<int>(multiplicities.size()) != nKnots) {
+            throw std::runtime_error("makeBSplineEdge: knots and multiplicities must be the same non-trivial length");
+        }
+        if (!weights.empty() && static_cast<int>(weights.size()) != nPoles) {
+            throw std::runtime_error("makeBSplineEdge: weights length must match pole count");
+        }
+        NCollection_Array1<gp_Pnt> polesArr(1, nPoles);
+        for (int i = 0; i < nPoles; i++) {
+            polesArr.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+        }
+        NCollection_Array1<double> knotsArr(1, nKnots);
+        NCollection_Array1<int> multsArr(1, nKnots);
+        for (int i = 0; i < nKnots; i++) {
+            knotsArr.SetValue(i + 1, knots[i]);
+            multsArr.SetValue(i + 1, multiplicities[i]);
+        }
+        bool rational = false;
+        for (double w : weights) {
+            if (std::abs(w - 1.0) > Precision::Confusion()) {
+                rational = true;
+                break;
+            }
+        }
+        Handle(Geom_BSplineCurve) curve;
+        if (rational) {
+            NCollection_Array1<double> weightsArr(1, nPoles);
+            for (int i = 0; i < nPoles; i++) {
+                weightsArr.SetValue(i + 1, weights[i]);
+            }
+            curve = new Geom_BSplineCurve(polesArr, weightsArr, knotsArr, multsArr, degree, periodic);
+        } else {
+            curve = new Geom_BSplineCurve(polesArr, knotsArr, multsArr, degree, periodic);
+        }
+        BRepBuilderAPI_MakeEdge maker(curve);
+        if (!maker.IsDone()) {
+            throw std::runtime_error("makeBSplineEdge: edge construction failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("makeBSplineEdge: ") + e.what());
+    }
+}
+
 uint32_t OcctKernel::makeEllipseArc(double cx, double cy, double cz, double nx, double ny, double nz, double majorRadius, double minorRadius, double startAngle, double endAngle) {
     try {
         gp_Ax2 axis(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
@@ -2417,11 +2470,14 @@ uint32_t OcctKernel::liftCurve2dToPlane(std::vector<double> flatPoints2d, double
 NurbsCurveData OcctKernel::getNurbsCurveData(uint32_t edgeId) {
     try {
         BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
-        if (adaptor.GetType() != GeomAbs_BSplineCurve) {
-            throw std::runtime_error("getNurbsCurveData: edge is not a BSpline curve");
+        Handle(Geom_BSplineCurve) bspline;
+        if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+            bspline = adaptor.BSpline();
+        } else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+            bspline = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+        } else {
+            throw std::runtime_error("getNurbsCurveData: edge is not a BSpline or Bezier curve");
         }
-        
-        Handle(Geom_BSplineCurve) bspline = adaptor.BSpline();
         NurbsCurveData result{};
         result.degree = bspline->Degree();
         result.rational = bspline->IsRational();
@@ -2457,6 +2513,119 @@ NurbsCurveData OcctKernel::getNurbsCurveData(uint32_t edgeId) {
         return result;
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("getNurbsCurveData: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::curveDegreeElevate(uint32_t edgeId, int elevateBy) {
+    try {
+        BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
+        Handle(Geom_BSplineCurve) bspline;
+        if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+            bspline = Handle(Geom_BSplineCurve)::DownCast(adaptor.BSpline()->Copy());
+        } else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+            bspline = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+        } else {
+            throw std::runtime_error("curveDegreeElevate: edge is not a BSpline or Bezier curve");
+        }
+        bspline->IncreaseDegree(bspline->Degree() + elevateBy);
+        BRepBuilderAPI_MakeEdge maker(bspline);
+        if (!maker.IsDone()) {
+            throw std::runtime_error("curveDegreeElevate: edge construction failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("curveDegreeElevate: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::curveKnotInsert(uint32_t edgeId, double knot, int times) {
+    try {
+        BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
+        Handle(Geom_BSplineCurve) bspline;
+        if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+            bspline = Handle(Geom_BSplineCurve)::DownCast(adaptor.BSpline()->Copy());
+        } else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+            bspline = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+        } else {
+            throw std::runtime_error("curveKnotInsert: edge is not a BSpline or Bezier curve");
+        }
+        bspline->InsertKnot(knot, times, Precision::Confusion());
+        BRepBuilderAPI_MakeEdge maker(bspline);
+        if (!maker.IsDone()) {
+            throw std::runtime_error("curveKnotInsert: edge construction failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("curveKnotInsert: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::curveKnotRemove(uint32_t edgeId, double knot, double tolerance) {
+    try {
+        BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
+        Handle(Geom_BSplineCurve) bspline;
+        if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+            bspline = Handle(Geom_BSplineCurve)::DownCast(adaptor.BSpline()->Copy());
+        } else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+            bspline = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+        } else {
+            throw std::runtime_error("curveKnotRemove: edge is not a BSpline or Bezier curve");
+        }
+        int index = 0;
+        for (int i = 1; i <= bspline->NbKnots(); i++) {
+            if (std::abs(bspline->Knot(i) - knot) <= tolerance) {
+                index = i;
+                break;
+            }
+        }
+        if (index == 0) {
+            throw std::runtime_error("curveKnotRemove: knot value not found");
+        }
+        int mult = bspline->Multiplicity(index);
+        if (!bspline->RemoveKnot(index, mult - 1, tolerance)) {
+            throw std::runtime_error("curveKnotRemove: knot cannot be removed within tolerance");
+        }
+        BRepBuilderAPI_MakeEdge maker(bspline);
+        if (!maker.IsDone()) {
+            throw std::runtime_error("curveKnotRemove: edge construction failed");
+        }
+        return store(maker.Shape());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("curveKnotRemove: ") + e.what());
+    }
+}
+
+std::vector<uint32_t> OcctKernel::curveSplit(uint32_t edgeId, double param) {
+    try {
+        BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
+        Handle(Geom_BSplineCurve) base;
+        if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+            base = adaptor.BSpline();
+        } else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+            base = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+        } else {
+            throw std::runtime_error("curveSplit: edge is not a BSpline or Bezier curve");
+        }
+        double first = base->FirstParameter();
+        double last = base->LastParameter();
+        if (param <= first || param >= last) {
+            throw std::runtime_error("curveSplit: parameter out of range");
+        }
+        Handle(Geom_BSplineCurve) left = Handle(Geom_BSplineCurve)::DownCast(base->Copy());
+        Handle(Geom_BSplineCurve) right = Handle(Geom_BSplineCurve)::DownCast(base->Copy());
+        left->Segment(first, param);
+        right->Segment(param, last);
+        BRepBuilderAPI_MakeEdge leftMaker(left);
+        BRepBuilderAPI_MakeEdge rightMaker(right);
+        if (!leftMaker.IsDone() || !rightMaker.IsDone()) {
+            throw std::runtime_error("curveSplit: edge construction failed");
+        }
+        std::vector<uint32_t> result;
+        result.push_back(store(leftMaker.Shape()));
+        result.push_back(store(rightMaker.Shape()));
+        return result;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("curveSplit: ") + e.what());
     }
 }
 

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -197,6 +197,9 @@ class OcctKernel {
                             double majorRadius, double minorRadius, double startAngle,
                             double endAngle);
     uint32_t makeBezierEdge(std::vector<double> flatPoints);
+    uint32_t makeBSplineEdge(std::vector<double> poles, std::vector<double> weights,
+                             std::vector<double> knots, std::vector<int> multiplicities, int degree,
+                             bool periodic);
     uint32_t makeTangentArc(double x1, double y1, double z1, double tx, double ty, double tz,
                             double x2, double y2, double z2);
     uint32_t makeHelixWire(double px, double py, double pz, double dx, double dy, double dz,
@@ -360,6 +363,10 @@ class OcctKernel {
 
     // --- NURBS introspection ---
     NurbsCurveData getNurbsCurveData(uint32_t edgeId);
+    uint32_t curveDegreeElevate(uint32_t edgeId, int elevateBy);
+    uint32_t curveKnotInsert(uint32_t edgeId, double knot, int times);
+    uint32_t curveKnotRemove(uint32_t edgeId, double knot, double tolerance);
+    std::vector<uint32_t> curveSplit(uint32_t edgeId, double param);
 
     // --- Surface construction ---
     uint32_t bsplineSurface(std::vector<double> flatPoints, int rows, int cols);

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -1009,6 +1009,131 @@ describe("curve operations", () => {
         data.multiplicities.delete();
         data.weights.delete();
     });
+
+    it("getNurbsCurveData reads poles from a Bezier edge (Bezier→BSpline conversion)", () => {
+        const pts = new Module.VectorDouble();
+        pts.push_back(0); pts.push_back(0); pts.push_back(0);
+        pts.push_back(5); pts.push_back(5); pts.push_back(0);
+        pts.push_back(10); pts.push_back(0); pts.push_back(0);
+        const bez = kernel.makeBezierEdge(pts);
+        pts.delete();
+        expect(kernel.curveType(bez)).toBe("bezier");
+        const data = kernel.getNurbsCurveData(bez);
+        expect(data.degree).toBe(2);
+        expect(data.poles.size()).toBe(9);
+        data.poles.delete();
+        data.knots.delete();
+        data.multiplicities.delete();
+        data.weights.delete();
+    });
+
+    // A non-rational degree-2 BSpline with a single knot span: knots [0,1],
+    // mults [3,3], 3 poles. Round-trips through getNurbsCurveData.
+    function makeTestBSpline() {
+        const poles = new Module.VectorDouble();
+        poles.push_back(0); poles.push_back(0); poles.push_back(0);
+        poles.push_back(5); poles.push_back(5); poles.push_back(0);
+        poles.push_back(10); poles.push_back(0); poles.push_back(0);
+        const weights = new Module.VectorDouble();
+        const knots = new Module.VectorDouble();
+        knots.push_back(0); knots.push_back(1);
+        const mults = new Module.VectorInt();
+        mults.push_back(3); mults.push_back(3);
+        const edge = kernel.makeBSplineEdge(poles, weights, knots, mults, 2, false);
+        poles.delete(); weights.delete(); knots.delete(); mults.delete();
+        return edge;
+    }
+
+    it("makeBSplineEdge constructs a BSpline edge that round-trips getNurbsCurveData", () => {
+        const edge = makeTestBSpline();
+        expect(edge).toBeGreaterThan(0);
+        expect(kernel.getShapeType(edge)).toBe("edge");
+        const data = kernel.getNurbsCurveData(edge);
+        expect(data.degree).toBe(2);
+        expect(data.poles.size()).toBe(9);
+        expect(data.rational).toBe(false);
+        data.poles.delete();
+        data.knots.delete();
+        data.multiplicities.delete();
+        data.weights.delete();
+    });
+
+    it("makeBSplineEdge builds a rational curve when weights differ from 1", () => {
+        const poles = new Module.VectorDouble();
+        poles.push_back(0); poles.push_back(0); poles.push_back(0);
+        poles.push_back(5); poles.push_back(5); poles.push_back(0);
+        poles.push_back(10); poles.push_back(0); poles.push_back(0);
+        const weights = new Module.VectorDouble();
+        weights.push_back(1); weights.push_back(2); weights.push_back(1);
+        const knots = new Module.VectorDouble();
+        knots.push_back(0); knots.push_back(1);
+        const mults = new Module.VectorInt();
+        mults.push_back(3); mults.push_back(3);
+        const edge = kernel.makeBSplineEdge(poles, weights, knots, mults, 2, false);
+        poles.delete(); weights.delete(); knots.delete(); mults.delete();
+        const data = kernel.getNurbsCurveData(edge);
+        expect(data.rational).toBe(true);
+        expect(data.weights.size()).toBe(3);
+        data.poles.delete();
+        data.knots.delete();
+        data.multiplicities.delete();
+        data.weights.delete();
+    });
+
+    it("curveDegreeElevate raises the degree", () => {
+        const edge = makeTestBSpline();
+        const elevated = kernel.curveDegreeElevate(edge, 1);
+        const data = kernel.getNurbsCurveData(elevated);
+        expect(data.degree).toBe(3);
+        data.poles.delete();
+        data.knots.delete();
+        data.multiplicities.delete();
+        data.weights.delete();
+    });
+
+    it("curveKnotInsert adds a knot without changing the curve shape", () => {
+        const edge = makeTestBSpline();
+        const before = kernel.getNurbsCurveData(edge);
+        const beforeKnots = before.knots.size();
+        before.poles.delete(); before.knots.delete();
+        before.multiplicities.delete(); before.weights.delete();
+
+        const inserted = kernel.curveKnotInsert(edge, 0.5, 1);
+        const after = kernel.getNurbsCurveData(inserted);
+        expect(after.knots.size()).toBe(beforeKnots + 1);
+        // Shape preserved: curveLength is a GCPnts approximation, so allow ~1e-3.
+        expect(kernel.curveLength(inserted)).toBeCloseTo(kernel.curveLength(edge), 3);
+        after.poles.delete(); after.knots.delete();
+        after.multiplicities.delete(); after.weights.delete();
+    });
+
+    it("curveKnotRemove undoes an inserted knot", () => {
+        const edge = makeTestBSpline();
+        const inserted = kernel.curveKnotInsert(edge, 0.5, 1);
+        const removed = kernel.curveKnotRemove(inserted, 0.5, 1e-3);
+        const data = kernel.getNurbsCurveData(removed);
+        expect(data.knots.size()).toBe(2);
+        data.poles.delete(); data.knots.delete();
+        data.multiplicities.delete(); data.weights.delete();
+    });
+
+    it("curveSplit returns two sub-edges that sum to the original length", () => {
+        const edge = makeTestBSpline();
+        const total = kernel.curveLength(edge);
+        const parts = kernel.curveSplit(edge, 0.5);
+        expect(parts.size()).toBe(2);
+        const left = parts.get(0);
+        const right = parts.get(1);
+        expect(kernel.getShapeType(left)).toBe("edge");
+        expect(kernel.getShapeType(right)).toBe("edge");
+        expect(kernel.curveLength(left) + kernel.curveLength(right)).toBeCloseTo(total, 3);
+        parts.delete();
+    });
+
+    it("curveSplit rejects an out-of-range parameter", () => {
+        const edge = makeTestBSpline();
+        expect(() => kernel.curveSplit(edge, 5)).toThrow();
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -587,6 +587,27 @@ export class OcctKernel {
         });
     }
 
+    makeBSplineEdge(
+        poles: number[],
+        weights: number[],
+        knots: number[],
+        multiplicities: number[],
+        degree: number,
+        periodic = false,
+    ): ShapeHandle {
+        return wrap("makeBSplineEdge", () =>
+            this.#withF64(poles, (polesVec) =>
+                this.#withF64(weights, (weightsVec) =>
+                    this.#withF64(knots, (knotsVec) =>
+                        this.#withI32(multiplicities, (multsVec) =>
+                            handle(this.#raw.makeBSplineEdge(polesVec, weightsVec, knotsVec, multsVec, degree, periodic)),
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+
     makeTangentArc(start: Vec3, tangent: Vec3, end: Vec3): ShapeHandle {
         return wrap("makeTangentArc", () =>
             handle(this.#raw.makeTangentArc(
@@ -1456,6 +1477,28 @@ export class OcctKernel {
                 weights: this.#drainVector(raw.weights, Float64Array),
             };
             return result;
+        });
+    }
+
+    curveDegreeElevate(edge: ShapeHandle, elevateBy: number): ShapeHandle {
+        return wrap("curveDegreeElevate", () => handle(this.#raw.curveDegreeElevate(edge, elevateBy)));
+    }
+
+    curveKnotInsert(edge: ShapeHandle, knot: number, times: number): ShapeHandle {
+        return wrap("curveKnotInsert", () => handle(this.#raw.curveKnotInsert(edge, knot, times)));
+    }
+
+    curveKnotRemove(edge: ShapeHandle, knot: number, tolerance: number): ShapeHandle {
+        return wrap("curveKnotRemove", () => handle(this.#raw.curveKnotRemove(edge, knot, tolerance)));
+    }
+
+    curveSplit(edge: ShapeHandle, param: number): [ShapeHandle, ShapeHandle] {
+        return wrap("curveSplit", () => {
+            const parts = this.#vecToHandles(this.#raw.curveSplit(edge, param));
+            if (parts.length !== 2) {
+                throw new Error(`curveSplit: expected 2 edges, got ${parts.length}`);
+            }
+            return [parts[0]!, parts[1]!];
         });
     }
 

--- a/ts/src/raw-types.ts
+++ b/ts/src/raw-types.ts
@@ -189,6 +189,7 @@ export interface OcctRawKernel {
     makeEllipseEdge(cx: number, cy: number, cz: number, nx: number, ny: number, nz: number, majorRadius: number, minorRadius: number): number;
     makeEllipseArc(cx: number, cy: number, cz: number, nx: number, ny: number, nz: number, majorRadius: number, minorRadius: number, startAngle: number, endAngle: number): number;
     makeBezierEdge(flatPoints: EmbindVectorF64): number;
+    makeBSplineEdge(poles: EmbindVectorF64, weights: EmbindVectorF64, knots: EmbindVectorF64, multiplicities: EmbindVectorI32, degree: number, periodic: boolean): number;
     makeTangentArc(x1: number, y1: number, z1: number, tx: number, ty: number, tz: number, x2: number, y2: number, z2: number): number;
     makeHelixWire(px: number, py: number, pz: number, dx: number, dy: number, dz: number, pitch: number, height: number, radius: number): number;
     makeWire(edgeIds: EmbindVectorU32): number;
@@ -298,6 +299,10 @@ export interface OcctRawKernel {
     projectPointOnEdge(edgeId: number, x: number, y: number, z: number): EmbindVectorF64;
     approximatePoints(flatPoints: EmbindVectorF64, tolerance: number): number;
     getNurbsCurveData(edgeId: number): RawNurbsCurveData;
+    curveDegreeElevate(edgeId: number, elevateBy: number): number;
+    curveKnotInsert(edgeId: number, knot: number, times: number): number;
+    curveKnotRemove(edgeId: number, knot: number, tolerance: number): number;
+    curveSplit(edgeId: number, param: number): EmbindVectorU32;
     liftCurve2dToPlane(flatPoints2d: EmbindVectorF64, planeOx: number, planeOy: number, planeOz: number, planeZx: number, planeZy: number, planeZz: number, planeXx: number, planeXy: number, planeXz: number): number;
 
     // Projection

--- a/ts/src/worker.ts
+++ b/ts/src/worker.ts
@@ -136,6 +136,11 @@ export interface OcctWorkerProxy {
     curveType(edge: ShapeHandle): Promise<CurveKind>;
     curveLength(edge: ShapeHandle): Promise<number>;
     getNurbsCurveData(edge: ShapeHandle): Promise<NurbsCurveData>;
+    makeBSplineEdge(poles: number[], weights: number[], knots: number[], multiplicities: number[], degree: number, periodic?: boolean): Promise<ShapeHandle>;
+    curveDegreeElevate(edge: ShapeHandle, elevateBy: number): Promise<ShapeHandle>;
+    curveKnotInsert(edge: ShapeHandle, knot: number, times: number): Promise<ShapeHandle>;
+    curveKnotRemove(edge: ShapeHandle, knot: number, tolerance: number): Promise<ShapeHandle>;
+    curveSplit(edge: ShapeHandle, param: number): Promise<[ShapeHandle, ShapeHandle]>;
 
     // Projection
     projectEdges(shape: ShapeHandle, viewOrigin: Vec3, viewDirection: Vec3, xAxis?: Vec3): Promise<ProjectionData>;

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -1446,6 +1446,70 @@ return store(maker.Shape());",
         return_type: ReturnType::ShapeId,
     },
     MethodSpec {
+        name: "makeBSplineEdge",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::VectorDouble("poles"),
+            FacadeParam::VectorDouble("weights"),
+            FacadeParam::VectorDouble("knots"),
+            FacadeParam::VectorInt("multiplicities"),
+            FacadeParam::Int("degree"),
+            FacadeParam::Bool("periodic"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+int nPoles = static_cast<int>(poles.size()) / 3;
+if (nPoles < 2) {
+    throw std::runtime_error(\"makeBSplineEdge: need at least 2 poles\");
+}
+int nKnots = static_cast<int>(knots.size());
+if (nKnots < 2 || static_cast<int>(multiplicities.size()) != nKnots) {
+    throw std::runtime_error(\"makeBSplineEdge: knots and multiplicities must be the same non-trivial length\");
+}
+if (!weights.empty() && static_cast<int>(weights.size()) != nPoles) {
+    throw std::runtime_error(\"makeBSplineEdge: weights length must match pole count\");
+}
+NCollection_Array1<gp_Pnt> polesArr(1, nPoles);
+for (int i = 0; i < nPoles; i++) {
+    polesArr.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+}
+NCollection_Array1<double> knotsArr(1, nKnots);
+NCollection_Array1<int> multsArr(1, nKnots);
+for (int i = 0; i < nKnots; i++) {
+    knotsArr.SetValue(i + 1, knots[i]);
+    multsArr.SetValue(i + 1, multiplicities[i]);
+}
+bool rational = false;
+for (double w : weights) {
+    if (std::abs(w - 1.0) > Precision::Confusion()) {
+        rational = true;
+        break;
+    }
+}
+Handle(Geom_BSplineCurve) curve;
+if (rational) {
+    NCollection_Array1<double> weightsArr(1, nPoles);
+    for (int i = 0; i < nPoles; i++) {
+        weightsArr.SetValue(i + 1, weights[i]);
+    }
+    curve = new Geom_BSplineCurve(polesArr, weightsArr, knotsArr, multsArr, degree, periodic);
+} else {
+    curve = new Geom_BSplineCurve(polesArr, knotsArr, multsArr, degree, periodic);
+}
+BRepBuilderAPI_MakeEdge maker(curve);
+if (!maker.IsDone()) {
+    throw std::runtime_error(\"makeBSplineEdge: edge construction failed\");
+}
+return store(maker.Shape());",
+        includes: &[
+            "BRepBuilderAPI_MakeEdge.hxx", "Geom_BSplineCurve.hxx",
+            "NCollection_Array1.hxx", "Precision.hxx", "cmath", "gp_Pnt.hxx",
+        ],
+        category: "construction",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
         name: "makeEllipseArc",
         kind: MethodKind::CustomBody,
         params: &[
@@ -2829,11 +2893,14 @@ return store(edgeMaker.Shape());",
         ctor_args: "",
         setup_code: "\
 BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
-if (adaptor.GetType() != GeomAbs_BSplineCurve) {
-    throw std::runtime_error(\"getNurbsCurveData: edge is not a BSpline curve\");
+Handle(Geom_BSplineCurve) bspline;
+if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+    bspline = adaptor.BSpline();
+} else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+    bspline = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+} else {
+    throw std::runtime_error(\"getNurbsCurveData: edge is not a BSpline or Bezier curve\");
 }
-
-Handle(Geom_BSplineCurve) bspline = adaptor.BSpline();
 NurbsCurveData result{};
 result.degree = bspline->Degree();
 result.rational = bspline->IsRational();
@@ -2869,10 +2936,164 @@ if (bspline->IsRational()) {
 return result;",
         includes: &[
             "BRepAdaptor_Curve.hxx", "GeomAbs_CurveType.hxx",
-            "Geom_BSplineCurve.hxx", "TopoDS.hxx", "gp_Pnt.hxx",
+            "Geom_BSplineCurve.hxx", "Geom_BezierCurve.hxx", "GeomConvert.hxx",
+            "TopoDS.hxx", "gp_Pnt.hxx",
         ],
         category: "curve",
         return_type: ReturnType::NurbsCurveData,
+    },
+    MethodSpec {
+        name: "curveDegreeElevate",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("edgeId"), FacadeParam::Int("elevateBy")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
+Handle(Geom_BSplineCurve) bspline;
+if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+    bspline = Handle(Geom_BSplineCurve)::DownCast(adaptor.BSpline()->Copy());
+} else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+    bspline = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+} else {
+    throw std::runtime_error(\"curveDegreeElevate: edge is not a BSpline or Bezier curve\");
+}
+bspline->IncreaseDegree(bspline->Degree() + elevateBy);
+BRepBuilderAPI_MakeEdge maker(bspline);
+if (!maker.IsDone()) {
+    throw std::runtime_error(\"curveDegreeElevate: edge construction failed\");
+}
+return store(maker.Shape());",
+        includes: &[
+            "BRepAdaptor_Curve.hxx", "BRepBuilderAPI_MakeEdge.hxx",
+            "GeomAbs_CurveType.hxx", "Geom_BSplineCurve.hxx",
+            "Geom_BezierCurve.hxx", "GeomConvert.hxx", "TopoDS.hxx",
+        ],
+        category: "curve",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "curveKnotInsert",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::ShapeId("edgeId"),
+            FacadeParam::Double("knot"),
+            FacadeParam::Int("times"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
+Handle(Geom_BSplineCurve) bspline;
+if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+    bspline = Handle(Geom_BSplineCurve)::DownCast(adaptor.BSpline()->Copy());
+} else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+    bspline = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+} else {
+    throw std::runtime_error(\"curveKnotInsert: edge is not a BSpline or Bezier curve\");
+}
+bspline->InsertKnot(knot, times, Precision::Confusion());
+BRepBuilderAPI_MakeEdge maker(bspline);
+if (!maker.IsDone()) {
+    throw std::runtime_error(\"curveKnotInsert: edge construction failed\");
+}
+return store(maker.Shape());",
+        includes: &[
+            "BRepAdaptor_Curve.hxx", "BRepBuilderAPI_MakeEdge.hxx",
+            "GeomAbs_CurveType.hxx", "Geom_BSplineCurve.hxx",
+            "Geom_BezierCurve.hxx", "GeomConvert.hxx", "Precision.hxx", "TopoDS.hxx",
+        ],
+        category: "curve",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "curveKnotRemove",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::ShapeId("edgeId"),
+            FacadeParam::Double("knot"),
+            FacadeParam::Double("tolerance"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
+Handle(Geom_BSplineCurve) bspline;
+if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+    bspline = Handle(Geom_BSplineCurve)::DownCast(adaptor.BSpline()->Copy());
+} else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+    bspline = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+} else {
+    throw std::runtime_error(\"curveKnotRemove: edge is not a BSpline or Bezier curve\");
+}
+int index = 0;
+for (int i = 1; i <= bspline->NbKnots(); i++) {
+    if (std::abs(bspline->Knot(i) - knot) <= tolerance) {
+        index = i;
+        break;
+    }
+}
+if (index == 0) {
+    throw std::runtime_error(\"curveKnotRemove: knot value not found\");
+}
+int mult = bspline->Multiplicity(index);
+if (!bspline->RemoveKnot(index, mult - 1, tolerance)) {
+    throw std::runtime_error(\"curveKnotRemove: knot cannot be removed within tolerance\");
+}
+BRepBuilderAPI_MakeEdge maker(bspline);
+if (!maker.IsDone()) {
+    throw std::runtime_error(\"curveKnotRemove: edge construction failed\");
+}
+return store(maker.Shape());",
+        includes: &[
+            "BRepAdaptor_Curve.hxx", "BRepBuilderAPI_MakeEdge.hxx", "cmath",
+            "GeomAbs_CurveType.hxx", "Geom_BSplineCurve.hxx",
+            "Geom_BezierCurve.hxx", "GeomConvert.hxx", "TopoDS.hxx",
+        ],
+        category: "curve",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
+        name: "curveSplit",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("edgeId"), FacadeParam::Double("param")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+BRepAdaptor_Curve adaptor(TopoDS::Edge(get(edgeId)));
+Handle(Geom_BSplineCurve) base;
+if (adaptor.GetType() == GeomAbs_BSplineCurve) {
+    base = adaptor.BSpline();
+} else if (adaptor.GetType() == GeomAbs_BezierCurve) {
+    base = GeomConvert::CurveToBSplineCurve(adaptor.Bezier());
+} else {
+    throw std::runtime_error(\"curveSplit: edge is not a BSpline or Bezier curve\");
+}
+double first = base->FirstParameter();
+double last = base->LastParameter();
+if (param <= first || param >= last) {
+    throw std::runtime_error(\"curveSplit: parameter out of range\");
+}
+Handle(Geom_BSplineCurve) left = Handle(Geom_BSplineCurve)::DownCast(base->Copy());
+Handle(Geom_BSplineCurve) right = Handle(Geom_BSplineCurve)::DownCast(base->Copy());
+left->Segment(first, param);
+right->Segment(param, last);
+BRepBuilderAPI_MakeEdge leftMaker(left);
+BRepBuilderAPI_MakeEdge rightMaker(right);
+if (!leftMaker.IsDone() || !rightMaker.IsDone()) {
+    throw std::runtime_error(\"curveSplit: edge construction failed\");
+}
+std::vector<uint32_t> result;
+result.push_back(store(leftMaker.Shape()));
+result.push_back(store(rightMaker.Shape()));
+return result;",
+        includes: &[
+            "BRepAdaptor_Curve.hxx", "BRepBuilderAPI_MakeEdge.hxx",
+            "GeomAbs_CurveType.hxx", "Geom_BSplineCurve.hxx",
+            "Geom_BezierCurve.hxx", "GeomConvert.hxx", "TopoDS.hxx",
+        ],
+        category: "curve",
+        return_type: ReturnType::VectorUint32,
     },
     MethodSpec {
         name: "hasTriangulation",


### PR DESCRIPTION
Closes #172.

Adds the curve-editing and construction bindings that downstream consumers (brepjs) need to reach kernel parity. All map directly to existing OCCT primitives, so they're thin bindings.

## New bindings

| Binding | OCCT primitive |
|---|---|
| `makeBSplineEdge(poles, weights, knots, multiplicities, degree, periodic) → edge` | `Geom_BSplineCurve` ctor + `BRepBuilderAPI_MakeEdge` |
| `curveDegreeElevate(edge, elevateBy) → edge` | `Geom_BSplineCurve::IncreaseDegree` |
| `curveKnotInsert(edge, knot, times) → edge` | `Geom_BSplineCurve::InsertKnot` |
| `curveKnotRemove(edge, knot, tolerance) → edge` | `Geom_BSplineCurve::RemoveKnot` (resolves knot value → index) |
| `curveSplit(edge, param) → [edge, edge]` | `Geom_BSplineCurve::Segment` on two copies |

The edit ops copy the source B-spline (`->Copy()`) before mutating, so the input edge is never altered. They also accept Bézier edges (converted on the fly), as does `makeBSplineEdge`'s rational path (any weight ≠ 1 selects the rational ctor).

## Bézier read gap

`getNurbsCurveData` now converts a `Geom_BezierCurve` to a B-spline via `GeomConvert::CurveToBSplineCurve` before reading poles, instead of returning `null`. A Bézier's B-spline form preserves the same control poles, so this unblocks downstream's `getBezierPenultimatePole` (`poles[n-2]`) without a dedicated binding.

```ts
const bez = k.makeBezierEdge([[0,0,0],[5,5,0],[10,0,0]]);
k.curveType(bez);          // "bezier"
k.getNurbsCurveData(bez);  // now returns degree-2 data with 3 poles (was null)
```

## Layers touched

- `xtask/src/codegen/config.rs` — 5 new `MethodSpec`s + the `getNurbsCurveData` body change (single source of truth)
- Regenerated facade (`kernel.cpp`, `bindings.cpp`, `wasi_exports.cpp`) + crate (`kernel_generated.rs`)
- Re-embedded `crate/src/occt-wasm.wasm.br` (WASI rebuild)
- Hand-written: `occt_kernel.h` declarations, TS wrapper (`index.ts`), worker proxy (`worker.ts`), raw type surface (`raw-types.ts`)

## Tests

8 new raw-level tests in `api-coverage.test.ts`: Bézier pole read, B-spline round-trip, rational construction, degree elevation, knot insert/remove inverse, split-length conservation, out-of-range rejection.

- Full vitest suite: **327 passed**, 2 pre-existing skips
- Crate tests pass against the fresh `wasm.br`
- `tsc` + `eslint` + `cargo fmt` + `clippy -D warnings` + clang-format all clean

## Out of scope

`createCurveAdaptor` — per the issue, evaluation is already covered by the id-based API (`curvePointAtParam` / `curveTangent` / `curveParameters`), so no adaptor object is exposed.