### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What

Bumps the transitive `crossbeam-epoch` lockfile entry from 0.9.18 → 0.9.20.

## Why

The **OSV Scan (blocking)** check on `main` is red because `crossbeam-epoch 0.9.18` is flagged by [RUSTSEC-2026-0204](https://osv.dev/RUSTSEC-2026-0204), and the scanner runs with `fail-on-vuln: true`.

Dependency path: `wasmtime → rayon → rayon-core → crossbeam-deque → crossbeam-epoch`. No manifest change needed — a targeted `cargo update -p crossbeam-epoch --precise 0.9.20` resolves it. `cargo check -p occt-wasm` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps transitive `crossbeam-epoch` from 0.9.18 to 0.9.20 to resolve `RUSTSEC-2026-0204` and unblock the OSV Scan gate.
Lockfile-only update via `cargo update -p crossbeam-epoch --precise 0.9.20`; no manifest changes.

<sup>Written for commit 418e2cf27efa6e6e663c9e571c8757cc4c780e72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

