### PR TITLE
fix(facade): preserve cone surfaces and boolean-cut colors in XCAF STEP export

### DIFF
--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -112,6 +112,7 @@
 #include <ShapeFix_Shape.hxx>
 #include <ShapeFix_Solid.hxx>
 #include <ShapeFix_Wire.hxx>
+#include <ShapeProcess.hxx>
 #include <ShapeUpgrade_UnifySameDomain.hxx>
 #include <Standard_Failure.hxx>
 #include <StlAPI_Reader.hxx>
@@ -2924,6 +2925,16 @@ std::string OcctKernel::exportStep(uint32_t id) {
         const auto& shape = get(id);
         
         STEPControl_Writer writer;
+        // The STEP write actor only fixes non-conformant elementary surfaces (e.g. a
+        // cone whose stored ConicalSurface has a negative semi-angle) when the
+        // DirectFaces shape-processing op runs. That op lives on the shared OCCT "STEP"
+        // controller actor, whose flags any prior XCAF/STEPCAF export silently clears --
+        // after which writer.Transfer() runs no processing and drops conical faces. Set
+        // the flags explicitly so single-shape STEP export is independent of that state.
+        ShapeProcess::OperationsFlags spFlags;
+        spFlags.set(ShapeProcess::Operation::DirectFaces);
+        spFlags.set(ShapeProcess::Operation::SplitCommonVertex);
+        writer.SetShapeProcessFlags(spFlags);
         IFSelect_ReturnStatus status = writer.Transfer(shape, STEPControl_AsIs);
         if (status != IFSelect_RetDone) {
             throw std::runtime_error("exportStep: transfer failed");
@@ -3646,7 +3657,12 @@ int OcctKernel::xcafAddShape(uint32_t docId, uint32_t shapeId) {
         
         Handle(XCAFDoc_ShapeTool) shapeTool =
             XCAFDoc_DocumentTool::ShapeTool(it->second.doc->Main());
-        TDF_Label label = shapeTool->AddShape(get(shapeId));
+        // makeAssembly=false: add the shape as a single part. With the default (true),
+        // a COMPOUND -- e.g. the single-solid compound a boolean cut/fuse returns -- is
+        // auto-decomposed into an assembly, so a color set on this (assembly) label is
+        // never emitted as a STYLED_ITEM for the underlying solid. Treating a root shape
+        // as one part keeps per-label colors attached to its geometry.
+        TDF_Label label = shapeTool->AddShape(get(shapeId), Standard_False);
         
         int facadeId = it->second.nextLabelId++;
         it->second.labelRegistry[facadeId] = label;
@@ -3827,6 +3843,16 @@ std::string OcctKernel::xcafExportSTEP(uint32_t docId) {
         STEPCAFControl_Writer writer;
         writer.SetColorMode(Standard_True);
         writer.SetNameMode(Standard_True);
+        // STEPCAFControl_Writer does not seed the write actor's shape-processing flags,
+        // so non-conformant elementary surfaces (notably cones, whose stored
+        // ConicalSurface carries a negative semi-angle) are never fixed and their
+        // lateral faces are dropped from the output. Enable DirectFaces explicitly to
+        // match the plain exportStep path. (This also re-seeds the shared controller
+        // actor, leaving subsequent exportStep calls in a healthy state.)
+        ShapeProcess::OperationsFlags spFlags;
+        spFlags.set(ShapeProcess::Operation::DirectFaces);
+        spFlags.set(ShapeProcess::Operation::SplitCommonVertex);
+        writer.SetShapeProcessFlags(spFlags);
         
         if (!writer.Transfer(it->second.doc, STEPControl_AsIs)) {
             throw std::runtime_error("xcafExportSTEP: transfer failed");

--- a/test/xcaf.test.ts
+++ b/test/xcaf.test.ts
@@ -211,4 +211,48 @@ describe("XCAF", () => {
         kernel.release(box);
         kernel.xcafClose(docId);
     });
+
+    // Regression: https://github.com/andymai/occt-wasm/issues/194
+    describe("issue #194 — XCAF STEP export parity with plain exportStep", () => {
+        const count = (s: string, re: RegExp) => (s.match(re) ?? []).length;
+
+        it("preserves a cone's CONICAL_SURFACE (matching exportStep)", () => {
+            const docId = kernel.xcafNewDocument();
+            kernel.xcafAddShape(docId, kernel.makeBox(10, 10, 10));
+            kernel.xcafAddShape(docId, kernel.makeCone(8, 0, 24));
+            const step: string = kernel.xcafExportSTEP(docId);
+            expect(count(step, /CONICAL_SURFACE/g)).toBe(1);
+            expect(count(step, /ADVANCED_FACE/g)).toBe(8); // box(6) + cone(2)
+            kernel.xcafClose(docId);
+        });
+
+        it("preserves a cone frustum's CONICAL_SURFACE", () => {
+            const docId = kernel.xcafNewDocument();
+            kernel.xcafAddShape(docId, kernel.makeCone(8, 4, 24));
+            const step: string = kernel.xcafExportSTEP(docId);
+            expect(count(step, /CONICAL_SURFACE/g)).toBe(1);
+            kernel.xcafClose(docId);
+        });
+
+        it("applies a per-label color to a boolean-cut body", () => {
+            const docId = kernel.xcafNewDocument();
+            const cut = kernel.cut(kernel.makeBox(10, 10, 10), kernel.makeCylinder(2, 30));
+            const tag = kernel.xcafAddShape(docId, cut);
+            kernel.xcafSetColor(docId, tag, 0.83, 0.09, 0.13);
+            const step: string = kernel.xcafExportSTEP(docId);
+            expect(count(step, /COLOUR_RGB/g)).toBeGreaterThanOrEqual(1);
+            expect(count(step, /STYLED_ITEM/g)).toBeGreaterThanOrEqual(1);
+            kernel.xcafClose(docId);
+        });
+
+        it("does not corrupt later exportStep calls (no global-state leak)", () => {
+            const conical = () => count(kernel.exportStep(kernel.makeCone(8, 0, 24)), /CONICAL_SURFACE/g);
+            expect(conical()).toBe(1);
+            const docId = kernel.xcafNewDocument();
+            kernel.xcafAddShape(docId, kernel.makeCone(8, 0, 24));
+            kernel.xcafExportSTEP(docId);
+            kernel.xcafClose(docId);
+            expect(conical()).toBe(1); // would be 0 before the fix
+        });
+    });
 });

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -3645,6 +3645,16 @@ return store(reader.OneShape());",
 const auto& shape = get(id);
 
 STEPControl_Writer writer;
+// The STEP write actor only fixes non-conformant elementary surfaces (e.g. a
+// cone whose stored ConicalSurface has a negative semi-angle) when the
+// DirectFaces shape-processing op runs. That op lives on the shared OCCT \"STEP\"
+// controller actor, whose flags any prior XCAF/STEPCAF export silently clears --
+// after which writer.Transfer() runs no processing and drops conical faces. Set
+// the flags explicitly so single-shape STEP export is independent of that state.
+ShapeProcess::OperationsFlags spFlags;
+spFlags.set(ShapeProcess::Operation::DirectFaces);
+spFlags.set(ShapeProcess::Operation::SplitCommonVertex);
+writer.SetShapeProcessFlags(spFlags);
 IFSelect_ReturnStatus status = writer.Transfer(shape, STEPControl_AsIs);
 if (status != IFSelect_RetDone) {
     throw std::runtime_error(\"exportStep: transfer failed\");
@@ -3672,7 +3682,7 @@ fclose(f);
 return result;",
         includes: &[
             "IFSelect_ReturnStatus.hxx", "STEPControl_Writer.hxx",
-            "STEPControl_StepModelType.hxx",
+            "STEPControl_StepModelType.hxx", "ShapeProcess.hxx",
         ],
         category: "io",
         return_type: ReturnType::String,
@@ -4590,7 +4600,12 @@ if (it == xcafDocs_.end())
 
 Handle(XCAFDoc_ShapeTool) shapeTool =
     XCAFDoc_DocumentTool::ShapeTool(it->second.doc->Main());
-TDF_Label label = shapeTool->AddShape(get(shapeId));
+// makeAssembly=false: add the shape as a single part. With the default (true),
+// a COMPOUND -- e.g. the single-solid compound a boolean cut/fuse returns -- is
+// auto-decomposed into an assembly, so a color set on this (assembly) label is
+// never emitted as a STYLED_ITEM for the underlying solid. Treating a root shape
+// as one part keeps per-label colors attached to its geometry.
+TDF_Label label = shapeTool->AddShape(get(shapeId), Standard_False);
 
 int facadeId = it->second.nextLabelId++;
 it->second.labelRegistry[facadeId] = label;
@@ -4843,6 +4858,16 @@ if (it == xcafDocs_.end())
 STEPCAFControl_Writer writer;
 writer.SetColorMode(Standard_True);
 writer.SetNameMode(Standard_True);
+// STEPCAFControl_Writer does not seed the write actor's shape-processing flags,
+// so non-conformant elementary surfaces (notably cones, whose stored
+// ConicalSurface carries a negative semi-angle) are never fixed and their
+// lateral faces are dropped from the output. Enable DirectFaces explicitly to
+// match the plain exportStep path. (This also re-seeds the shared controller
+// actor, leaving subsequent exportStep calls in a healthy state.)
+ShapeProcess::OperationsFlags spFlags;
+spFlags.set(ShapeProcess::Operation::DirectFaces);
+spFlags.set(ShapeProcess::Operation::SplitCommonVertex);
+writer.SetShapeProcessFlags(spFlags);
 
 if (!writer.Transfer(it->second.doc, STEPControl_AsIs)) {
     throw std::runtime_error(\"xcafExportSTEP: transfer failed\");
@@ -4860,7 +4885,7 @@ std::remove(tmpPath.c_str());
 return content;",
         includes: &[
             "STEPCAFControl_Writer.hxx", "STEPControl_StepModelType.hxx",
-            "Standard_Failure.hxx",
+            "Standard_Failure.hxx", "ShapeProcess.hxx",
         ],
         category: "xcaf",
         return_type: ReturnType::String,


### PR DESCRIPTION
Fixes #194.

## Summary

The XCAF STEP export path (`xcafExportSTEP` / `XCAFDocument.exportSTEP()`) silently dropped geometry/style that the plain `exportStep` path preserved:

1. a cone's lateral `CONICAL_SURFACE` collapsed to its base plane, and
2. a per-label color was not applied to a boolean-`cut` body.

Investigation showed these are **two distinct root causes** — and bug 1 is systemic (it leaks beyond XCAF).

## Root cause 1 — cone faces (systemic global-state leak)

OCCT's STEP write actor only makes non-conformant elementary surfaces conformant when the **`DirectFaces`** shape-processing operation runs. A primitive cone's stored `Geom_ConicalSurface` carries a **negative semi-angle** (`-0.32` for `makeCone(8,0,24)`), so `GeomToStep_MakeConicalSurface` throws *"Conicalsurface not STEP conformant"* and the face is silently skipped — unless `DirectFaces` flips it to conformant first.

`STEPCAFControl_Writer` never seeds those flags. Worse, the flags live on the **process-global `"STEP"` controller actor** (a shared singleton). A single XCAF export clears them, so every later plain `exportStep` in the same kernel instance *also* starts dropping cone faces:

```
exportStep(cone)            -> CONICAL 1   (ok)
xcafExportSTEP(cone)        -> CONICAL 0   (bug)
exportStep(cone)            -> CONICAL 0   (now poisoned!)
```

**Fix:** set `DirectFaces` + `SplitCommonVertex` explicitly on both writers (matching what OCCT's own DE provider does via the private `InitializeMissingParameters`), so STEP export no longer depends on shared global state.

## Root cause 2 — boolean-cut colors

`cut()`/`fuse()` return a single-solid `COMPOUND`. With `AddShape`'s default `makeAssembly=true`, XCAF decomposes it into an assembly, so a color set on the (assembly) root label is never emitted as a `STYLED_ITEM` for the underlying solid (`NEXT_ASSEMBLY_USAGE_OCCURRENCE` appears instead). **Fix:** add root shapes with `makeAssembly=false` so they stay one colored part.

## Changes
- `xtask/src/codegen/config.rs` — the fix (source of truth) for `exportStep`, `xcafExportSTEP`, `xcafAddShape`; `facade/generated/kernel.cpp` regenerated.
- `crate/src/occt-wasm.wasm.br` — regenerated standalone WASI binary.
- `test/xcaf.test.ts` — regressions: cone (apex + frustum) surface preserved, cut-body color emitted, and a no-global-leak invariant.

## Verification
- Repro from the issue now matches `exportStep`: `XCAF box+cone -> CONICAL 1 FACE 8`; cut box -> `COLOUR_RGB 1 STYLED_ITEM 1`.
- Cylinder/sphere/torus unaffected (were always fine); confirms the fix is targeted.
- Full vitest suite: 333 passed / 2 skipped. Crate tests pass against the regenerated binary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes XCAF STEP export dropping cone lateral surfaces and losing colors on boolean-cut bodies, matching `exportStep` and resolving #194. Also removes a global-state dependency that could break later STEP exports.

- **Bug Fixes**
  - Set shape-processing flags (`DirectFaces`, `SplitCommonVertex`) on `exportStep` and `xcafExportSTEP` so `CONICAL_SURFACE` faces are preserved and exports don’t depend on shared state.
  - Add root shapes with `makeAssembly=false` in `xcafAddShape` so colors on `cut`/`fuse` results emit as `STYLED_ITEM`.
  - Add regression tests for cones, frustums, colors, and no cross-call leaks; re-embed the CI-built `crate/src/occt-wasm.wasm.br`.

<sup>Written for commit 0c1a505a4403984675db34c8c441759894746d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

