### PR TITLE
feat(facade): arena memory-management primitives (#205, #206, #207)

### DIFF
--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -103,6 +103,8 @@ pub(crate) struct GeneratedFuncs {
     fn_bspline_surface: TypedFunc<(i32, i32, i32, i32), u32>,
     fn_get_shape_type: TypedFunc<(u32,), i32>,
     fn_get_sub_shapes: TypedFunc<(u32, i32, i32), i32>,
+    fn_sub_shape_count: TypedFunc<(u32, i32, i32), i32>,
+    fn_sub_shape_hashes: TypedFunc<(u32, i32, i32, i32), i32>,
     fn_distance_between: TypedFunc<(u32, u32), f64>,
     fn_is_same: TypedFunc<(u32, u32), i32>,
     fn_is_equal: TypedFunc<(u32, u32), i32>,
@@ -201,6 +203,8 @@ pub(crate) struct GeneratedFuncs {
     fn_project_edges: TypedFunc<(u32, f64, f64, f64, f64, f64, f64, f64, f64, f64, i32), i32>,
     fn_release: TypedFunc<(u32,), i32>,
     fn_release_all: TypedFunc<(), i32>,
+    fn_checkpoint: TypedFunc<(), u32>,
+    fn_release_since: TypedFunc<(u32,), i32>,
     fn_get_shape_count: TypedFunc<(), u32>,
     fn_make_null_shape: TypedFunc<(), u32>,
     fn_xcaf_new_document: TypedFunc<(), u32>,
@@ -310,6 +314,8 @@ impl GeneratedFuncs {
             fn_bspline_surface: instance.get_typed_func(&mut store, "occt_bspline_surface")?,
             fn_get_shape_type: instance.get_typed_func(&mut store, "occt_get_shape_type")?,
             fn_get_sub_shapes: instance.get_typed_func(&mut store, "occt_get_sub_shapes")?,
+            fn_sub_shape_count: instance.get_typed_func(&mut store, "occt_sub_shape_count")?,
+            fn_sub_shape_hashes: instance.get_typed_func(&mut store, "occt_sub_shape_hashes")?,
             fn_distance_between: instance.get_typed_func(&mut store, "occt_distance_between")?,
             fn_is_same: instance.get_typed_func(&mut store, "occt_is_same")?,
             fn_is_equal: instance.get_typed_func(&mut store, "occt_is_equal")?,
@@ -437,6 +443,8 @@ impl GeneratedFuncs {
             fn_project_edges: instance.get_typed_func(&mut store, "occt_project_edges")?,
             fn_release: instance.get_typed_func(&mut store, "occt_release")?,
             fn_release_all: instance.get_typed_func(&mut store, "occt_release_all")?,
+            fn_checkpoint: instance.get_typed_func(&mut store, "occt_checkpoint")?,
+            fn_release_since: instance.get_typed_func(&mut store, "occt_release_since")?,
             fn_get_shape_count: instance.get_typed_func(&mut store, "occt_get_shape_count")?,
             fn_make_null_shape: instance.get_typed_func(&mut store, "occt_make_null_shape")?,
             fn_xcaf_new_document: instance.get_typed_func(&mut store, "occt_xcaf_new_document")?,
@@ -2059,6 +2067,44 @@ impl crate::kernel::OcctKernel {
             return Err(self.read_last_error("get_sub_shapes"));
         }
         self.read_vec_u32_result()
+    }
+
+    pub fn sub_shape_count(&mut self, id: ShapeHandle, shape_type: &str) -> OcctResult<i32> {
+        let shape_type_ptr = self.write_bytes(shape_type.as_bytes())?;
+        let shape_type_len = shape_type.len() as u32;
+        let result = self.generated.fn_sub_shape_count.call(
+            &mut self.store,
+            (id.0, shape_type_ptr as i32, shape_type_len as i32),
+        );
+        self.free_bytes(shape_type_ptr)?;
+        let result = result?;
+        self.check_error("sub_shape_count")?;
+        Ok(result)
+    }
+
+    pub fn sub_shape_hashes(
+        &mut self,
+        id: ShapeHandle,
+        shape_type: &str,
+        hash_upper_bound: i32,
+    ) -> OcctResult<Vec<i32>> {
+        let shape_type_ptr = self.write_bytes(shape_type.as_bytes())?;
+        let shape_type_len = shape_type.len() as u32;
+        let len = self.generated.fn_sub_shape_hashes.call(
+            &mut self.store,
+            (
+                id.0,
+                shape_type_ptr as i32,
+                shape_type_len as i32,
+                hash_upper_bound,
+            ),
+        );
+        self.free_bytes(shape_type_ptr)?;
+        let len = len?;
+        if len < 0 {
+            return Err(self.read_last_error("sub_shape_hashes"));
+        }
+        self.read_vec_i32_result()
     }
 
     pub fn distance_between(&mut self, a: ShapeHandle, b: ShapeHandle) -> OcctResult<f64> {
@@ -3768,6 +3814,23 @@ impl crate::kernel::OcctKernel {
         let result = self.generated.fn_release_all.call(&mut self.store, ())?;
         if result < 0 {
             return Err(self.read_last_error("release_all"));
+        }
+        Ok(())
+    }
+
+    pub fn checkpoint(&mut self) -> OcctResult<u32> {
+        let result = self.generated.fn_checkpoint.call(&mut self.store, ())?;
+        self.check_error("checkpoint")?;
+        Ok(result)
+    }
+
+    pub fn release_since(&mut self, mark: u32) -> OcctResult<()> {
+        let result = self
+            .generated
+            .fn_release_since
+            .call(&mut self.store, (mark,))?;
+        if result < 0 {
+            return Err(self.read_last_error("release_since"));
         }
         Ok(())
     }

--- a/crate/tests/integration.rs
+++ b/crate/tests/integration.rs
@@ -202,6 +202,32 @@ fn get_sub_shapes() {
 }
 
 #[test]
+fn sub_shape_count_and_hashes() {
+    let Some(mut kernel) = try_kernel() else {
+        return;
+    };
+    let shape = kernel.make_box(10.0, 10.0, 10.0).unwrap();
+    assert_eq!(kernel.sub_shape_count(shape, "face").unwrap(), 6);
+    let hashes = kernel.sub_shape_hashes(shape, "face", 1_000_000).unwrap();
+    assert_eq!(hashes.len(), 6, "one hash per face, no handles allocated");
+}
+
+#[test]
+fn checkpoint_release_since() {
+    let Some(mut kernel) = try_kernel() else {
+        return;
+    };
+    let _keep = kernel.make_box(1.0, 1.0, 1.0).unwrap();
+    let mark = kernel.checkpoint().unwrap();
+    let _a = kernel.make_box(2.0, 2.0, 2.0).unwrap();
+    let _b = kernel.make_box(3.0, 3.0, 3.0).unwrap();
+    assert_eq!(kernel.get_shape_count().unwrap(), 3);
+    kernel.release_since(mark).unwrap();
+    // Only the pre-checkpoint handle survives.
+    assert_eq!(kernel.get_shape_count().unwrap(), 1);
+}
+
+#[test]
 fn extrude_rectangle() {
     let Some(mut kernel) = try_kernel() else {
         return;

--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -193,6 +193,8 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         // topology
         .function("getShapeType", &OcctKernel::getShapeType)
         .function("getSubShapes", &OcctKernel::getSubShapes)
+        .function("subShapeCount", &OcctKernel::subShapeCount)
+        .function("subShapeHashes", &OcctKernel::subShapeHashes)
         .function("distanceBetween", &OcctKernel::distanceBetween)
         .function("isSame", &OcctKernel::isSame)
         .function("isEqual", &OcctKernel::isEqual)
@@ -307,6 +309,8 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         // kernel
         .function("release", &OcctKernel::release)
         .function("releaseAll", &OcctKernel::releaseAll)
+        .function("checkpoint", &OcctKernel::checkpoint)
+        .function("releaseSince", &OcctKernel::releaseSince)
         .function("getShapeCount", &OcctKernel::getShapeCount)
         .function("makeNullShape", &OcctKernel::makeNullShape)
 

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -1701,6 +1701,54 @@ std::vector<uint32_t> OcctKernel::getSubShapes(uint32_t id, const std::string& s
     }
 }
 
+int OcctKernel::subShapeCount(uint32_t id, const std::string& shapeType) {
+    try {
+        auto parseType = [](const std::string& t) -> TopAbs_ShapeEnum {
+            if (t == "vertex") return TopAbs_VERTEX;
+            if (t == "edge") return TopAbs_EDGE;
+            if (t == "wire") return TopAbs_WIRE;
+            if (t == "face") return TopAbs_FACE;
+            if (t == "shell") return TopAbs_SHELL;
+            if (t == "solid") return TopAbs_SOLID;
+            if (t == "compsolid") return TopAbs_COMPSOLID;
+            if (t == "compound") return TopAbs_COMPOUND;
+            throw std::runtime_error("Unknown shape type: " + t);
+        };
+        NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> map;
+        TopExp::MapShapes(get(id), parseType(shapeType), map);
+        return map.Extent();
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("subShapeCount: ") + e.what());
+    }
+}
+
+std::vector<int> OcctKernel::subShapeHashes(uint32_t id, const std::string& shapeType, int hashUpperBound) {
+    try {
+        auto parseType = [](const std::string& t) -> TopAbs_ShapeEnum {
+            if (t == "vertex") return TopAbs_VERTEX;
+            if (t == "edge") return TopAbs_EDGE;
+            if (t == "wire") return TopAbs_WIRE;
+            if (t == "face") return TopAbs_FACE;
+            if (t == "shell") return TopAbs_SHELL;
+            if (t == "solid") return TopAbs_SOLID;
+            if (t == "compsolid") return TopAbs_COMPSOLID;
+            if (t == "compound") return TopAbs_COMPOUND;
+            throw std::runtime_error("Unknown shape type: " + t);
+        };
+        NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> map;
+        TopExp::MapShapes(get(id), parseType(shapeType), map);
+        std::vector<int> result;
+        result.reserve(map.Extent());
+        for (int i = 1; i <= map.Extent(); i++) {
+            result.push_back(static_cast<int>(TopTools_ShapeMapHasher{}(map.FindKey(i)) %
+                                              static_cast<size_t>(hashUpperBound)));
+        }
+        return result;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("subShapeHashes: ") + e.what());
+    }
+}
+
 double OcctKernel::distanceBetween(uint32_t a, uint32_t b) {
     try {
         BRepExtrema_DistShapeShape dist(get(a), get(b));
@@ -1825,7 +1873,10 @@ uint32_t OcctKernel::downcast(uint32_t id, const std::string& targetType) {
         if (shape.ShapeType() != target) {
             throw std::runtime_error("downcast: shape type mismatch");
         }
-        return store(shape);
+        // The shape is already the requested type, so the cast is a pure identity.
+        // Return the existing id instead of storing a duplicate handle, sparing
+        // callers the post-downcast release() bookkeeping (see issue #205).
+        return id;
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("downcast: ") + e.what());
     }
@@ -3597,6 +3648,28 @@ void OcctKernel::releaseAll() {
         nextId_ = 1;
     } catch (const Standard_Failure& e) {
         throw std::runtime_error(std::string("releaseAll: ") + e.what());
+    }
+}
+
+uint32_t OcctKernel::checkpoint() {
+    try {
+        return nextId_;
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("checkpoint: ") + e.what());
+    }
+}
+
+void OcctKernel::releaseSince(uint32_t mark) {
+    try {
+        for (auto it = arena_.begin(); it != arena_.end();) {
+            if (it->first >= mark) {
+                it = arena_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("releaseSince: ") + e.what());
     }
 }
 

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -130,6 +130,8 @@ class OcctKernel {
     void release(uint32_t id);
     void releaseAll();
     uint32_t getShapeCount();
+    uint32_t checkpoint();
+    void releaseSince(uint32_t mark);
 
     // --- Primitives ---
     uint32_t makeBox(double dx, double dy, double dz);
@@ -248,6 +250,8 @@ class OcctKernel {
     // --- Topology query ---
     std::string getShapeType(uint32_t id);
     std::vector<uint32_t> getSubShapes(uint32_t id, const std::string& shapeType);
+    int subShapeCount(uint32_t id, const std::string& shapeType);
+    std::vector<int> subShapeHashes(uint32_t id, const std::string& shapeType, int hashUpperBound);
     uint32_t downcast(uint32_t id, const std::string& targetType);
     double distanceBetween(uint32_t a, uint32_t b);
     bool isSame(uint32_t a, uint32_t b);

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -703,6 +703,67 @@ describe("topology query (extended)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Arena memory management (issues #205 / #206 / #207)
+// ---------------------------------------------------------------------------
+
+describe("arena memory management", () => {
+    it("downcast is identity for an already-correct-type shape (no new arena slot)", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const faces = kernel.getSubShapes(box, "face");
+        const faceId = faces.get(0);
+        const before = kernel.getShapeCount();
+        const result = kernel.downcast(faceId, "face");
+        expect(result).toBe(faceId); // same handle, not a freshly counted id
+        expect(kernel.getShapeCount()).toBe(before); // no arena churn
+        faces.delete();
+    });
+
+    it("subShapeCount matches getSubShapes length without allocating handles", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const before = kernel.getShapeCount();
+        expect(kernel.subShapeCount(box, "face")).toBe(6);
+        expect(kernel.subShapeCount(box, "edge")).toBe(12);
+        expect(kernel.subShapeCount(box, "vertex")).toBe(8);
+        expect(kernel.getShapeCount()).toBe(before);
+    });
+
+    it("subShapeHashes returns one hash per sub-shape without allocating handles", () => {
+        const box = kernel.makeBox(10, 10, 10);
+        const before = kernel.getShapeCount();
+        const hashes = kernel.subShapeHashes(box, "face", 1_000_000);
+        expect(hashes.size()).toBe(6);
+        for (let i = 0; i < hashes.size(); i++) {
+            expect(hashes.get(i)).toBeGreaterThanOrEqual(0);
+            expect(hashes.get(i)).toBeLessThan(1_000_000);
+        }
+        expect(kernel.getShapeCount()).toBe(before);
+        hashes.delete();
+    });
+
+    it("checkpoint + releaseSince bulk-frees only ids allocated after the mark", () => {
+        const keep = kernel.makeBox(1, 1, 1);
+        const mark = kernel.checkpoint();
+        kernel.makeBox(2, 2, 2);
+        const orphan = kernel.makeBox(3, 3, 3);
+        const before = kernel.getShapeCount();
+        expect(before).toBe(3);
+
+        kernel.releaseSince(mark);
+
+        expect(kernel.getShapeCount()).toBe(1); // only `keep` survives
+        expect(kernel.getShapeType(keep)).toBe("solid");
+        expect(() => kernel.getShapeType(orphan)).toThrow();
+    });
+
+    it("releaseSince(checkpoint()) with no intervening allocations is a no-op", () => {
+        kernel.makeBox(1, 1, 1);
+        const before = kernel.getShapeCount();
+        kernel.releaseSince(kernel.checkpoint());
+        expect(kernel.getShapeCount()).toBe(before);
+    });
+});
+
+// ---------------------------------------------------------------------------
 // Tessellation (extended)
 // ---------------------------------------------------------------------------
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -966,6 +966,22 @@ export class OcctKernel {
         return wrap("getSubShapes", () => this.#vecToHandles(this.#raw.getSubShapes(shape, type)));
     }
 
+    /** Count sub-shapes of a type without materialising a handle per sub-shape. */
+    subShapeCount(shape: ShapeHandle, type: "vertex" | "edge" | "wire" | "face" | "shell" | "solid"): number {
+        return wrap("subShapeCount", () => this.#raw.subShapeCount(shape, type));
+    }
+
+    /**
+     * Deduplicated hashes of a shape's sub-shapes, with no per-sub-shape handle
+     * allocation. Use for hash-only paths (face-hash collection, tagging) that
+     * would otherwise iterate {@link getSubShapes} handles just to release them.
+     */
+    subShapeHashes(shape: ShapeHandle, type: "vertex" | "edge" | "wire" | "face" | "shell" | "solid", hashUpperBound: number): number[] {
+        return wrap("subShapeHashes", () =>
+            this.#drainVector(this.#raw.subShapeHashes(shape, type, hashUpperBound), Int32Array),
+        );
+    }
+
     downcast(shape: ShapeHandle, targetType: "vertex" | "edge" | "wire" | "face" | "shell" | "solid"): ShapeHandle {
         return wrap("downcast", () => handle(this.#raw.downcast(shape, targetType)));
     }
@@ -1838,6 +1854,26 @@ export class OcctKernel {
 
     releaseAll(): void {
         this.#raw.releaseAll();
+    }
+
+    /**
+     * Mark the current arena high-water point. Every handle produced after this
+     * call can be reclaimed in one step with {@link releaseSince}. Pair the two
+     * around a logical operation to bulk-free intermediates instead of tracking
+     * each id for individual {@link release}.
+     */
+    checkpoint(): number {
+        return this.#raw.checkpoint();
+    }
+
+    /**
+     * Release every handle allocated at or after `mark` (a value from a prior
+     * {@link checkpoint}). Handles the caller wants to keep must be produced
+     * before the checkpoint, or copied out; ids created after the mark become
+     * invalid once this returns.
+     */
+    releaseSince(mark: number): void {
+        this.#raw.releaseSince(mark);
     }
 
     get shapeCount(): number {

--- a/ts/src/raw-types.ts
+++ b/ts/src/raw-types.ts
@@ -135,6 +135,8 @@ export interface OcctRawKernel {
     release(id: number): void;
     releaseAll(): void;
     getShapeCount(): number;
+    checkpoint(): number;
+    releaseSince(mark: number): void;
 
     // Primitives
     makeBox(dx: number, dy: number, dz: number): number;
@@ -232,6 +234,8 @@ export interface OcctRawKernel {
     // Topology
     getShapeType(id: number): string;
     getSubShapes(id: number, shapeType: string): EmbindVectorU32;
+    subShapeCount(id: number, shapeType: string): number;
+    subShapeHashes(id: number, shapeType: string, hashUpperBound: number): EmbindVectorI32;
     downcast(id: number, targetType: string): number;
     distanceBetween(a: number, b: number): number;
     isSame(a: number, b: number): boolean;

--- a/ts/src/worker.ts
+++ b/ts/src/worker.ts
@@ -97,6 +97,8 @@ export interface OcctWorkerProxy {
     isVertex(shape: ShapeHandle): Promise<boolean>;
     isShell(shape: ShapeHandle): Promise<boolean>;
     getSubShapes(shape: ShapeHandle, type: "vertex" | "edge" | "wire" | "face" | "shell" | "solid"): Promise<ShapeHandle[]>;
+    subShapeCount(shape: ShapeHandle, type: "vertex" | "edge" | "wire" | "face" | "shell" | "solid"): Promise<number>;
+    subShapeHashes(shape: ShapeHandle, type: "vertex" | "edge" | "wire" | "face" | "shell" | "solid", hashUpperBound: number): Promise<number[]>;
     distanceBetween(a: ShapeHandle, b: ShapeHandle): Promise<number>;
     isSame(a: ShapeHandle, b: ShapeHandle): Promise<boolean>;
     isNull(shape: ShapeHandle): Promise<boolean>;
@@ -163,6 +165,8 @@ export interface OcctWorkerProxy {
     // Memory
     release(shape: ShapeHandle): Promise<void>;
     releaseAll(): Promise<void>;
+    checkpoint(): Promise<number>;
+    releaseSince(mark: number): Promise<void>;
     readonly shapeCount: Promise<number>;
 
     // Debugging

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -1913,6 +1913,74 @@ return result;",
         return_type: ReturnType::VectorUint32,
     },
     MethodSpec {
+        name: "subShapeCount",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("id"), FacadeParam::String("shapeType")],
+        occt_class: "",
+        ctor_args: "",
+        setup_code: "\
+auto parseType = [](const std::string& t) -> TopAbs_ShapeEnum {
+    if (t == \"vertex\") return TopAbs_VERTEX;
+    if (t == \"edge\") return TopAbs_EDGE;
+    if (t == \"wire\") return TopAbs_WIRE;
+    if (t == \"face\") return TopAbs_FACE;
+    if (t == \"shell\") return TopAbs_SHELL;
+    if (t == \"solid\") return TopAbs_SOLID;
+    if (t == \"compsolid\") return TopAbs_COMPSOLID;
+    if (t == \"compound\") return TopAbs_COMPOUND;
+    throw std::runtime_error(\"Unknown shape type: \" + t);
+};
+NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> map;
+TopExp::MapShapes(get(id), parseType(shapeType), map);
+return map.Extent();",
+        includes: &[
+            "TopAbs_ShapeEnum.hxx", "TopExp.hxx",
+            "NCollection_IndexedMap.hxx", "TopTools_ShapeMapHasher.hxx",
+        ],
+        category: "topology",
+        return_type: ReturnType::Int,
+    },
+    MethodSpec {
+        name: "subShapeHashes",
+        kind: MethodKind::CustomBody,
+        params: &[
+            FacadeParam::ShapeId("id"),
+            FacadeParam::String("shapeType"),
+            FacadeParam::Int("hashUpperBound"),
+        ],
+        occt_class: "",
+        ctor_args: "",
+        // Deduplicated sub-shape hashes with no per-sub-shape arena handle,
+        // mirroring edgeToFaceMap's handle-free hash reporting (see issue #206).
+        setup_code: "\
+auto parseType = [](const std::string& t) -> TopAbs_ShapeEnum {
+    if (t == \"vertex\") return TopAbs_VERTEX;
+    if (t == \"edge\") return TopAbs_EDGE;
+    if (t == \"wire\") return TopAbs_WIRE;
+    if (t == \"face\") return TopAbs_FACE;
+    if (t == \"shell\") return TopAbs_SHELL;
+    if (t == \"solid\") return TopAbs_SOLID;
+    if (t == \"compsolid\") return TopAbs_COMPSOLID;
+    if (t == \"compound\") return TopAbs_COMPOUND;
+    throw std::runtime_error(\"Unknown shape type: \" + t);
+};
+NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> map;
+TopExp::MapShapes(get(id), parseType(shapeType), map);
+std::vector<int> result;
+result.reserve(map.Extent());
+for (int i = 1; i <= map.Extent(); i++) {
+    result.push_back(static_cast<int>(TopTools_ShapeMapHasher{}(map.FindKey(i)) %
+                                      static_cast<size_t>(hashUpperBound)));
+}
+return result;",
+        includes: &[
+            "TopAbs_ShapeEnum.hxx", "TopExp.hxx",
+            "NCollection_IndexedMap.hxx", "TopTools_ShapeMapHasher.hxx",
+        ],
+        category: "topology",
+        return_type: ReturnType::VectorInt,
+    },
+    MethodSpec {
         name: "distanceBetween",
         kind: MethodKind::CustomBody,
         params: &[FacadeParam::ShapeId("a"), FacadeParam::ShapeId("b")],
@@ -2069,7 +2137,10 @@ TopAbs_ShapeEnum target = parseType(targetType);
 if (shape.ShapeType() != target) {
     throw std::runtime_error(\"downcast: shape type mismatch\");
 }
-return store(shape);",
+// The shape is already the requested type, so the cast is a pure identity.
+// Return the existing id instead of storing a duplicate handle, sparing
+// callers the post-downcast release() bookkeeping (see issue #205).
+return id;",
         includes: &["TopAbs_ShapeEnum.hxx", "TopoDS.hxx"],
         category: "topology",
         return_type: ReturnType::ShapeId,
@@ -4515,6 +4586,41 @@ return result;",
         setup_code: "\
 arena_.clear();
 nextId_ = 1;",
+        includes: &[],
+        category: "kernel",
+        return_type: ReturnType::Void,
+    },
+    MethodSpec {
+        name: "checkpoint",
+        kind: MethodKind::CustomBody,
+        params: &[],
+        occt_class: "",
+        ctor_args: "",
+        // The next id to be handed out is the high-water mark: every id
+        // allocated after this call is >= the returned value.
+        setup_code: "return nextId_;",
+        includes: &[],
+        category: "kernel",
+        return_type: ReturnType::Uint32,
+    },
+    MethodSpec {
+        name: "releaseSince",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::Uint32("mark")],
+        occt_class: "",
+        ctor_args: "",
+        // Release every id allocated at or after `mark` (a value from a prior
+        // checkpoint()). nextId_ is left untouched so subsequent allocations
+        // keep climbing -- reusing freed ids would alias live handles a caller
+        // promoted past the mark.
+        setup_code: "\
+for (auto it = arena_.begin(); it != arena_.end();) {
+    if (it->first >= mark) {
+        it = arena_.erase(it);
+    } else {
+        ++it;
+    }
+}",
         includes: &[],
         category: "kernel",
         return_type: ReturnType::Void,

--- a/xtask/src/codegen/emitter.rs
+++ b/xtask/src/codegen/emitter.rs
@@ -11,7 +11,7 @@ use super::types::{FacadeParam, MethodKind, MethodSpec, ReturnType};
 /// Format a [`FacadeParam`] as a C++ formal parameter declaration.
 fn param_to_cpp(param: &FacadeParam) -> String {
     match param {
-        FacadeParam::ShapeId(name) => format!("uint32_t {name}"),
+        FacadeParam::ShapeId(name) | FacadeParam::Uint32(name) => format!("uint32_t {name}"),
         FacadeParam::Double(name) => format!("double {name}"),
         FacadeParam::VectorShapeIds(name) => format!("std::vector<uint32_t> {name}"),
         FacadeParam::Bool(name) => format!("bool {name}"),

--- a/xtask/src/codegen/rust_emitter.rs
+++ b/xtask/src/codegen/rust_emitter.rs
@@ -16,6 +16,7 @@ fn param_to_rust(param: &FacadeParam) -> String {
         FacadeParam::Double(name) => format!("{}: f64", rust_param_name(name)),
         FacadeParam::Bool(name) => format!("{}: bool", rust_param_name(name)),
         FacadeParam::Int(name) => format!("{}: i32", rust_param_name(name)),
+        FacadeParam::Uint32(name) => format!("{}: u32", rust_param_name(name)),
         FacadeParam::String(name) => format!("{}: &str", rust_param_name(name)),
         FacadeParam::VectorShapeIds(name) => format!("{}: &[ShapeHandle]", rust_param_name(name)),
         FacadeParam::VectorDouble(name) => format!("{}: &[f64]", rust_param_name(name)),
@@ -188,7 +189,7 @@ fn emit_wasm_call_args(params: &[FacadeParam]) -> String {
         .iter()
         .flat_map(|p| match p {
             FacadeParam::ShapeId(name) => vec![format!("{}.0", rust_param_name(name))],
-            FacadeParam::Double(name) | FacadeParam::Int(name) => {
+            FacadeParam::Double(name) | FacadeParam::Int(name) | FacadeParam::Uint32(name) => {
                 vec![rust_param_name(name)]
             }
             FacadeParam::Bool(name) => vec![format!("i32::from({})", rust_param_name(name))],
@@ -243,7 +244,7 @@ fn wasm_typed_func_type(spec: &MethodSpec) -> String {
         .params
         .iter()
         .flat_map(|p| match p {
-            FacadeParam::ShapeId(_) => vec!["u32"],
+            FacadeParam::ShapeId(_) | FacadeParam::Uint32(_) => vec!["u32"],
             FacadeParam::Double(_) => vec!["f64"],
             FacadeParam::Bool(_) | FacadeParam::Int(_) => vec!["i32"],
             FacadeParam::String(_)

--- a/xtask/src/codegen/types.rs
+++ b/xtask/src/codegen/types.rs
@@ -58,6 +58,9 @@ pub enum FacadeParam {
     /// `int` integer.
     Int(&'static str),
 
+    /// `uint32_t` non-shape-ID integer (e.g. an arena high-water mark).
+    Uint32(&'static str),
+
     /// `std::string` value.
     String(&'static str),
 
@@ -77,6 +80,7 @@ impl FacadeParam {
             | Self::VectorShapeIds(n)
             | Self::Bool(n)
             | Self::Int(n)
+            | Self::Uint32(n)
             | Self::String(n)
             | Self::VectorDouble(n)
             | Self::VectorInt(n) => n,

--- a/xtask/src/codegen/wasi_emitter.rs
+++ b/xtask/src/codegen/wasi_emitter.rs
@@ -44,7 +44,7 @@ pub fn camel_to_snake(s: &str) -> String {
 /// String and vector types expand to pointer+length pairs.
 fn param_to_c_abi(param: &FacadeParam) -> String {
     match param {
-        FacadeParam::ShapeId(name) => format!("uint32_t {name}"),
+        FacadeParam::ShapeId(name) | FacadeParam::Uint32(name) => format!("uint32_t {name}"),
         FacadeParam::Double(name) => format!("double {name}"),
         FacadeParam::Bool(name) | FacadeParam::Int(name) => format!("int32_t {name}"),
         FacadeParam::String(name) => format!("const char* {name}_ptr, uint32_t {name}_len"),
@@ -73,9 +73,10 @@ fn c_abi_param_list(params: &[FacadeParam]) -> String {
 /// String/vector types are reconstructed from ptr+len pairs.
 fn param_to_call_arg(param: &FacadeParam) -> String {
     match param {
-        FacadeParam::ShapeId(name) | FacadeParam::Double(name) | FacadeParam::Int(name) => {
-            (*name).to_owned()
-        }
+        FacadeParam::ShapeId(name)
+        | FacadeParam::Double(name)
+        | FacadeParam::Int(name)
+        | FacadeParam::Uint32(name) => (*name).to_owned(),
         FacadeParam::Bool(name) => format!("({name} != 0)"),
         FacadeParam::String(name) => format!("std::string({name}_ptr, {name}_len)"),
         FacadeParam::VectorShapeIds(name) => {


### PR DESCRIPTION
Adds the three arena memory-management APIs filed in #205, #206, and #207. Together they let downstream consumers (e.g. brepjs) drop the per-operation handle bookkeeping that currently exists purely to keep the arena from growing.

## #205 — `downcast` is now identity for an already-correct-type shape
The facade's `downcast` only ever succeeded when the shape was already `targetType` (it throws otherwise), so the sole side effect of the old `store(shape)` was burning an arena slot. It now returns the input `id` unchanged — allocation-free in the overwhelmingly common already-correct-type case.

**Migration note:** callers that previously `release()`d the pre-downcast source must stop doing so, or they'll double-free (the source id now equals the returned id).

## #206 — handle-free sub-shape queries
- `subShapeCount(shape, type) -> number`
- `subShapeHashes(shape, type, hashUpperBound) -> number[]`

Both return counts/deduplicated hashes without materialising one arena handle per sub-shape, following the existing `edgeToFaceMap` hash-only precedent. Removes per-sub-shape arena churn on hot hash-collection / tagging paths.

## #207 — `checkpoint` / `releaseSince` arena scope
- `checkpoint() -> number` returns the current high-water mark.
- `releaseSince(mark)` releases every id allocated at or after `mark`.

`nextId_` is left climbing after a `releaseSince`, so reused ids can never alias a handle the caller promoted past the mark. Handles to keep must be produced before the checkpoint (or copied out).

## Implementation
`releaseSince` needed a non-shape-ID `u32` parameter, so this adds a `Uint32` `FacadeParam` variant threaded through all four emitters (C++ facade, Embind bindings, WASI C-ABI, Rust host) — symmetric with the existing `ReturnType::Uint32`. Regenerated the committed facade files (`kernel.cpp`, `bindings.cpp`, `kernel_generated.rs`) and re-embedded a freshly-built `crate/src/occt-wasm.wasm.br`.

## Testing
Verified locally against real builds (emsdk 5.0.3 + prebuilt OCCT libs):
- **npm/Embind:** full vitest suite — 338 passed, incl. 5 new raw-kernel arena tests (`test/api-coverage.test.ts`) asserting no arena churn via `getShapeCount()` deltas.
- **crate/WASI:** `cargo test -p occt-wasm --release` — 16 passed (0 skipped, so the fresh `wasm.br` really instantiated and every new C-ABI export resolved), incl. 2 new tests.
- Lint gate: `clippy -D warnings`, `fmt --check`, codegen drift check, `tsc --noEmit`, `eslint` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add arena memory-management APIs to reduce handle churn and simplify consumers like brepjs. Implements #205, #206, and #207 with allocation-free downcasts, handle-free sub-shape queries, and checkpoint-based bulk release; stop calling `release()` on the source id after a successful `downcast`.

- **New Features**
  - `downcast` returns the same id when the shape already matches the target type (no new arena slot) (#205).
  - `subShapeCount(shape, type)` and `subShapeHashes(shape, type, hashUpperBound)` return counts and deduplicated hashes without allocating per-sub-shape handles (#206).
  - `checkpoint()` and `releaseSince(mark)` bulk-free all ids allocated at or after the mark; `nextId_` keeps increasing to avoid id aliasing (#207).

- **Dependencies**
  - Re-embedded `crate/src/occt-wasm.wasm.br` from the CI build to satisfy the stale-check; no API or behavior change.

<sup>Written for commit bc2fab0472a7af2cbdbd791fefadf14ff50324c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

