### PR TITLE
ci: vendor three so the demo specs need no CDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "husky": "^9",
         "opencascade.js": "^1.1.1",
         "serve": "^14.2.6",
+        "three": "0.172.0",
         "vitest": "^4.1.10"
       }
     },
@@ -2877,6 +2878,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.172.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
+      "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "husky": "^9",
     "opencascade.js": "^1.1.1",
     "serve": "^14.2.6",
+    "three": "0.172.0",
     "vitest": "^4.1.10"
   }
 }

--- a/test/browser/examples.spec.ts
+++ b/test/browser/examples.spec.ts
@@ -8,6 +8,8 @@
  * demo fails instead of passing quietly.
  */
 import { test, expect, type Page } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import { join, normalize } from "node:path";
 
 // Both demos construct a THREE.WebGLRenderer before touching OCCT, and headless
 // Firefox ships no software WebGL backend — `getContext("webgl")` returns null
@@ -19,6 +21,54 @@ test.skip(({ browserName }) => browserName === "firefox", "headless Firefox has 
 // Cold WASM compile dominates; the smoke test uses the same headroom.
 const LOAD_TIMEOUT = 50_000;
 
+// `three` does not export ./package.json, so resolve the root by layout.
+const THREE_ROOT = normalize(join(import.meta.dirname, "../../node_modules/three"));
+const CDN_PREFIX = /^https:\/\/cdn\.jsdelivr\.net\/npm\/three@[\d.]+\//;
+
+const MIME: Record<string, string> = {
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".wasm": "application/wasm",
+};
+
+/**
+ * Serve the demos' Three.js imports from the vendored copy, and fail on any
+ * other outbound request. The demos import Three from a CDN so a reader can
+ * open them straight from disk, but CI must not depend on a third party being
+ * up — and blocking the rest turns "we vendored it" into something the suite
+ * actually proves rather than something we assert in a comment.
+ */
+async function serveThreeLocally(page: Page, offences: string[]): Promise<void> {
+    await page.route(/^https?:\/\//, async (route) => {
+        const url = route.request().url();
+        if (url.startsWith("http://localhost:3000/")) return route.continue();
+
+        const match = url.match(CDN_PREFIX);
+        if (!match) {
+            offences.push(url);
+            return route.abort();
+        }
+
+        const rest = url.slice(match[0].length).split(/[?#]/)[0] ?? "";
+        const file = normalize(join(THREE_ROOT, rest));
+        // Keep a crafted path from reaching outside the package.
+        if (!file.startsWith(THREE_ROOT)) {
+            offences.push(`escapes package root: ${url}`);
+            return route.abort();
+        }
+        try {
+            const ext = file.slice(file.lastIndexOf("."));
+            return await route.fulfill({
+                body: await readFile(file),
+                contentType: MIME[ext] ?? "application/octet-stream",
+            });
+        } catch {
+            offences.push(`not vendored: ${url}`);
+            return route.abort();
+        }
+    });
+}
+
 function collectErrors(page: Page): string[] {
     const errors: string[] = [];
     page.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
@@ -28,8 +78,22 @@ function collectErrors(page: Page): string[] {
     return errors;
 }
 
+test("the vendored three matches the version the demos import", async () => {
+    const { version } = JSON.parse(await readFile(join(THREE_ROOT, "package.json"), "utf8"));
+    for (const demo of ["three-js", "step-viewer"]) {
+        const html = await readFile(join(import.meta.dirname, `../../examples/${demo}/index.html`), "utf8");
+        const pinned = html.match(/cdn\.jsdelivr\.net\/npm\/three@([\d.]+)\//)?.[1];
+        expect(pinned, `${demo} should pin a three version`).toBeTruthy();
+        // Bumping the demo's CDN pin without bumping the devDependency would
+        // leave CI testing a different Three than readers actually load.
+        expect(pinned, `${demo} pins three@${pinned}, vendored is ${version}`).toBe(version);
+    }
+});
+
 test("three-js example builds, tessellates, and loads glTF", async ({ page }) => {
     const errors = collectErrors(page);
+    const offences: string[] = [];
+    await serveThreeLocally(page, offences);
 
     await page.goto("http://localhost:3000/examples/three-js/index.html");
 
@@ -46,10 +110,13 @@ test("three-js example builds, tessellates, and loads glTF", async ({ page }) =>
     expect(triangles).toBeGreaterThan(500);
 
     expect(errors).toEqual([]);
+    expect(offences, "demo reached the network").toEqual([]);
 });
 
 test("step-viewer example loads its demo shape", async ({ page }) => {
     const errors = collectErrors(page);
+    const offences: string[] = [];
+    await serveThreeLocally(page, offences);
 
     await page.goto("http://localhost:3000/examples/step-viewer/index.html");
 
@@ -71,4 +138,5 @@ test("step-viewer example loads its demo shape", async ({ page }) => {
     expect(Number(text.match(/([\d,]+) triangles/)?.[1]?.replace(/,/g, "") ?? 0)).toBeGreaterThan(100);
 
     expect(errors).toEqual([]);
+    expect(offences, "demo reached the network").toEqual([]);
 });


### PR DESCRIPTION
Follow-up to #227, which left CI depending on jsdelivr being up.

## What changed

`three` is a devDependency now, pinned **exactly** (`0.172.0`, not `^0.172.0`) so the vendored copy cannot drift from the version the demos name. The specs route the CDN URLs to it via `page.route`.

The demos keep their CDN importmap — that is what lets a reader open one straight from disk — so only the tests are redirected. Nothing about the examples themselves changes.

## The interception is proven, not asserted

Two things could have made this change cosmetic, so both are checked:

**Is the route actually serving the files?** The specs passed before vendoring too, so passing proves nothing on its own. I forced the handler to abort the Three requests: both demos fail (`""` and `"Ready. Waiting for WASM..."`). The local copy really is what serves them.

**Does anything else still reach the network?** The handler aborts every non-localhost request that is not the Three CDN and records it, and both specs assert that list is empty. "No network dependency" is now demonstrated by the suite rather than claimed in a comment.

## Version drift would otherwise be silent

Because the URL match is version-agnostic, bumping a demo's CDN pin leaves the specs happily serving the *old* vendored copy — CI passes while testing a different Three than readers load.

Confirmed by bumping three-js to `three@0.180.0`: **both demo specs still passed**, and only the new version check caught it —

```
three-js pins three@0.180.0, vendored is 0.172.0
```

That check reads the pin out of each demo's importmap and compares it to the installed package.

## Notes

- `three` does not export `./package.json`, so the package root is resolved by layout rather than `require.resolve`.
- The `browser-smoke` job already runs `npm ci` at the root, so no workflow change was needed.
- Locally: 5 passed, 3 skipped (Firefox, per #227 — no headless WebGL).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendor Three.js for demo tests so CI no longer depends on a CDN and versions can’t drift. Tests now serve Three from a pinned local devDependency and block all external network calls.

- **Dependencies**
  - Added `three` as a devDependency pinned to `0.172.0`.
  - No workflow changes; existing `npm ci` covers it.

- **Refactors**
  - Playwright routes Three CDN URLs to the local `node_modules` copy; all other non-localhost requests are aborted and fail the test.
  - Added a check to ensure each demo’s CDN pin matches the installed `three` version.
  - Demos remain unchanged (keep CDN importmap) so they still open from disk.

<sup>Written for commit 2bf3209ce224844097a446eefca617014fcea1af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

