### PR TITLE
feat(facade): add located() cheap location-only move

### DIFF
--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -67,6 +67,7 @@ pub(crate) struct GeneratedFuncs {
     fn_linear_pattern: TypedFunc<(u32, f64, f64, f64, f64, i32), u32>,
     fn_circular_pattern: TypedFunc<(u32, f64, f64, f64, f64, f64, f64, f64, i32), u32>,
     fn_transform: TypedFunc<(u32, i32, i32), u32>,
+    fn_located: TypedFunc<(u32, i32, i32), u32>,
     fn_general_transform: TypedFunc<(u32, i32, i32), u32>,
     fn_translate_batch: TypedFunc<(i32, i32, i32, i32), i32>,
     fn_compose_transform: TypedFunc<(i32, i32, i32, i32), i32>,
@@ -268,6 +269,7 @@ impl GeneratedFuncs {
             fn_linear_pattern: instance.get_typed_func(&mut store, "occt_linear_pattern")?,
             fn_circular_pattern: instance.get_typed_func(&mut store, "occt_circular_pattern")?,
             fn_transform: instance.get_typed_func(&mut store, "occt_transform")?,
+            fn_located: instance.get_typed_func(&mut store, "occt_located")?,
             fn_general_transform: instance.get_typed_func(&mut store, "occt_general_transform")?,
             fn_translate_batch: instance.get_typed_func(&mut store, "occt_translate_batch")?,
             fn_compose_transform: instance.get_typed_func(&mut store, "occt_compose_transform")?,
@@ -1247,6 +1249,23 @@ impl crate::kernel::OcctKernel {
         self.check_error("transform")?;
         if result == 0 {
             return Err(self.read_last_error("transform"));
+        }
+        Ok(ShapeHandle(result))
+    }
+
+    pub fn located(&mut self, id: ShapeHandle, matrix: &[f64]) -> OcctResult<ShapeHandle> {
+        let matrix_bytes: Vec<u8> = matrix.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let matrix_ptr = self.write_bytes(&matrix_bytes)?;
+        let matrix_len = matrix.len() as u32;
+        let result = self.generated.fn_located.call(
+            &mut self.store,
+            (id.0, matrix_ptr as i32, matrix_len as i32),
+        );
+        self.free_bytes(matrix_ptr)?;
+        let result = result?;
+        self.check_error("located")?;
+        if result == 0 {
+            return Err(self.read_last_error("located"));
         }
         Ok(ShapeHandle(result))
     }

--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -153,6 +153,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("linearPattern", &OcctKernel::linearPattern)
         .function("circularPattern", &OcctKernel::circularPattern)
         .function("transform", &OcctKernel::transform)
+        .function("located", &OcctKernel::located)
         .function("generalTransform", &OcctKernel::generalTransform)
         .function("translateBatch", &OcctKernel::translateBatch)
         .function("composeTransform", &OcctKernel::composeTransform)

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -990,6 +990,21 @@ uint32_t OcctKernel::transform(uint32_t id, std::vector<double> matrix) {
     }
 }
 
+uint32_t OcctKernel::located(uint32_t id, std::vector<double> matrix) {
+    try {
+        if (matrix.size() != 12) {
+            throw std::runtime_error("located: matrix must have 12 elements (3x4)");
+        }
+        gp_Trsf trsf;
+        trsf.SetValues(matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5], matrix[6],
+                       matrix[7], matrix[8], matrix[9], matrix[10], matrix[11]);
+        TopLoc_Location loc(trsf);
+        return store(get(id).Moved(loc));
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("located: ") + e.what());
+    }
+}
+
 uint32_t OcctKernel::generalTransform(uint32_t id, std::vector<double> matrix) {
     try {
         if (matrix.size() != 12) {

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -226,6 +226,7 @@ class OcctKernel {
     uint32_t mirror(uint32_t id, double px, double py, double pz, double nx, double ny, double nz);
     uint32_t copy(uint32_t id);
     uint32_t transform(uint32_t id, std::vector<double> matrix);
+    uint32_t located(uint32_t id, std::vector<double> matrix);
     uint32_t generalTransform(uint32_t id, std::vector<double> matrix);
     uint32_t linearPattern(uint32_t id, double dx, double dy, double dz, double spacing, int count);
     uint32_t circularPattern(uint32_t id, double cx, double cy, double cz, double ax, double ay,

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -519,6 +519,54 @@ describe("transforms (extended)", () => {
         mat.delete();
     });
 
+    it("located moves a shape identically to transform (location re-tag, no copy)", () => {
+        // 3x4 row-major translation matrix: translate by (50, 7, -3).
+        const values = [1, 0, 0, 50, 0, 1, 0, 7, 0, 0, 1, -3];
+
+        const box = kernel.makeBox(10, 10, 10);
+        const origVol = kernel.getVolume(box);
+
+        const matA = new Module.VectorDouble();
+        for (const v of values) matA.push_back(v);
+        const viaTransform = kernel.transform(box, matA);
+        matA.delete();
+
+        const matB = new Module.VectorDouble();
+        for (const v of values) matB.push_back(v);
+        const viaLocated = kernel.located(box, matB);
+        matB.delete();
+
+        expect(viaLocated).toBeGreaterThan(0);
+
+        // Volume is preserved and identical to the deep-copy transform.
+        expect(kernel.getVolume(viaLocated)).toBeCloseTo(origVol, 5);
+        expect(kernel.getVolume(viaLocated)).toBeCloseTo(kernel.getVolume(viaTransform), 5);
+
+        // Bounding box matches the transform result exactly — only the cost differs.
+        const bT = kernel.getBoundingBox(viaTransform, true);
+        const bL = kernel.getBoundingBox(viaLocated, true);
+        expect(bL.xmin).toBeCloseTo(bT.xmin, 5);
+        expect(bL.ymin).toBeCloseTo(bT.ymin, 5);
+        expect(bL.zmin).toBeCloseTo(bT.zmin, 5);
+        expect(bL.xmax).toBeCloseTo(bT.xmax, 5);
+        expect(bL.ymax).toBeCloseTo(bT.ymax, 5);
+        expect(bL.zmax).toBeCloseTo(bT.zmax, 5);
+
+        // Absolute placement check against the requested translation.
+        expect(bL.xmin).toBeCloseTo(50, 5);
+        expect(bL.ymin).toBeCloseTo(7, 5);
+        expect(bL.zmin).toBeCloseTo(-3, 5);
+    });
+
+    it("located rejects a malformed matrix", () => {
+        const box = kernel.makeBox(1, 1, 1);
+        const bad = new Module.VectorDouble();
+        bad.push_back(1);
+        bad.push_back(0);
+        expect(() => kernel.located(box, bad)).toThrow();
+        bad.delete();
+    });
+
     it("linearPattern creates copies along a direction", () => {
         const box = kernel.makeBox(5, 5, 5);
         const result = kernel.linearPattern(box, 1, 0, 0, 10, 3);

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -772,6 +772,17 @@ export class OcctKernel {
         });
     }
 
+    /**
+     * Re-tag a shape with a `TopLoc_Location` from a 3x4 row-major affine matrix
+     * (same 12-double layout as {@link transform}). Shares the underlying topology
+     * instead of deep-copying it, so a pure move is O(1).
+     */
+    located(shape: ShapeHandle, matrix: number[]): ShapeHandle {
+        return wrap("located", () => {
+            return this.#withF64(matrix, (vec) => handle(this.#raw.located(shape, vec)));
+        });
+    }
+
     /** Apply a general (possibly non-affine) 3x4 row-major transformation matrix (12 doubles). */
     generalTransform(shape: ShapeHandle, matrix: number[]): ShapeHandle {
         return wrap("generalTransform", () => {

--- a/ts/src/raw-types.ts
+++ b/ts/src/raw-types.ts
@@ -213,6 +213,7 @@ export interface OcctRawKernel {
     mirror(id: number, px: number, py: number, pz: number, nx: number, ny: number, nz: number): number;
     copy(id: number): number;
     transform(id: number, matrix: EmbindVectorF64): number;
+    located(id: number, matrix: EmbindVectorF64): number;
     generalTransform(id: number, matrix: EmbindVectorF64): number;
     linearPattern(id: number, dx: number, dy: number, dz: number, spacing: number, count: number): number;
     circularPattern(id: number, cx: number, cy: number, cz: number, ax: number, ay: number, az: number, angle: number, count: number): number;

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -956,6 +956,25 @@ return store(maker.Shape());",
         return_type: ReturnType::ShapeId,
     },
     MethodSpec {
+        name: "located",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("id"), FacadeParam::VectorDouble("matrix")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+if (matrix.size() != 12) {
+    throw std::runtime_error(\"located: matrix must have 12 elements (3x4)\");
+}
+gp_Trsf trsf;
+trsf.SetValues(matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5], matrix[6],
+               matrix[7], matrix[8], matrix[9], matrix[10], matrix[11]);
+TopLoc_Location loc(trsf);
+return store(get(id).Moved(loc));",
+        includes: &["gp_Trsf.hxx", "TopLoc_Location.hxx"],
+        category: "transforms",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
         name: "generalTransform",
         kind: MethodKind::CustomBody,
         params: &[FacadeParam::ShapeId("id"), FacadeParam::VectorDouble("matrix")],


### PR DESCRIPTION
## Summary

Adds a `located(id, matrix)` kernel method: a cheap, **location-only** rigid move that re-tags a shape's location (`TopoDS_Shape::Moved(TopLoc_Location(trsf))`) instead of deep-copying its topology the way `transform` does. A pure move becomes **O(1)** (shares the underlying `TShape`) rather than O(topology size).

## Why

`transform`/`translate`/`rotate` go through `BRepBuilderAPI_Transform(..., /*copy=*/true)`, which deep-copies all topology. Profiling from the downstream consumer (brepjs) measured this as a **57× cost** on a 200-face solid vs a 1-face box — moving an assembled widget to N placements pays a full B-rep copy each time. A `TopLoc_Location` re-tag is the standard OCCT cheap path and makes a move O(1).

## API

```
located(id: number, matrix: number[]): ShapeHandle
```

- `matrix`: 12-element row-major 3×4 affine `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]` — identical layout to `transform`. Throws `"located: matrix must have 12 elements (3x4)"` otherwise.
- Returns a new arena id for the moved shape, sharing the source's `TShape` (geometry/topology queries identical to `transform`; only the cost differs). Intended for rigid motions; non-rigid input is unsupported.

## Changes

- Codegen `MethodSpec` in `xtask/src/codegen/config.rs` (source of truth), mirroring the `transform` entry → regenerates `facade/generated/{kernel,bindings}.cpp`, `wasi_exports.cpp`, and `crate/src/kernel_generated.rs`.
- Header decl (`occt_kernel.h`), embind binding, TS `raw-types.ts` + `index.ts` wrapper.
- Tests in `test/api-coverage.test.ts`: `located` output matches `transform` (volume + all 6 bounding-box bounds identical) plus a malformed-matrix throw. `transforms` category 15→16.

## Validation

- `cargo xtask codegen` + `cargo fmt` → no drift on tracked generated files.
- `cargo clippy --all-targets`, `cargo fmt --check`, `tsc --noEmit`, `eslint src/` — all clean.

> Note: the WASI `crate/src/occt-wasm.wasm.br` is rebuilt by CI's build-wasi job; if the stale-check flags a byte diff, the fresh artifact will be embedded before merge.

## Downstream

brepjs already feature-detects `located` and falls back to the copying `transform` when absent (andymai/brepjs#1633). Once this ships and brepjs bumps its occt-wasm peer dep, the default-kernel move speedup activates with no further brepjs change.

Closes #187