### PR TITLE
fix(occt): document and release OCCT V8.0.0.p1 upstream fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,10 @@ These are upstream OCCT V8.0.0.p1 issues, not occt-wasm bugs:
 
 These will be addressed as upstream OCCT and browser support improve.
 
+OCCT V8.0.0.p1 (2026-06) resolved several upstream hangs and crashes that
+affected modeling here: infinite-loop guards in `IntWalk_IWalking` and
+`BRepFill_CompatibleWires`, and a null-curve guard in `BRepExtrema_DistanceSS`.
+
 ## Contributing
 
 This project is open source. Bug reports and feature requests are welcome via GitHub Issues. For pull requests, please open an issue first to discuss the change.


### PR DESCRIPTION
Second release-signal attempt for the p1 bump (supersedes the empty #183).

**Why #183 didn't work:** release-please assigns commits to a package by the files they touch, so the empty follow-up commit was invisible ("No user facing commits found"). This commit touches README (a real, on-topic doc change noting the p1 fixes), so the `fix(occt)` registers and release-please will cut a patch release.

**No functional change** — p1 already shipped in #182 (submodule `6e1fe65`, refreshed `wasm.br`, builder image pushed). Merging this makes release-please open the `chore(main): release 3.5.1` PR; merging *that* publishes p1 to npm.