### PR TITLE
docs(xtask): explain why npm build keeps legacy wasm EH

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -281,6 +281,14 @@ fn optimize_wasm(sh: &Shell, root: &Path) -> Result<()> {
 
     let wasm_opt_bin = find_wasm_opt();
 
+    // Deliberately NOT translating legacy `try`/`catch` to the new
+    // `try_table`/`exnref` encoding here (cf. `convert_eh` in build_wasi.rs).
+    // Firefox emits a deprecation warning for legacy EH, but it still runs it;
+    // exnref, by contrast, is rejected by Node's V8 without
+    // --experimental-wasm-exnref and post-dates the Chrome 114 / Safari 17.2
+    // floor. The crate build can use exnref only because wasmtime is configured
+    // to accept it; the npm build targets unmodified browsers AND Node, so
+    // legacy EH stays. Revisit once exnref is default across the support matrix.
     eprintln!("Step 4: Running wasm-opt...");
     cmd!(
         sh,


### PR DESCRIPTION
## What

Adds a comment at the npm build's `wasm-opt` step (`optimize_wasm` in `xtask/src/build.rs`) documenting why it deliberately keeps Emscripten's **legacy `try`/`catch` exception encoding** rather than translating to the new `try_table`/`exnref` form.

## Why

Firefox prints a deprecation warning for legacy wasm EH and suggests `try_table`. Flipping the npm build to exnref (mirroring `convert_eh` in `build_wasi.rs`) silences the warning but **breaks Node** consumers of the package.

Verified empirically by translating the existing `dist/occt-wasm.wasm` with `wasm-opt --translate-to-new-eh` and loading it:

| Engine | Legacy `try` (current) | New `try_table`/`exnref` |
|--------|------------------------|--------------------------|
| Firefox 146 | works (+ warning) | works, warning gone |
| Node 24.11 (V8) | works | **fails to instantiate** — `CompileError: invalid value type 'exn', enable with --experimental-wasm-exnref` |

`exnref` is still flag-gated in Node's V8 and post-dates the Chrome 114 / Safari 17.2 support floor. The crate build can use exnref only because wasmtime is configured (`wasm_exceptions(true)`) to accept it — that doesn't transfer to the npm build, which targets unmodified browsers **and** Node. The deprecation warning is harmless; legacy EH runs everywhere in the matrix.

## Change

Comment-only — no behavior change. Revisit once exnref is enabled-by-default across Node and the Chrome/Safari floors.