### PR TITLE
feat(ts): support Firefox 121+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium firefox --with-deps
 
       - name: Run browser smoke test
         run: npx playwright test

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To set expectations, this library deliberately does not:
 
 - **Provide a higher-level CAD modeling API** — parametric sketching, constraints, feature trees, and ergonomic modeling belong in [brepjs](https://github.com/andymai/brepjs), which wraps occt-wasm for that purpose
 - **Manage memory automatically beyond arena handles** — shapes are freed when the kernel is disposed or you call `release()`; there is no per-shape garbage collection
-- **Support non-WASM-SIMD browsers** — the build requires WASM SIMD (baseline `-msimd128`), tail calls, and wasm exceptions; Firefox lacks tail call support as of v130. Relaxed-SIMD is intentionally not used: some Safari/iOS WebKit builds fail to compile relaxed-SIMD modules, and it made geometry non-reproducible across CPUs
+- **Support non-WASM-SIMD browsers** — the build requires WASM SIMD (baseline `-msimd128`), tail calls, and wasm exceptions, so it needs a recent engine (see [Browser Compatibility](#browser-compatibility)). Relaxed-SIMD is intentionally not used: some Safari/iOS WebKit builds fail to compile relaxed-SIMD modules, and it made geometry non-reproducible across CPUs
 - **Include OCCT visualization or display modules** — TKV3d, TKHLR (except the HLR facade), and the AIS interactive context are excluded; bring your own renderer (Three.js, Babylon.js, etc.)
 - **Support IGES import/export** -- TKDEIGES is excluded from the link; use STEP for interchange
 
@@ -377,15 +377,15 @@ npm run docker:dist     # Build + copy dist/ artifacts to host
 
 occt-wasm requires modern browsers with WASM SIMD, tail calls, and exception
 handling. WASM **tail calls** are the newest and therefore binding requirement —
-they gate the minimum versions below and are the reason Firefox is unsupported.
-The versions listed are the lowest combinations verified to load the kernel:
+they gate the minimum versions below. The versions listed are the lowest
+combinations verified to load the kernel:
 
 | Browser | Minimum (verified) | Notes                                       |
 | ------- | ------------------ | ------------------------------------------- |
 | Chrome  | 114+               | Tail calls landed in 112; 114 is verified   |
 | Edge    | 114+               | Same engine as Chrome                       |
 | Safari  | 17.2+              | Earliest WebKit verified to load the kernel |
-| Firefox | Not supported      | No WASM tail call support as of Firefox 130 |
+| Firefox | 121+               | Tail calls shipped in 121; 146 is verified  |
 
 Node.js 22+ is recommended (tail calls via V8). Node.js 18+ works if your V8 version supports the required WASM features.
 
@@ -396,7 +396,6 @@ These are upstream OCCT V8.0.0 issues, not occt-wasm bugs:
 - **IGES** -- TKDEIGES excluded from link; no IGES import/export
 - **Zero-length extrusion** -- WASM exception escapes JS catch boundary (1 test skip)
 - **Single WASM thread** -- each kernel instance is single-threaded; use `OcctWorker` (see above) to move work off the main thread
-- **Firefox** -- not supported due to missing WASM tail call support
 
 These will be addressed as upstream OCCT and browser support improve.
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,13 @@
-import { defineConfig } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
     testDir: "test/browser",
     timeout: 60_000,
-    use: {
-        browserName: "chromium",
-    },
+    projects: [
+        { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+        // Firefox 121+ ships WASM tail calls, the build's binding requirement.
+        { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    ],
     webServer: {
         command: "npx serve . -l 3000 --no-clipboard",
         port: 3000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,9 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
     testDir: "test/browser",
-    timeout: 60_000,
+    // 90s leaves headroom above the 50s in-page WASM-compile wait (smoke.spec.ts)
+    // for page.goto + assertions on a cold, loaded CI runner.
+    timeout: 90_000,
     projects: [
         { name: "chromium", use: { ...devices["Desktop Chrome"] } },
         // Firefox 121+ ships WASM tail calls, the build's binding requirement.

--- a/test/browser/smoke.spec.ts
+++ b/test/browser/smoke.spec.ts
@@ -4,8 +4,9 @@ test("WASM loads and basic operations work in the browser", async ({ page }) => 
     // Serve the test page
     await page.goto("http://localhost:3000/test/browser/index.html");
 
-    // Wait for WASM to load and tests to complete
-    const result = await page.waitForSelector("#result", { timeout: 30_000 });
+    // Wait for WASM to load and tests to complete. A cold Firefox profile
+    // compiling the ~22 MB module needs more headroom than warm Chromium.
+    const result = await page.waitForSelector("#result", { timeout: 50_000 });
     const text = await result.textContent();
 
     // Verify all checks passed


### PR DESCRIPTION
## What

Marks **Firefox 121+** as a supported browser and adds it to the CI browser smoke matrix.

## Why

The build's only stated blocker for Firefox was WASM **tail calls** (\`-mtail-call\` / \`--enable-tail-call\`). Firefox shipped tail calls **by default in v121 (Dec 2023)**, so the "unsupported" docs were stale. Everything else the binary needs — SIMD (FF 89+), wasm-exceptions (FF 100+), module workers (FF 114+) — Firefox has long supported.

## Verification

Ran the existing browser smoke suite in **Firefox 146** (Playwright). All checks pass: \`makeBox\`, \`getVolume\`, boolean \`cut\`, \`tessellate\`, full STEP export→reimport round-trip, and \`getShapeType\`. The only Firefox-specific signal is a *deprecation warning* (legacy wasm-EH \`try\` vs \`try_table\`) — not an error.

## Changes

- **playwright.config.ts** — add a \`firefox\` project alongside \`chromium\`
- **.github/workflows/ci.yml** — \`playwright install chromium firefox\` so the \`browser-smoke\` job exercises Firefox
- **test/browser/smoke.spec.ts** — widen the page-load wait (30s→50s) for cold Firefox WASM compiles; still under the 60s test cap
- **README.md** — Firefox row → 121+ (146 verified); drop the three stale "unsupported / no tail calls" claims

No binary/build-flag changes — \`dist/\` and \`crate/src/occt-wasm.wasm.br\` are untouched, so no WASI rebuild or stale-check is triggered.