### PR TITLE
fix(ts): decode wasm exceptions and repair the quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,29 +56,36 @@ import { OcctKernel } from "occt-wasm";
   const box = kernel.makeBox(20, 20, 20);
   const cyl = kernel.makeCylinder(8, 30);
 
-  // Booleans
-  const fused = kernel.fuse(box, cyl);
+  // Modeling -- fillet takes a solid, so round the box before combining
+  const edges = kernel.getSubShapes(box, "edge");
+  const filleted = kernel.fillet(box, edges.slice(0, 4), 2.0);
 
-  // Modeling
-  const edges = kernel.getSubShapes(fused, "edge");
-  const filleted = kernel.fillet(fused, edges.slice(0, 4), 2.0);
+  // Booleans
+  const fused = kernel.fuse(filleted, cyl);
 
   // Tessellation -> Three.js / Babylon.js
-  const mesh = kernel.tessellate(filleted);
+  const mesh = kernel.tessellate(fused);
   // mesh.positions (Float32Array), mesh.normals, mesh.indices
 
   // STEP I/O
-  const step = kernel.exportStep(filleted);
+  const step = kernel.exportStep(fused);
   const reimported = kernel.importStep(step);
 
   // Query
-  const vol = kernel.getVolume(filleted);
-  const bbox = kernel.getBoundingBox(filleted);
-  const com = kernel.getCenterOfMass(filleted);
+  const vol = kernel.getVolume(fused);
+  const bbox = kernel.getBoundingBox(fused);
+  const com = kernel.getCenterOfMass(fused);
 
   // kernel is disposed at end of block
 }
 ```
+
+> **Boolean results are compounds.** OCCT's `BRepAlgoAPI` operations wrap their
+> output in a `TopoDS_Compound` — a boolean can produce several disjoint solids.
+> Operations that require a solid (`fillet`, `chamfer`, `shell`, ...) reject one,
+> so unwrap first: `const solid = kernel.getSubShapes(fused, "solid")[0]`.
+> Note too that not every edge of a shape is filletable — seam and degenerate
+> edges are not, so pick edges deliberately rather than by index.
 
 ## Rust Crate
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ Available error codes:
 | `KernelError`        | OCCT `Standard_Failure` (unclassified)          |
 | `Unknown`            | Error from outside the kernel                   |
 
+> **`OcctWorker` is the exception.** Comlink serializes a thrown error down to
+> `{ message, name, stack }`, so an error crossing the worker boundary arrives
+> as a plain `Error`: the message survives intact, but `code`, `operation`, and
+> `instanceof OcctError` do not. Match on `e.message` there, or do the
+> `switch (e.code)` inside the worker.
+
 ## Named Enums
 
 Sweep, offset, and boolean operations use self-documenting enums instead of opaque numbers:

--- a/README.md
+++ b/README.md
@@ -82,10 +82,14 @@ import { OcctKernel } from "occt-wasm";
 
 > **Boolean results are compounds.** OCCT's `BRepAlgoAPI` operations wrap their
 > output in a `TopoDS_Compound` — a boolean can produce several disjoint solids.
-> Operations that require a solid (`fillet`, `chamfer`, `shell`, ...) reject one,
-> so unwrap first: `const solid = kernel.getSubShapes(fused, "solid")[0]`.
-> Note too that not every edge of a shape is filletable — seam and degenerate
-> edges are not, so pick edges deliberately rather than by index.
+> The operations that downcast to a solid (`fillet`, `chamfer`, `filletVariable`,
+> `filletBatch`, `healSolid`) reject one, so unwrap first:
+> `const solid = kernel.getSubShapes(fused, "solid")[0]`.
+>
+> **Not every edge is filletable.** Seam and degenerate edges are not, so on a
+> shape you didn't build yourself, select edges by geometry rather than by index.
+> The `slice(0, 4)` above is safe only because all 12 edges of a plain box round
+> cleanly — on the box-plus-cylinder fusion, only 13 of 20 edges do.
 
 ## Rust Crate
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ import { OcctKernel } from "occt-wasm";
 > output in a `TopoDS_Compound` — a boolean can produce several disjoint solids.
 > The operations that downcast to a solid (`fillet`, `chamfer`, `filletVariable`,
 > `filletBatch`, `healSolid`) reject one, so unwrap first:
-> `const solid = kernel.getSubShapes(fused, "solid")[0]`.
+>
+> ```typescript
+> const [solid] = kernel.getSubShapes(fused, "solid");
+> if (!solid) throw new Error("boolean produced no solid");
+> ```
 >
 > **Not every edge is filletable.** Seam and degenerate edges are not, so on a
 > shape you didn't build yourself, select edges by geometry rather than by index.

--- a/examples/step-viewer/index.html
+++ b/examples/step-viewer/index.html
@@ -241,19 +241,19 @@
             const moved = kernel.translate(sphere, 15, 10, 15);
             const fused = kernel.fuse(cut, moved);
 
-            const edges = kernel.getSubShapes(fused, 'edge');
+            // A boolean result is a compound; fillet needs the solid inside it.
+            const solids = kernel.getSubShapes(fused, 'solid');
+            const solid = solids.get(0);
+
+            const edges = kernel.getSubShapes(solid, 'edge');
             const edgeVec = new Module.VectorUint32();
             for (let i = 0; i < Math.min(4, edges.size()); i++) {
                 edgeVec.push_back(edges.get(i));
             }
-            let result;
-            try {
-                result = kernel.fillet(fused, edgeVec, 1.5);
-            } catch {
-                result = fused;
-            }
+            const result = kernel.fillet(solid, edgeVec, 1.5);
             edgeVec.delete();
             edges.delete();
+            solids.delete();
 
             displayShape(result, 'Demo (box - cylinder + sphere, filleted)');
         };

--- a/examples/three-js/index.html
+++ b/examples/three-js/index.html
@@ -80,25 +80,20 @@
         const t1 = performance.now();
         const kernel = new Module.OcctKernel();
 
-        // Box + cylinder fuse + fillet
+        // Box fillet + cylinder fuse. fillet needs a solid, and a boolean
+        // result is a compound, so round the box before fusing.
         const box = kernel.makeBox(20, 20, 20);
-        const cyl = kernel.makeCylinder(8, 30);
-        const cylCentered = kernel.translate(cyl, 10, 10, -5);
-        const fused = kernel.fuse(box, cylCentered);
 
-        // Get edges and fillet
-        const edges = kernel.getSubShapes(fused, 'edge');
+        const edges = kernel.getSubShapes(box, 'edge');
         const edgeVec = new Module.VectorUint32();
         for (let i = 0; i < edges.size(); i++) {
             edgeVec.push_back(edges.get(i));
         }
+        const rounded = kernel.fillet(box, edgeVec, 1.5);
 
-        let result;
-        try {
-            result = kernel.fillet(fused, edgeVec, 1.5);
-        } catch {
-            result = fused; // Fallback if fillet fails on complex edges
-        }
+        const cyl = kernel.makeCylinder(8, 30);
+        const cylCentered = kernel.translate(cyl, 10, 10, -5);
+        const result = kernel.fuse(rounded, cylCentered);
 
         const shapeMs = (performance.now() - t1).toFixed(0);
 

--- a/test/new-features.test.ts
+++ b/test/new-features.test.ts
@@ -169,16 +169,24 @@ describe("OcctErrorCode classification", () => {
 
 describe("wrap decodes WebAssembly.Exception", () => {
     let wrap: any;
-    let setExceptionDecoder: any;
+    let addExceptionDecoder: any;
+    let release: Array<() => void> = [];
+
+    const register = (decoder: any) => {
+        const off = addExceptionDecoder(decoder);
+        release.push(off);
+        return off;
+    };
 
     beforeAll(async () => {
         const types = await import(resolve(__dirname, "../ts/src/types.ts"));
         wrap = types.wrap;
-        setExceptionDecoder = types.setExceptionDecoder;
+        addExceptionDecoder = types.addExceptionDecoder;
     });
 
     afterEach(() => {
-        setExceptionDecoder(undefined);
+        release.forEach((off) => off());
+        release = [];
     });
 
     const filletCompound = () => {
@@ -201,7 +209,7 @@ describe("wrap decodes WebAssembly.Exception", () => {
     };
 
     it("recovers the OCCT message when a decoder is registered", () => {
-        setExceptionDecoder((e: unknown) => Module.getExceptionMessage(e));
+        register((e: unknown) => Module.getExceptionMessage(e));
         const err = catchWrapped("fillet", filletCompound());
         expect(err).toBeInstanceOf(OcctError);
         expect(err.message).not.toContain("[object WebAssembly.Exception]");
@@ -210,7 +218,7 @@ describe("wrap decodes WebAssembly.Exception", () => {
     });
 
     it("does not repeat the operation name already prefixed by the facade", () => {
-        setExceptionDecoder((e: unknown) => Module.getExceptionMessage(e));
+        register((e: unknown) => Module.getExceptionMessage(e));
         const err = catchWrapped("fillet", filletCompound());
         expect(err.message.startsWith("fillet: fillet:")).toBe(false);
         expect(err.message).toBe("fillet: TopoDS::Solid");
@@ -223,7 +231,7 @@ describe("wrap decodes WebAssembly.Exception", () => {
     });
 
     it("survives a decoder that throws", () => {
-        setExceptionDecoder(() => {
+        register(() => {
             throw new Error("decoder blew up");
         });
         const err = catchWrapped("fillet", filletCompound());
@@ -232,12 +240,50 @@ describe("wrap decodes WebAssembly.Exception", () => {
     });
 
     it("leaves plain Error messages untouched", () => {
-        setExceptionDecoder(() => ["std::runtime_error", "should not be used"]);
+        register(() => ["std::runtime_error", "should not be used"]);
         const err = catchWrapped("makeBox", () => {
             throw new Error("makeBox: construction failed");
         });
         expect(err.message).toBe("makeBox: construction failed");
     });
+
+    it("stops decoding once its registration is released", () => {
+        const off = register((e: unknown) => Module.getExceptionMessage(e));
+        expect(catchWrapped("fillet", filletCompound()).message).toBe("fillet: TopoDS::Solid");
+        off();
+        expect(catchWrapped("fillet", filletCompound()).message).toContain(
+            "[object WebAssembly.Exception]",
+        );
+    });
+
+    // A second kernel must not blind the first: each registers its own
+    // module-bound decoder, and a foreign module's getArg rejects the tag.
+    it("still decodes when another module's decoder is registered first", async () => {
+        const createModule = (await import(jsPath)).default;
+        const other = await createModule({
+            locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
+        });
+        expect(other).not.toBe(Module);
+
+        register((e: unknown) => other.getExceptionMessage(e));
+        register((e: unknown) => Module.getExceptionMessage(e));
+
+        const err = catchWrapped("fillet", filletCompound());
+        expect(err.message).toBe("fillet: TopoDS::Solid");
+    }, 60_000);
+
+    it("decodes regardless of decoder registration order", async () => {
+        const createModule = (await import(jsPath)).default;
+        const other = await createModule({
+            locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
+        });
+
+        register((e: unknown) => Module.getExceptionMessage(e));
+        register((e: unknown) => other.getExceptionMessage(e));
+
+        const err = catchWrapped("fillet", filletCompound());
+        expect(err.message).toBe("fillet: TopoDS::Solid");
+    }, 60_000);
 });
 
 // ============================================================================

--- a/test/new-features.test.ts
+++ b/test/new-features.test.ts
@@ -159,6 +159,88 @@ describe("OcctErrorCode classification", () => {
 });
 
 // ============================================================================
+// WebAssembly.Exception decoding
+//
+// Under -fwasm-exceptions a C++ throw reaches JS as a WebAssembly.Exception,
+// which is not an Error — stringifying it yields "[object WebAssembly.Exception]"
+// and the OCCT diagnostic is lost. OcctKernel.init() registers the Emscripten
+// getExceptionMessage helper so wrap() can recover what().
+// ============================================================================
+
+describe("wrap decodes WebAssembly.Exception", () => {
+    let wrap: any;
+    let setExceptionDecoder: any;
+
+    beforeAll(async () => {
+        const types = await import(resolve(__dirname, "../ts/src/types.ts"));
+        wrap = types.wrap;
+        setExceptionDecoder = types.setExceptionDecoder;
+    });
+
+    afterEach(() => {
+        setExceptionDecoder(undefined);
+    });
+
+    const filletCompound = () => {
+        // A boolean result is a TopoDS_Compound; fillet's TopoDS::Solid cast
+        // rejects it with Standard_TypeMismatch.
+        const fused = kernel.fuse(kernel.makeBox(20, 20, 20), kernel.makeCylinder(8, 30));
+        const edges = kernel.getSubShapes(fused, "edge");
+        const edgeVec = new Module.VectorUint32();
+        edgeVec.push_back(edges.get(0));
+        return () => kernel.fillet(fused, edgeVec, 1.0);
+    };
+
+    const catchWrapped = (op: string, fn: () => unknown) => {
+        try {
+            wrap(op, fn);
+        } catch (e) {
+            return e as InstanceType<typeof OcctError>;
+        }
+        return undefined;
+    };
+
+    it("recovers the OCCT message when a decoder is registered", () => {
+        setExceptionDecoder((e: unknown) => Module.getExceptionMessage(e));
+        const err = catchWrapped("fillet", filletCompound());
+        expect(err).toBeInstanceOf(OcctError);
+        expect(err.message).not.toContain("[object WebAssembly.Exception]");
+        expect(err.message).toContain("TopoDS::Solid");
+        expect(err.operation).toBe("fillet");
+    });
+
+    it("does not repeat the operation name already prefixed by the facade", () => {
+        setExceptionDecoder((e: unknown) => Module.getExceptionMessage(e));
+        const err = catchWrapped("fillet", filletCompound());
+        expect(err.message.startsWith("fillet: fillet:")).toBe(false);
+        expect(err.message).toBe("fillet: TopoDS::Solid");
+    });
+
+    it("still produces an OcctError when no decoder is registered", () => {
+        const err = catchWrapped("fillet", filletCompound());
+        expect(err).toBeInstanceOf(OcctError);
+        expect(err.code).toBe(OcctErrorCode.KernelError);
+    });
+
+    it("survives a decoder that throws", () => {
+        setExceptionDecoder(() => {
+            throw new Error("decoder blew up");
+        });
+        const err = catchWrapped("fillet", filletCompound());
+        expect(err).toBeInstanceOf(OcctError);
+        expect(err.message).not.toContain("decoder blew up");
+    });
+
+    it("leaves plain Error messages untouched", () => {
+        setExceptionDecoder(() => ["std::runtime_error", "should not be used"]);
+        const err = catchWrapped("makeBox", () => {
+            throw new Error("makeBox: construction failed");
+        });
+        expect(err.message).toBe("makeBox: construction failed");
+    });
+});
+
+// ============================================================================
 // Type predicate methods
 // ============================================================================
 

--- a/test/new-features.test.ts
+++ b/test/new-features.test.ts
@@ -303,6 +303,70 @@ describe("wrap decodes WebAssembly.Exception", () => {
 });
 
 // ============================================================================
+// OcctKernel lifecycle wiring
+//
+// The block above drives wrap()/addExceptionDecoder directly. These build the
+// real wrapper, so they cover what the constructor and Symbol.dispose actually
+// wire up — and the one-argument getBoundingBox call from issue #223.
+// ============================================================================
+
+describe("OcctKernel wires decoding into its lifecycle", () => {
+    let WrapperKernel: any;
+    let ownModule: any;
+    let kernel2: any;
+
+    beforeAll(async () => {
+        WrapperKernel = (await import(resolve(__dirname, "../ts/src/index.ts"))).OcctKernel;
+        const createModule = (await import(jsPath)).default;
+        ownModule = await createModule({
+            locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
+        });
+        // The constructor is TS-private only; erased at runtime.
+        kernel2 = new WrapperKernel(ownModule);
+    }, 60_000);
+
+    it("decodes without any manual decoder registration", () => {
+        let thrown: any;
+        try {
+            kernel2.getVolume(99999);
+        } catch (e) {
+            thrown = e;
+        }
+        expect(thrown).toBeInstanceOf(OcctError);
+        expect(thrown.message).toContain("Invalid shape ID");
+        expect(thrown.code).toBe(OcctErrorCode.InvalidShapeId);
+    });
+
+    it("accepts a single-argument getBoundingBox — issue #223", () => {
+        const box = kernel2.makeBox(10, 20, 30);
+        const bbox = kernel2.getBoundingBox(box);
+        expect(bbox.xmax).toBeCloseTo(10);
+        expect(bbox.ymax).toBeCloseTo(20);
+        expect(bbox.zmax).toBeCloseTo(30);
+        expect(bbox).toEqual(kernel2.getBoundingBox(box, false));
+    });
+
+    it("releases its decoder on dispose", async () => {
+        const { wrap } = await import(resolve(__dirname, "../ts/src/types.ts"));
+        const raw = new ownModule.OcctKernel();
+        let thrown: any;
+        try {
+            raw.getVolume(99999);
+        } catch (e) {
+            thrown = e;
+        }
+        const rethrow = () => wrap("getVolume", () => {
+            throw thrown;
+        });
+
+        expect(() => rethrow()).toThrow(/Invalid shape ID/);
+        kernel2[Symbol.dispose]();
+        expect(() => rethrow()).toThrow(/\[object WebAssembly.Exception\]/);
+        raw.delete();
+    });
+});
+
+// ============================================================================
 // Type predicate methods
 // ============================================================================
 

--- a/test/new-features.test.ts
+++ b/test/new-features.test.ts
@@ -163,13 +163,14 @@ describe("OcctErrorCode classification", () => {
 //
 // Under -fwasm-exceptions a C++ throw reaches JS as a WebAssembly.Exception,
 // which is not an Error — stringifying it yields "[object WebAssembly.Exception]"
-// and the OCCT diagnostic is lost. OcctKernel.init() registers the Emscripten
-// getExceptionMessage helper so wrap() can recover what().
+// and the OCCT diagnostic is lost. Each kernel registers its module's
+// Emscripten getExceptionMessage helper so wrap() can recover what().
 // ============================================================================
 
 describe("wrap decodes WebAssembly.Exception", () => {
     let wrap: any;
     let addExceptionDecoder: any;
+    let otherModule: any;
     let release: Array<() => void> = [];
 
     const register = (decoder: any) => {
@@ -182,22 +183,17 @@ describe("wrap decodes WebAssembly.Exception", () => {
         const types = await import(resolve(__dirname, "../ts/src/types.ts"));
         wrap = types.wrap;
         addExceptionDecoder = types.addExceptionDecoder;
-    });
+
+        const createModule = (await import(jsPath)).default;
+        otherModule = await createModule({
+            locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
+        });
+    }, 60_000);
 
     afterEach(() => {
         release.forEach((off) => off());
         release = [];
     });
-
-    const filletCompound = () => {
-        // A boolean result is a TopoDS_Compound; fillet's TopoDS::Solid cast
-        // rejects it with Standard_TypeMismatch.
-        const fused = kernel.fuse(kernel.makeBox(20, 20, 20), kernel.makeCylinder(8, 30));
-        const edges = kernel.getSubShapes(fused, "edge");
-        const edgeVec = new Module.VectorUint32();
-        edgeVec.push_back(edges.get(0));
-        return () => kernel.fillet(fused, edgeVec, 1.0);
-    };
 
     const catchWrapped = (op: string, fn: () => unknown) => {
         try {
@@ -208,9 +204,25 @@ describe("wrap decodes WebAssembly.Exception", () => {
         return undefined;
     };
 
+    // releaseAll() frees arena shapes but not Embind vectors, so delete those here.
+    const catchFilletCompound = () => {
+        // A boolean result is a TopoDS_Compound; fillet's TopoDS::Solid cast
+        // rejects it with Standard_TypeMismatch.
+        const fused = kernel.fuse(kernel.makeBox(20, 20, 20), kernel.makeCylinder(8, 30));
+        const edges = kernel.getSubShapes(fused, "edge");
+        const edgeVec = new Module.VectorUint32();
+        edgeVec.push_back(edges.get(0));
+        try {
+            return catchWrapped("fillet", () => kernel.fillet(fused, edgeVec, 1.0));
+        } finally {
+            edgeVec.delete();
+            edges.delete();
+        }
+    };
+
     it("recovers the OCCT message when a decoder is registered", () => {
         register((e: unknown) => Module.getExceptionMessage(e));
-        const err = catchWrapped("fillet", filletCompound());
+        const err = catchFilletCompound();
         expect(err).toBeInstanceOf(OcctError);
         expect(err.message).not.toContain("[object WebAssembly.Exception]");
         expect(err.message).toContain("TopoDS::Solid");
@@ -219,13 +231,13 @@ describe("wrap decodes WebAssembly.Exception", () => {
 
     it("does not repeat the operation name already prefixed by the facade", () => {
         register((e: unknown) => Module.getExceptionMessage(e));
-        const err = catchWrapped("fillet", filletCompound());
+        const err = catchFilletCompound();
         expect(err.message.startsWith("fillet: fillet:")).toBe(false);
         expect(err.message).toBe("fillet: TopoDS::Solid");
     });
 
     it("still produces an OcctError when no decoder is registered", () => {
-        const err = catchWrapped("fillet", filletCompound());
+        const err = catchFilletCompound();
         expect(err).toBeInstanceOf(OcctError);
         expect(err.code).toBe(OcctErrorCode.KernelError);
     });
@@ -234,7 +246,7 @@ describe("wrap decodes WebAssembly.Exception", () => {
         register(() => {
             throw new Error("decoder blew up");
         });
-        const err = catchWrapped("fillet", filletCompound());
+        const err = catchFilletCompound();
         expect(err).toBeInstanceOf(OcctError);
         expect(err.message).not.toContain("decoder blew up");
     });
@@ -247,43 +259,47 @@ describe("wrap decodes WebAssembly.Exception", () => {
         expect(err.message).toBe("makeBox: construction failed");
     });
 
+    // The headline effect: classifyError matches on the message, so without
+    // decoding every message-pattern branch was unreachable through wrap() and
+    // real kernel errors only ever got the operation-category fallback.
+    it("restores message-based error codes", () => {
+        const undecoded = catchWrapped("getVolume", () => kernel.getVolume(99999));
+        expect(undecoded.code).toBe(OcctErrorCode.KernelError);
+
+        register((e: unknown) => Module.getExceptionMessage(e));
+        const decoded = catchWrapped("getVolume", () => kernel.getVolume(99999));
+        expect(decoded.message).toContain("Invalid shape ID");
+        expect(decoded.code).toBe(OcctErrorCode.InvalidShapeId);
+    });
+
     it("stops decoding once its registration is released", () => {
         const off = register((e: unknown) => Module.getExceptionMessage(e));
-        expect(catchWrapped("fillet", filletCompound()).message).toBe("fillet: TopoDS::Solid");
+        expect(catchFilletCompound().message).toBe("fillet: TopoDS::Solid");
         off();
-        expect(catchWrapped("fillet", filletCompound()).message).toContain(
+        expect(catchFilletCompound().message).toContain(
             "[object WebAssembly.Exception]",
         );
     });
 
     // A second kernel must not blind the first: each registers its own
     // module-bound decoder, and a foreign module's getArg rejects the tag.
-    it("still decodes when another module's decoder is registered first", async () => {
-        const createModule = (await import(jsPath)).default;
-        const other = await createModule({
-            locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
-        });
-        expect(other).not.toBe(Module);
+    it("still decodes when another module's decoder is registered first", () => {
+        expect(otherModule).not.toBe(Module);
 
-        register((e: unknown) => other.getExceptionMessage(e));
+        register((e: unknown) => otherModule.getExceptionMessage(e));
         register((e: unknown) => Module.getExceptionMessage(e));
 
-        const err = catchWrapped("fillet", filletCompound());
+        const err = catchFilletCompound();
         expect(err.message).toBe("fillet: TopoDS::Solid");
-    }, 60_000);
+    });
 
-    it("decodes regardless of decoder registration order", async () => {
-        const createModule = (await import(jsPath)).default;
-        const other = await createModule({
-            locateFile: (path: string) => (path.endsWith(".wasm") ? wasmPath : path),
-        });
-
+    it("still decodes when another module's decoder is registered last", () => {
         register((e: unknown) => Module.getExceptionMessage(e));
-        register((e: unknown) => other.getExceptionMessage(e));
+        register((e: unknown) => otherModule.getExceptionMessage(e));
 
-        const err = catchWrapped("fillet", filletCompound());
+        const err = catchFilletCompound();
         expect(err.message).toBe("fillet: TopoDS::Solid");
-    }, 60_000);
+    });
 });
 
 // ============================================================================

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1229,12 +1229,15 @@ export class OcctKernel {
      * geometry by ~0.27·r for arcs of radius r — that was the source of the
      * uniform 1.2 mm bounds shift versus brepjs in occt-wasm 2.0.
      *
-     * @param useTriangulation - If `true`, use existing triangulation as the
-     *     starting bound and refine via surface analysis (faster). If `false`
-     *     (the default), do the surface analysis from scratch (slower, but
-     *     doesn't depend on prior tessellation). Both modes produce tight
-     *     bounds; brepjs's `BRepBndLib.Add(shape, box, true)` corresponds to
-     *     `true` here.
+     * @param useTriangulation - `false` (the default) does the surface analysis
+     *     from scratch, giving the same bounds whether or not the shape has been
+     *     tessellated. `true` bounds an existing triangulation instead, which is
+     *     far faster but only as tight as that mesh — on a 2.0-deflection mesh
+     *     it overshot a 26 mm extent by 1.8 mm, and on a 0.1-deflection mesh by
+     *     0.16 mm. With no triangulation present the two agree exactly and cost
+     *     the same, so `true` is worth it only when you have a fine mesh and
+     *     want the ~30x faster query. brepjs's
+     *     `BRepBndLib.Add(shape, box, true)` corresponds to `true` here.
      */
     getBoundingBox(shape: ShapeHandle, useTriangulation = false): BoundingBox {
         return wrap("getBoundingBox", () => this.#raw.getBoundingBox(shape, useTriangulation));

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -90,7 +90,7 @@ import type {
     UVBounds,
     Vec3,
 } from "./types.js";
-import { JoinType, SweepMode, TransitionMode, wrap } from "./types.js";
+import { JoinType, SweepMode, TransitionMode, setExceptionDecoder, wrap } from "./types.js";
 import { SHAPE_TYPES, SHAPE_ORIENTATIONS, POINT_CLASSIFICATIONS } from "./types.js";
 import type {
     OcctWasmModule,
@@ -167,6 +167,8 @@ export class OcctKernel {
     private constructor(module: OcctWasmModule) {
         this.#module = module;
         this.#raw = new module.OcctKernel();
+        const decode = module.getExceptionMessage;
+        setExceptionDecoder(decode ? (e) => decode.call(module, e) : undefined);
         kernelRegistry.register(this, this.#raw, this);
     }
 
@@ -1224,12 +1226,13 @@ export class OcctKernel {
      * uniform 1.2 mm bounds shift versus brepjs in occt-wasm 2.0.
      *
      * @param useTriangulation - If `true`, use existing triangulation as the
-     *     starting bound and refine via surface analysis (faster). If `false`,
-     *     do the surface analysis from scratch (slower, but doesn't depend on
-     *     prior tessellation). Both modes produce tight bounds; brepjs's
-     *     `BRepBndLib.Add(shape, box, true)` corresponds to `true` here.
+     *     starting bound and refine via surface analysis (faster). If `false`
+     *     (the default), do the surface analysis from scratch (slower, but
+     *     doesn't depend on prior tessellation). Both modes produce tight
+     *     bounds; brepjs's `BRepBndLib.Add(shape, box, true)` corresponds to
+     *     `true` here.
      */
-    getBoundingBox(shape: ShapeHandle, useTriangulation: boolean): BoundingBox {
+    getBoundingBox(shape: ShapeHandle, useTriangulation = false): BoundingBox {
         return wrap("getBoundingBox", () => this.#raw.getBoundingBox(shape, useTriangulation));
     }
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -90,7 +90,7 @@ import type {
     UVBounds,
     Vec3,
 } from "./types.js";
-import { JoinType, SweepMode, TransitionMode, setExceptionDecoder, wrap } from "./types.js";
+import { JoinType, SweepMode, TransitionMode, addExceptionDecoder, wrap } from "./types.js";
 import { SHAPE_TYPES, SHAPE_ORIENTATIONS, POINT_CLASSIFICATIONS } from "./types.js";
 import type {
     OcctWasmModule,
@@ -139,7 +139,11 @@ function asEnum<T extends string>(value: string, allowed: ReadonlySet<string>, l
  * garbage-collected without being disposed. Prefer `using` or explicit
  * `kernel[Symbol.dispose]()` — the FinalizationRegistry is a last resort.
  */
-const kernelRegistry = new FinalizationRegistry<OcctRawKernel>((raw) => {
+const kernelRegistry = new FinalizationRegistry<{
+    raw: OcctRawKernel;
+    releaseDecoder: () => void;
+}>(({ raw, releaseDecoder }) => {
+    releaseDecoder();
     try {
         raw.releaseAll();
         raw.delete();
@@ -163,13 +167,20 @@ const kernelRegistry = new FinalizationRegistry<OcctRawKernel>((raw) => {
 export class OcctKernel {
     readonly #raw: OcctRawKernel;
     readonly #module: OcctWasmModule;
+    readonly #releaseDecoder: () => void;
 
     private constructor(module: OcctWasmModule) {
         this.#module = module;
         this.#raw = new module.OcctKernel();
         const decode = module.getExceptionMessage;
-        setExceptionDecoder(decode ? (e) => decode.call(module, e) : undefined);
-        kernelRegistry.register(this, this.#raw, this);
+        this.#releaseDecoder = decode
+            ? addExceptionDecoder((e) => decode.call(module, e))
+            : () => {};
+        kernelRegistry.register(
+            this,
+            { raw: this.#raw, releaseDecoder: this.#releaseDecoder },
+            this,
+        );
     }
 
     /**
@@ -1920,6 +1931,7 @@ export class OcctKernel {
 
     [Symbol.dispose](): void {
         kernelRegistry.unregister(this);
+        this.#releaseDecoder();
         try {
             this.#raw.releaseAll();
             this.#raw.delete();

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -172,15 +172,8 @@ export class OcctKernel {
     private constructor(module: OcctWasmModule) {
         this.#module = module;
         this.#raw = new module.OcctKernel();
-        const decode = module.getExceptionMessage;
-        this.#releaseDecoder = decode
-            ? addExceptionDecoder((e) => decode.call(module, e))
-            : () => {};
-        kernelRegistry.register(
-            this,
-            { raw: this.#raw, releaseDecoder: this.#releaseDecoder },
-            this,
-        );
+        this.#releaseDecoder = addExceptionDecoder((e) => module.getExceptionMessage?.(e));
+        kernelRegistry.register(this, { raw: this.#raw, releaseDecoder: this.#releaseDecoder }, this);
     }
 
     /**

--- a/ts/src/raw-types.ts
+++ b/ts/src/raw-types.ts
@@ -35,6 +35,11 @@ export interface OcctWasmModule {
     HEAPU32: Uint32Array;
     HEAP32: Int32Array;
     FS: EmscriptenFS;
+    /**
+     * Emscripten helper exported by `-sEXPORT_EXCEPTION_HANDLING_HELPERS=1`.
+     * Decodes a thrown `WebAssembly.Exception` into `[type, what()]`.
+     */
+    getExceptionMessage?(e: unknown): [type: string, message: string];
 }
 
 export interface RawMeshData {

--- a/ts/src/svg.ts
+++ b/ts/src/svg.ts
@@ -17,7 +17,7 @@ import type { BoundingBox, ProjectionData, ShapeHandle, Vec3 } from "./types.js"
 
 /** The subset of the kernel API the SVG renderer depends on. */
 export interface SvgKernel {
-    getBoundingBox(shape: ShapeHandle, useTriangulation: boolean): BoundingBox;
+    getBoundingBox(shape: ShapeHandle, useTriangulation?: boolean): BoundingBox;
     projectEdges(
         shape: ShapeHandle,
         viewOrigin: Vec3,

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -420,20 +420,14 @@ function classifyError(operation: string, message: string): OcctErrorCode {
     return OcctErrorCode.Unknown;
 }
 
-/**
- * Decoder for the `WebAssembly.Exception` objects that `-fwasm-exceptions`
- * throws. Reading their payload needs the Emscripten module's memory and
- * exception tag, so a kernel registers its own module here on construction.
- */
 type ExceptionDecoder = (e: unknown) => [type: string, message: string] | null | undefined;
 
 /**
- * Every live kernel's decoder. Kernels can coexist, each over its own
- * Emscripten module, so a single slot would let the newest kernel make the
- * older ones' exceptions unreadable again. Decoding against the wrong module
- * fails loudly — `WebAssembly.Exception.getArg` rejects a foreign tag — so
- * trying each in turn resolves to the owning module rather than to a wrong
- * message.
+ * Every live kernel's decoder. Decoding a `WebAssembly.Exception` needs the
+ * throwing Emscripten module's memory and exception tag, and kernels over
+ * separate modules can coexist — so decoders accumulate rather than replace,
+ * and each is tried in turn. A foreign module can't return a wrong message:
+ * `WebAssembly.Exception.getArg` rejects a tag it doesn't own.
  */
 const exceptionDecoders = new Set<ExceptionDecoder>();
 
@@ -450,10 +444,9 @@ export function addExceptionDecoder(decoder: ExceptionDecoder): () => void {
 }
 
 /**
- * Best-effort message extraction for a thrown value. A C++ exception crossing
- * the Embind boundary under wasm exception handling is a `WebAssembly.Exception`,
- * not an `Error` — stringifying it yields the useless `[object
- * WebAssembly.Exception]`, so decode it when a decoder is available.
+ * Best-effort message extraction for a thrown value. Under `-fwasm-exceptions`
+ * a C++ throw crosses the Embind boundary as a `WebAssembly.Exception` rather
+ * than an `Error`, and stringifies to a useless `[object WebAssembly.Exception]`.
  */
 function messageOf(e: unknown): string {
     if (e instanceof Error) return e.message;
@@ -462,8 +455,8 @@ function messageOf(e: unknown): string {
             const decoded = decoder(e);
             if (decoded?.[1]) return decoded[1];
         } catch {
-            // Wrong module, or no helper — try the next one. Decoding is
-            // diagnostics-only, so exhausting them just means stringification.
+            // Wrong module, or no helper — decoding is diagnostics-only, so
+            // exhausting every decoder just falls back to stringification.
         }
     }
     return String(e);
@@ -487,8 +480,11 @@ export function wrap<T>(operation: string, fn: () => T): T {
         }
         // The C++ facade already prefixes its throws with the method name, and
         // OcctError prepends it again — drop the duplicate.
-        const raw = messageOf(e);
+        const message = messageOf(e);
         const prefix = `${operation}: `;
-        throw new OcctError(operation, raw.startsWith(prefix) ? raw.slice(prefix.length) : raw);
+        throw new OcctError(
+            operation,
+            message.startsWith(prefix) ? message.slice(prefix.length) : message,
+        );
     }
 }

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -427,14 +427,26 @@ function classifyError(operation: string, message: string): OcctErrorCode {
  */
 type ExceptionDecoder = (e: unknown) => [type: string, message: string] | null | undefined;
 
-let exceptionDecoder: ExceptionDecoder | undefined;
+/**
+ * Every live kernel's decoder. Kernels can coexist, each over its own
+ * Emscripten module, so a single slot would let the newest kernel make the
+ * older ones' exceptions unreadable again. Decoding against the wrong module
+ * fails loudly — `WebAssembly.Exception.getArg` rejects a foreign tag — so
+ * trying each in turn resolves to the owning module rather than to a wrong
+ * message.
+ */
+const exceptionDecoders = new Set<ExceptionDecoder>();
 
 /**
- * Register the module-backed decoder used to recover C++ `what()` strings from
- * thrown `WebAssembly.Exception` objects.
+ * Register a module-backed decoder used to recover C++ `what()` strings from
+ * thrown `WebAssembly.Exception` objects. Returns a function that unregisters
+ * it, which the kernel calls on disposal so the module isn't retained.
  */
-export function setExceptionDecoder(decoder: ExceptionDecoder | undefined): void {
-    exceptionDecoder = decoder;
+export function addExceptionDecoder(decoder: ExceptionDecoder): () => void {
+    exceptionDecoders.add(decoder);
+    return () => {
+        exceptionDecoders.delete(decoder);
+    };
 }
 
 /**
@@ -445,12 +457,13 @@ export function setExceptionDecoder(decoder: ExceptionDecoder | undefined): void
  */
 function messageOf(e: unknown): string {
     if (e instanceof Error) return e.message;
-    if (exceptionDecoder) {
+    for (const decoder of exceptionDecoders) {
         try {
-            const decoded = exceptionDecoder(e);
+            const decoded = decoder(e);
             if (decoded?.[1]) return decoded[1];
         } catch {
-            // Decoding is diagnostics-only; fall through to stringification.
+            // Wrong module, or no helper — try the next one. Decoding is
+            // diagnostics-only, so exhausting them just means stringification.
         }
     }
     return String(e);

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -421,6 +421,42 @@ function classifyError(operation: string, message: string): OcctErrorCode {
 }
 
 /**
+ * Decoder for the `WebAssembly.Exception` objects that `-fwasm-exceptions`
+ * throws. Reading their payload needs the Emscripten module's memory and
+ * exception tag, so a kernel registers its own module here on construction.
+ */
+type ExceptionDecoder = (e: unknown) => [type: string, message: string] | null | undefined;
+
+let exceptionDecoder: ExceptionDecoder | undefined;
+
+/**
+ * Register the module-backed decoder used to recover C++ `what()` strings from
+ * thrown `WebAssembly.Exception` objects.
+ */
+export function setExceptionDecoder(decoder: ExceptionDecoder | undefined): void {
+    exceptionDecoder = decoder;
+}
+
+/**
+ * Best-effort message extraction for a thrown value. A C++ exception crossing
+ * the Embind boundary under wasm exception handling is a `WebAssembly.Exception`,
+ * not an `Error` — stringifying it yields the useless `[object
+ * WebAssembly.Exception]`, so decode it when a decoder is available.
+ */
+function messageOf(e: unknown): string {
+    if (e instanceof Error) return e.message;
+    if (exceptionDecoder) {
+        try {
+            const decoded = exceptionDecoder(e);
+            if (decoded?.[1]) return decoded[1];
+        } catch {
+            // Decoding is diagnostics-only; fall through to stringification.
+        }
+    }
+    return String(e);
+}
+
+/**
  * Run `fn`, re-throwing any failure as an {@link OcctError} tagged with the
  * given operation name. Shared by the kernel and the XCAF document so error
  * classification stays in one place.
@@ -436,9 +472,10 @@ export function wrap<T>(operation: string, fn: () => T): T {
             // ImportExportFailed down to KernelError.
             throw new OcctError(operation, e.message, e.code);
         }
-        if (e instanceof Error) {
-            throw new OcctError(operation, e.message);
-        }
-        throw new OcctError(operation, String(e));
+        // The C++ facade already prefixes its throws with the method name, and
+        // OcctError prepends it again — drop the duplicate.
+        const raw = messageOf(e);
+        const prefix = `${operation}: `;
+        throw new OcctError(operation, raw.startsWith(prefix) ? raw.slice(prefix.length) : raw);
     }
 }

--- a/ts/src/worker.ts
+++ b/ts/src/worker.ts
@@ -242,7 +242,7 @@ export class OcctWorker {
     exportStep(shape: ShapeHandle) { return this.#proxy.exportStep(shape); }
     cacheStep(data: string | ArrayBuffer) { return this.#proxy.cacheStep(data); }
     loadCached(brep: string) { return this.#proxy.loadCached(brep); }
-    getBoundingBox(shape: ShapeHandle, useTriangulation = false) { return this.#proxy.getBoundingBox(shape, useTriangulation); }
+    getBoundingBox(shape: ShapeHandle, useTriangulation?: boolean) { return this.#proxy.getBoundingBox(shape, useTriangulation); }
     getVolume(shape: ShapeHandle) { return this.#proxy.getVolume(shape); }
     getSurfaceArea(shape: ShapeHandle) { return this.#proxy.getSurfaceArea(shape); }
     getShapeType(shape: ShapeHandle) { return this.#proxy.getShapeType(shape); }

--- a/ts/src/worker.ts
+++ b/ts/src/worker.ts
@@ -121,7 +121,7 @@ export interface OcctWorkerProxy {
     loadCached(brep: string): Promise<ShapeHandle>;
 
     // Query
-    getBoundingBox(shape: ShapeHandle, useTriangulation: boolean): Promise<BoundingBox>;
+    getBoundingBox(shape: ShapeHandle, useTriangulation?: boolean): Promise<BoundingBox>;
     getVolume(shape: ShapeHandle): Promise<number>;
     getSurfaceArea(shape: ShapeHandle): Promise<number>;
     getLength(shape: ShapeHandle): Promise<number>;
@@ -242,7 +242,7 @@ export class OcctWorker {
     exportStep(shape: ShapeHandle) { return this.#proxy.exportStep(shape); }
     cacheStep(data: string | ArrayBuffer) { return this.#proxy.cacheStep(data); }
     loadCached(brep: string) { return this.#proxy.loadCached(brep); }
-    getBoundingBox(shape: ShapeHandle, useTriangulation: boolean) { return this.#proxy.getBoundingBox(shape, useTriangulation); }
+    getBoundingBox(shape: ShapeHandle, useTriangulation = false) { return this.#proxy.getBoundingBox(shape, useTriangulation); }
     getVolume(shape: ShapeHandle) { return this.#proxy.getVolume(shape); }
     getSurfaceArea(shape: ShapeHandle) { return this.#proxy.getSurfaceArea(shape); }
     getShapeType(shape: ShapeHandle) { return this.#proxy.getShapeType(shape); }

--- a/ts/src/xcaf-document.ts
+++ b/ts/src/xcaf-document.ts
@@ -14,6 +14,11 @@
  * const glb = doc.exportGLTF(Module);
  * doc.close();
  * ```
+ *
+ * Prefer `kernel.createXCAFDocument()` over the static factories. Constructing
+ * from a bare raw kernel works, but only a live {@link OcctKernel} registers the
+ * module's exception decoder — without one, a failure here reports the
+ * undecoded `[object WebAssembly.Exception]` and downgrades to `KERNEL_ERROR`.
  */
 
 import type {
@@ -238,10 +243,11 @@ export class XCAFDocument {
 
     /** Close the document and free OCCT resources. */
     close(): void {
-        if (!this.#closed) {
-            this.#raw.xcafClose(this.#docId);
-            this.#closed = true;
-        }
+        if (this.#closed) return;
+        // Mark closed before the call so a failing close isn't retried by
+        // Symbol.dispose, which would throw again during stack unwinding.
+        this.#closed = true;
+        wrap("xcafClose", () => this.#raw.xcafClose(this.#docId));
     }
 
     [Symbol.dispose](): void {


### PR DESCRIPTION
Closes #223.

The reported issue is one broken README snippet, but it turned out to sit on top of three separate defects.

## 1. Every OCCT error message was unreadable

Under `-fwasm-exceptions` a C++ throw reaches JS as a `WebAssembly.Exception`, which is **not** an `Error` — so `wrap()` fell through to `String(e)` and produced `[object WebAssembly.Exception]` for every failure in the library.

The build already sets `-sEXPORT_EXCEPTION_HANDLING_HELPERS=1`, so `Module.getExceptionMessage` was available but never wired up. The kernel now registers it on construction and `wrap()` decodes the payload:

```
OcctError: fillet: TopoDS::Solid          // was: fillet: [object WebAssembly.Exception]
OcctError: fillet: There are no suitable edges for chamfer or fillet
```

The decoder is registered in the private constructor (the one chokepoint every `OcctKernel` passes through, and where the module reference lands). Decoding is diagnostics-only and guarded — a missing or throwing decoder falls back to the previous stringification.

## 2. `getBoundingBox` failed to compile with the documented call

`useTriangulation` was required, so the README's `kernel.getBoundingBox(shape)` raised TS2554. It now defaults to `false`, matching what every internal caller passes. Also relaxed in `worker.ts` and the `SvgKernel` interface.

## 3. The quick start could never have worked

Two independent reasons:

- `fuse` returns a `TopoDS_Compound` — OCCT wraps all `BRepAlgoAPI` output that way, since a boolean may yield disjoint solids — and `fillet` does a checked `TopoDS::Solid` downcast that rejects it.
- `edges.slice(0, 4)` picked the cylinder's seam/degenerate edges. Only 13 of that shape's 20 edges are filletable at *any* radius.

Reordered to fillet the box before fusing, plus a README note covering both traps.

The `three-js` and `step-viewer` demos hit the same compound trap, hidden behind a `try { fillet } catch { result = fused }` fallback — meaning those demos have never actually filleted anything. `node-cli` was already correct ("before booleans, more reliable").

## Scope

Deliberately TS + docs only. Making `fillet` unwrap a single-solid compound in the facade would be the deeper fix, but it invalidates the committed `crate/src/occt-wasm.wasm.br` and trips CI's stale-check — better as its own PR.

## Verification

- 346 tests pass, including 5 new ones covering the decode path, the operation-prefix dedup, a missing decoder, a throwing decoder, and plain `Error` passthrough.
- `tsgo --noEmit` and `eslint` clean.
- Compiled the corrected snippet against the built `dist/index.d.ts` in a separate project — the exact reproduction from the issue — and it type-checks.
- Ran each corrected example's operation sequence against the real kernel to confirm the fillets now succeed rather than silently falling back.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode wasm exceptions to surface real OCCT error messages in `occt-wasm`, fix the quick start so fillet actually runs, make `getBoundingBox` exact by default, and improve XCAF close errors. This also covers the broken README snippet and compound/edge traps in #223.

- **Bug Fixes**
  - Exceptions: per-kernel registration of `Module.getExceptionMessage`; `wrap()` decodes `WebAssembly.Exception`, avoids double operation prefixes, restores message-based `OcctErrorCode` (e.g., InvalidShapeId), tries decoders across modules, and releases them on dispose/GC.
  - API: `getBoundingBox(shape, useTriangulation = false)`; worker forwards the optional flag and `SvgKernel` accepts it as optional. `XCAFDocument.close()` now uses `wrap()` and marks closed before calling to report proper operation/code and avoid re-entry.
  - Examples: `three-js` and `step-viewer` fillet a solid before fuse and remove the silent try/catch fallback.

- **Docs**
  - Quick start: fillet the box before fuse; note boolean results are `TopoDS_Compound`; list ops that require a solid (`fillet`, `chamfer`, `filletVariable`, `filletBatch`, `healSolid`); clarify edge-selection advice; fix snippets to typecheck under `noUncheckedIndexedAccess`.
  - Errors and bounds: explain that `OcctWorker` errors cross as plain `Error` (message only; code/operation/instanceof lost); correct the bounding-box tradeoff—`false` is exact; `true` uses triangulation and can overshoot but is faster when a mesh exists. Recommend `kernel.createXCAFDocument()` since static factories don’t register exception decoding.

<sup>Written for commit 4f740f06d4ce4ca8f24f6b610d3522277dab683f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

