### PR TITLE
build(ts): adopt TS 7 native compiler (tsgo) for build + typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: cd ts && npm ci
 
       - name: TypeScript typecheck
-        run: cd ts && npx tsc --noEmit
+        run: cd ts && npx tsgo --noEmit
 
       - name: ESLint
         run: cd ts && npx eslint src/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Tests load the prebuilt WASM from `dist/`, so **run a build before testing**. To
 ```bash
 cd ts && npx vitest run ../test/integration.test.ts   # one file
 cd ts && npx vitest run -t "fuse"                      # tests whose name matches
-cd ts && npx tsc --noEmit && npx eslint src/           # the lint gate — no WASM needed
+cd ts && npx tsgo --noEmit && npx eslint src/          # the lint gate — no WASM needed
 ```
 
 Benchmarks: `npx vitest run test/bench.test.ts` (from repo root, after a build) writes `benchmarks/last-run.json`; `node scripts/bench-check.js` gates it against `baseline.json` (a regression is >15% **and** >0.5ms). Refresh the baseline with `node scripts/bench-check.js --update-baseline` after a run.
@@ -51,7 +51,7 @@ Any facade/codegen change invalidates the committed `wasm.br`. CI's "WASI build 
 Shapes live in a u32-keyed arena (`store`/`get`/`release`/`releaseAll`); IDs are never auto-freed, so the TS wrapper backs them with `Symbol.dispose` + a FinalizationRegistry safety net. Array arguments cross the boundary through `#withU32`/`#withF64`/`#withI32` scope guards (a bulk heap copy above a size threshold). The facade catches OCCT `Standard_Failure` and re-throws `std::runtime_error`; the TS `wrap()` in `types.ts` converts any throw to an `OcctError` whose `code` is inferred by `classifyError` from the operation name + message.
 
 ## CI shape
-- **lint** (no WASM): `cargo fmt --check`, `clippy -D warnings`, `tsc --noEmit`, `eslint`, plus the codegen drift check.
+- **lint** (no WASM): `cargo fmt --check`, `clippy -D warnings`, `tsgo --noEmit` (TS 7 native compiler; `typescript@6` stays for eslint/typedoc's JS API), `eslint`, plus the codegen drift check.
 - **build-test**: builds the Embind WASM in the builder container, runs the full vitest suite + the bench gate.
 - **build-wasi**: the `wasm.br` stale-check above. Releases ship via release-please → npm (OIDC) and a `crate-v*` tag → crates.io.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:occt": "cargo xtask build-occt",
     "test": "cd ts && npx vitest run",
     "lint": "cd ts && npx eslint src/",
-    "typecheck": "cd ts && npx tsc --noEmit",
+    "typecheck": "cd ts && npx tsgo --noEmit",
     "publish:dry": "./scripts/publish.sh --dry-run",
     "publish:npm": "./scripts/publish.sh",
     "docker:build": "DOCKER_BUILDKIT=1 docker build --progress=plain -t occt-wasm .",

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "occt-wasm",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "occt-wasm",
-      "version": "3.6.1",
+      "version": "3.7.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "comlink": "^4.4.2"
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
+        "@typescript/native-preview": "^7.0.0-dev.20260707.2",
         "eslint": "^10",
         "typedoc": "^0.28.18",
         "typescript": "^6.0",
@@ -886,6 +887,147 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitest/expect": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -19,11 +19,11 @@
     "dist/"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsgo",
     "prebuild": "bash scripts/copy-wasm.sh",
     "prepack": "cp ../README.md README.md",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "docs": "typedoc"
   },
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "eslint": "^10",
     "typedoc": "^0.28.18",
     "typescript": "^6.0",


### PR DESCRIPTION
## What

Upgrades the `ts/` package to TypeScript 7 using a **split toolchain**: the TS 7 native Go compiler (`tsgo`) drives compilation and typechecking, while `typescript@6` is retained solely as the JS-API provider for eslint and typedoc.

## Why not a bare `typescript@^7` bump

`typescript@7.0.2` is the native (Go) compiler — the package ships only a launcher + a platform-specific native binary (via optional deps) and **drops `lib/typescript.js`**, the JavaScript compiler API. Anything that imports the TS API programmatically breaks:

- `@typescript-eslint/parser` always `require('typescript')` to turn `.ts` into an ESTree (even for non-type-aware rules) — peer dep caps at `<6.1.0`.
- `typedoc` is built entirely on the API — peer dep caps at `6.0.x`.

So moving the `typescript` specifier to `^7` would kill the **lint gate** and **`npm docs`**. Keeping both packages is the intended state during the transition, not tech debt.

## Changes

| File | Change |
|------|--------|
| `ts/package.json` | add `@typescript/native-preview` (tsgo); `build` + `typecheck` scripts → `tsgo`; keep `typescript@^6` |
| `package.json` | root `typecheck` → `npx tsgo --noEmit` |
| `.github/workflows/ci.yml` | typecheck step → `npx tsgo --noEmit` |
| `CLAUDE.md` | document the split toolchain in the lint-gate + CI-shape sections |

## Verification

- `tsgo --noEmit` → clean
- `eslint src/` (TS 6 API) → clean
- `typedoc` → generates HTML, exit 0 (14 pre-existing warnings, unrelated)
- **Emit parity**: `tsgo` vs `tsc` produce byte-identical `.js`; the only `.d.ts` difference is `getShapeType`'s return union printing alphabetically sorted — structurally identical, invisible to consumers.

## Follow-up

`@typescript/native-preview` publishes only dev builds, so it's pinned to a dev-tag caret and will need occasional manual bumps. Once typescript-eslint and typedoc ship TS-7-compatible majors, this can collapse back to a single `typescript@7`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted the TypeScript 7 native compiler `tsgo` for build and typecheck in `ts/`, while keeping `typescript@6` for tools that rely on the JS API. CI and root scripts now use `tsgo --noEmit`; output matches `tsc`.

- **Dependencies**
  - Added `@typescript/native-preview` and switched `build`/`typecheck` scripts to `tsgo`.
  - Retained `typescript@^6` for `@typescript-eslint/*` and `typedoc`.
  - Updated root and CI typecheck to `tsgo --noEmit`; documented the split toolchain in `CLAUDE.md`.

<sup>Written for commit 76f08eaea52630b42747fe0a99a48d3deee13f51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

