### PR TITLE
feat(facade): add reverseSurfaceU for indirect surface sketching

### DIFF
--- a/crate/src/kernel_generated.rs
+++ b/crate/src/kernel_generated.rs
@@ -133,6 +133,7 @@ pub(crate) struct GeneratedFuncs {
     fn_surface_curvature: TypedFunc<(u32, f64, f64), i32>,
     fn_uv_bounds: TypedFunc<(u32,), i32>,
     fn_get_face_cylinder_data: TypedFunc<(u32,), i32>,
+    fn_reverse_surface_u: TypedFunc<(u32,), u32>,
     fn_uv_from_point: TypedFunc<(u32, f64, f64, f64), i32>,
     fn_project_point_on_face: TypedFunc<(u32, f64, f64, f64), i32>,
     fn_classify_point_on_face: TypedFunc<(u32, f64, f64), i32>,
@@ -348,6 +349,7 @@ impl GeneratedFuncs {
             fn_uv_bounds: instance.get_typed_func(&mut store, "occt_uv_bounds")?,
             fn_get_face_cylinder_data: instance
                 .get_typed_func(&mut store, "occt_get_face_cylinder_data")?,
+            fn_reverse_surface_u: instance.get_typed_func(&mut store, "occt_reverse_surface_u")?,
             fn_uv_from_point: instance.get_typed_func(&mut store, "occt_uv_from_point")?,
             fn_project_point_on_face: instance
                 .get_typed_func(&mut store, "occt_project_point_on_face")?,
@@ -2439,6 +2441,18 @@ impl crate::kernel::OcctKernel {
             return Err(self.read_last_error("get_face_cylinder_data"));
         }
         self.read_vec_f64_result()
+    }
+
+    pub fn reverse_surface_u(&mut self, face_id: ShapeHandle) -> OcctResult<ShapeHandle> {
+        let result = self
+            .generated
+            .fn_reverse_surface_u
+            .call(&mut self.store, (face_id.0,))?;
+        self.check_error("reverse_surface_u")?;
+        if result == 0 {
+            return Err(self.read_last_error("reverse_surface_u"));
+        }
+        Ok(ShapeHandle(result))
     }
 
     pub fn uv_from_point(

--- a/facade/generated/bindings.cpp
+++ b/facade/generated/bindings.cpp
@@ -142,6 +142,7 @@ EMSCRIPTEN_BINDINGS(occt_wasm) {
         .function("filletVariable", &OcctKernel::filletVariable)
         .function("filletBatch", &OcctKernel::filletBatch)
         .function("offsetWire2D", &OcctKernel::offsetWire2D)
+        .function("reverseSurfaceU", &OcctKernel::reverseSurfaceU)
         .function("draftPrism", &OcctKernel::draftPrism)
 
         // transforms

--- a/facade/generated/kernel.cpp
+++ b/facade/generated/kernel.cpp
@@ -828,6 +828,29 @@ uint32_t OcctKernel::offsetWire2D(uint32_t wireId, double offset, int joinType) 
     }
 }
 
+uint32_t OcctKernel::reverseSurfaceU(uint32_t faceId) {
+    try {
+        TopoDS_Face face = TopoDS::Face(get(faceId));
+        Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
+        if (surf.IsNull()) {
+            throw std::runtime_error("reverseSurfaceU: face has no geometric surface");
+        }
+        Standard_Real u1, u2, v1, v2;
+        BRepTools::UVBounds(face, u1, u2, v1, v2);
+        Standard_Real ru1 = surf->UReversedParameter(u2);
+        Standard_Real ru2 = surf->UReversedParameter(u1);
+        Handle(Geom_Surface) reversed = Handle(Geom_Surface)::DownCast(surf->Copy());
+        reversed->UReverse();
+        BRepBuilderAPI_MakeFace mkFace(reversed, ru1, ru2, v1, v2, Precision::Confusion());
+        if (!mkFace.IsDone()) {
+            throw std::runtime_error("reverseSurfaceU: face construction failed");
+        }
+        return store(mkFace.Face());
+    } catch (const Standard_Failure& e) {
+        throw std::runtime_error(std::string("reverseSurfaceU: ") + e.what());
+    }
+}
+
 uint32_t OcctKernel::draftPrism(uint32_t shapeId, double dx, double dy, double dz, double angleDeg) {
     try {
         // Step 1: Straight extrude

--- a/facade/include/occt_kernel.h
+++ b/facade/include/occt_kernel.h
@@ -301,6 +301,7 @@ class OcctKernel {
     std::vector<double> surfaceNormal(uint32_t faceId, double u, double v);
     std::vector<double> pointOnSurface(uint32_t faceId, double u, double v);
     uint32_t outerWire(uint32_t faceId);
+    uint32_t reverseSurfaceU(uint32_t faceId);
     std::vector<double> uvBounds(uint32_t faceId);
     std::vector<double> uvFromPoint(uint32_t faceId, double x, double y, double z);
     std::vector<double> getFaceCylinderData(uint32_t faceId);

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -953,6 +953,41 @@ describe("vertex and surface query", () => {
         faces.delete();
     });
 
+    it("reverseSurfaceU returns a face whose surface is the U-reversed original", () => {
+        const cyl = kernel.makeCylinder(5, 10);
+        const faces = kernel.getSubShapes(cyl, "face");
+        let cylFace = -1;
+        for (let i = 0; i < faces.size(); i++) {
+            if (kernel.surfaceType(faces.get(i)) === "cylinder") {
+                cylFace = faces.get(i);
+                break;
+            }
+        }
+        expect(cylFace).toBeGreaterThan(0);
+
+        const reversed = kernel.reverseSurfaceU(cylFace);
+        expect(kernel.getShapeType(reversed)).toBe("face");
+        expect(kernel.surfaceType(reversed)).toBe("cylinder");
+
+        const uv = kernel.uvBounds(cylFace);
+        const uFirst = uv.get(0);
+        const uLast = uv.get(1);
+        const v = 0.5 * (uv.get(2) + uv.get(3));
+        const u = uFirst + 0.3 * (uLast - uFirst);
+
+        // For a full-period cylinder, UReversedParameter(u) === uFirst+uLast-u,
+        // so the reversed surface at u equals the original at uFirst+uLast-u.
+        const pRev = kernel.pointOnSurface(reversed, u, v);
+        const pOrig = kernel.pointOnSurface(cylFace, uFirst + uLast - u, v);
+        for (let i = 0; i < 3; i++) {
+            expect(pRev.get(i)).toBeCloseTo(pOrig.get(i), 6);
+        }
+        pRev.delete();
+        pOrig.delete();
+        uv.delete();
+        faces.delete();
+    });
+
     it("outerWire returns the outer boundary wire of a face", () => {
         const face = makeSquareFace(10);
         const wire = kernel.outerWire(face);

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -953,9 +953,13 @@ describe("vertex and surface query", () => {
         faces.delete();
     });
 
-    it("reverseSurfaceU returns a face whose surface is the U-reversed original", () => {
+    it("reverseSurfaceU reverses the U parametrization of an indirect cylindrical face", () => {
+        // Mirroring a cylinder yields an indirect (left-handed) cylindrical face
+        // — the motivating case (brepjs#1881), where the U direction must be
+        // reversed to sketch a profile onto the correct circumferential side.
         const cyl = kernel.makeCylinder(5, 10);
-        const faces = kernel.getSubShapes(cyl, "face");
+        const mirrored = kernel.mirror(cyl, 0, 0, 0, 1, 0, 0);
+        const faces = kernel.getSubShapes(mirrored, "face");
         let cylFace = -1;
         for (let i = 0; i < faces.size(); i++) {
             if (kernel.surfaceType(faces.get(i)) === "cylinder") {
@@ -965,6 +969,11 @@ describe("vertex and surface query", () => {
         }
         expect(cylFace).toBeGreaterThan(0);
 
+        // The mirrored cylinder is genuinely indirect (gp_Cylinder::Direct() false).
+        const cylData = kernel.getFaceCylinderData(cylFace);
+        expect(cylData.get(1)).toBe(0);
+        cylData.delete();
+
         const reversed = kernel.reverseSurfaceU(cylFace);
         expect(kernel.getShapeType(reversed)).toBe("face");
         expect(kernel.surfaceType(reversed)).toBe("cylinder");
@@ -972,7 +981,9 @@ describe("vertex and surface query", () => {
         const uv = kernel.uvBounds(cylFace);
         const uFirst = uv.get(0);
         const uLast = uv.get(1);
-        const v = 0.5 * (uv.get(2) + uv.get(3));
+        const vMin = uv.get(2);
+        const vMax = uv.get(3);
+        const v = 0.5 * (vMin + vMax);
         const u = uFirst + 0.3 * (uLast - uFirst);
 
         // For a full-period cylinder, UReversedParameter(u) === uFirst+uLast-u,
@@ -982,9 +993,17 @@ describe("vertex and surface query", () => {
         for (let i = 0; i < 3; i++) {
             expect(pRev.get(i)).toBeCloseTo(pOrig.get(i), 6);
         }
+
+        // The reversed face carries a valid UV domain with V preserved.
+        const uvRev = kernel.uvBounds(reversed);
+        expect(uvRev.get(0)).toBeLessThan(uvRev.get(1));
+        expect(uvRev.get(2)).toBeCloseTo(vMin, 6);
+        expect(uvRev.get(3)).toBeCloseTo(vMax, 6);
+
         pRev.delete();
         pOrig.delete();
         uv.delete();
+        uvRev.delete();
         faces.delete();
     });
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1330,6 +1330,17 @@ export class OcctKernel {
         return wrap("outerWire", () => handle(this.#raw.outerWire(face)));
     }
 
+    /**
+     * Reverse a surface's U parametric direction (OCCT `Geom_Surface::UReverse`),
+     * returning a new face proxy whose surface is the U-reversed original.
+     * `pointOnSurface(result, u, v)` then evaluates the original surface at
+     * `origSurface.UReversedParameter(u)` — for a full-period cylinder that is
+     * `uFirst + uLast - u`.
+     */
+    reverseSurfaceU(face: ShapeHandle): ShapeHandle {
+        return wrap("reverseSurfaceU", () => handle(this.#raw.reverseSurfaceU(face)));
+    }
+
     uvBounds(face: ShapeHandle): UVBounds {
         return wrap("uvBounds", () =>
             this.#uvBoundsFromEmbind(this.#raw.uvBounds(face)),

--- a/ts/src/raw-types.ts
+++ b/ts/src/raw-types.ts
@@ -284,6 +284,7 @@ export interface OcctRawKernel {
     surfaceNormal(faceId: number, u: number, v: number): EmbindVectorF64;
     pointOnSurface(faceId: number, u: number, v: number): EmbindVectorF64;
     outerWire(faceId: number): number;
+    reverseSurfaceU(faceId: number): number;
     uvBounds(faceId: number): EmbindVectorF64;
     uvFromPoint(faceId: number, x: number, y: number, z: number): EmbindVectorF64;
     getFaceCylinderData(faceId: number): EmbindVectorF64;

--- a/xtask/src/codegen/config.rs
+++ b/xtask/src/codegen/config.rs
@@ -2529,6 +2529,45 @@ return {cyl.Radius(), cyl.Direct() ? 1.0 : 0.0};",
         return_type: ReturnType::VectorDouble,
     },
     MethodSpec {
+        name: "reverseSurfaceU",
+        kind: MethodKind::CustomBody,
+        params: &[FacadeParam::ShapeId("faceId")],
+        occt_class: "",
+        ctor_args: "",
+        // Return a new face carrying the U-reversed geometric surface (OCCT
+        // Geom_Surface::UReverse). Surfaces are face proxies here, so a caller
+        // that later evaluates pointOnSurface(result, u, v) gets
+        // origSurface.Value(origSurface.UReversedParameter(u), v) — for a
+        // full-period cylinder that is Value(uFirst+uLast-u, v), the
+        // reparametrization brepjs needs to sketch onto an indirect
+        // (left-handed) cylindrical face. Value() ignores face trimming, so the
+        // face bounds only need to be constructible; we map them through the
+        // reversal to keep uvBounds() honest.
+        setup_code: "\
+TopoDS_Face face = TopoDS::Face(get(faceId));
+Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
+if (surf.IsNull()) {
+    throw std::runtime_error(\"reverseSurfaceU: face has no geometric surface\");
+}
+Standard_Real u1, u2, v1, v2;
+BRepTools::UVBounds(face, u1, u2, v1, v2);
+Standard_Real ru1 = surf->UReversedParameter(u2);
+Standard_Real ru2 = surf->UReversedParameter(u1);
+Handle(Geom_Surface) reversed = Handle(Geom_Surface)::DownCast(surf->Copy());
+reversed->UReverse();
+BRepBuilderAPI_MakeFace mkFace(reversed, ru1, ru2, v1, v2, Precision::Confusion());
+if (!mkFace.IsDone()) {
+    throw std::runtime_error(\"reverseSurfaceU: face construction failed\");
+}
+return store(mkFace.Face());",
+        includes: &[
+            "BRep_Tool.hxx", "BRepBuilderAPI_MakeFace.hxx", "BRepTools.hxx", "Geom_Surface.hxx",
+            "Precision.hxx", "TopoDS.hxx", "TopoDS_Face.hxx",
+        ],
+        category: "modeling",
+        return_type: ReturnType::ShapeId,
+    },
+    MethodSpec {
         name: "uvFromPoint",
         kind: MethodKind::CustomBody,
         params: &[


### PR DESCRIPTION
## What

Adds a `reverseSurfaceU(faceId) -> faceId` facade primitive that returns a new face proxy carrying the **U-reversed geometric surface** (OCCT `Geom_Surface::UReverse`).

Since surfaces are face proxies in this library, a caller that then evaluates `pointOnSurface(result, u, v)` gets `origSurface.Value(origSurface.UReversedParameter(u), v)` — for a full-period cylinder that is `Value(uFirst + uLast - u, v)`.

## Why

[brepjs#1881](https://github.com/andymai/brepjs/issues/1881): sketching a 2D profile onto an **indirect (left-handed) cylindrical face** — e.g. the cylindrical face produced by mirroring a cylinder — needs the surface's U parametrization reversed so the profile maps onto the correct circumferential direction. On the default occt-wasm kernel this was unimplemented, so brepjs threw `UnsupportedKernelOperationError`. opencascade.js already implements it via `Geom_Surface::UReversed()`; this brings occt-wasm to parity.

A pure-TS workaround in brepjs (folding the reversal into the 2D transform) was equivalent to native reversal on opencascade.js but produced wrong geometry on occt-wasm, so the primitive is genuinely needed here.

## Implementation

- `MethodSpec` in `xtask/src/codegen/config.rs` (custom C++ body): copy the surface, `UReverse()` the copy, rebuild a face over the reversal-mapped UV window via `BRepBuilderAPI_MakeFace`. `UReversedParameter` is computed on the original surface before reversing (it's bound-symmetric and unaffected by `UReverse`), and its monotonic-decreasing property gives `umin < umax` for `MakeFace`.
- Regenerated facade (`facade/generated/{kernel,bindings}.cpp`), crate binding (`crate/src/kernel_generated.rs`), and the WASI `wasm.br`.
- Hand-written class declaration in `facade/include/occt_kernel.h` and the TS wrapper in `ts/src/{index,raw-types}.ts`.
- Semantic test in `test/api-coverage.test.ts`: asserts the reversed surface evaluated at `u` matches the original at the reversed parameter, on a real cylinder.

## Test plan

Built against the prebuilt builder image and ran vitest: the new `reverseSurfaceU` test passes and the surface-query suite shows no regression. Rust `clippy -D warnings`, `fmt`, `clang-format`, `tsgo`, and `eslint` all clean. Fresh `crate/src/occt-wasm.wasm.br` regenerated so the WASI stale-check passes.

## Follow-up

brepjs will wire `occtWasmAdapter.reverseSurfaceU` through to this method (removing the `notImplemented` stub) once a release with this change is published, then close #1881.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `reverseSurfaceU(faceId) -> faceId` to reverse a face’s surface U direction and fix profile mapping on indirect (left-handed) cylindrical faces. Brings `occt-wasm` to parity with `opencascade.js` and unblocks `brepjs` issue andymai/brepjs#1881.

- New Features
  - Kernel primitive `reverseSurfaceU` that copies the surface, calls OCCT `Geom_Surface::UReverse`, and rebuilds the face with reversal-mapped UV bounds.
  - Exposed via embind and TS: `OcctKernel.reverseSurfaceU(face)`.
  - Regenerated generated code and `crate/src/occt-wasm.wasm.br`.
  - Test strengthened: mirrors a cylinder to create an indirect face, asserts `gp_Cylinder::Direct()` is false, checks `uFirst + uLast - u` evaluation matches, and validates UV bounds (V preserved).

<sup>Written for commit f4731a54c247e54c8d6f127bf0d39d30564d4e3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

