### PR TITLE
ci: give firefox a display so it covers the demos too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,14 @@ jobs:
       - name: Install Playwright
         run: npx playwright install chromium firefox --with-deps
 
+      # Firefox exposes WebGL only against a real display, so the demo specs
+      # need one; Mesa's llvmpipe supplies the driver behind it. Chromium is
+      # unaffected — it falls back to SwiftShader either way.
+      - name: Install virtual display + software GL
+        run: sudo apt-get update && sudo apt-get install -y xvfb libgl1-mesa-dri mesa-utils
+
+      # xvfb-run sets DISPLAY, which flips the Firefox project to headed
+      # (playwright.config.ts). Without it the demo specs fail rather than skip,
+      # so a broken display setup cannot quietly cost us the coverage.
       - name: Run browser smoke test
-        run: npx playwright test
+        run: xvfb-run -a --server-args="-screen 0 1280x1024x24" npx playwright test

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,24 @@ export default defineConfig({
     projects: [
         { name: "chromium", use: { ...devices["Desktop Chrome"] } },
         // Firefox 121+ ships WASM tail calls, the build's binding requirement.
-        { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+        {
+            name: "firefox",
+            use: {
+                ...devices["Desktop Firefox"],
+                // Chromium falls back to SwiftShader, but Firefox exposes WebGL
+                // only against a real display — headless it hands back a null
+                // context, and the demos die constructing their renderer. CI
+                // runs under xvfb-run, which provides one; DISPLAY is how we
+                // tell. Without it, stay headless and let the demo specs skip.
+                headless: !process.env["DISPLAY"],
+                launchOptions: {
+                    firefoxUserPrefs: {
+                        "webgl.force-enabled": true,
+                        "webgl.forbid-software": false,
+                    },
+                },
+            },
+        },
     ],
     webServer: {
         command: "npx serve . -l 3000 --no-clipboard",

--- a/test/browser/examples.spec.ts
+++ b/test/browser/examples.spec.ts
@@ -11,15 +11,32 @@ import { test, expect, type Page } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 import { join, normalize } from "node:path";
 
-// Both demos construct a THREE.WebGLRenderer before touching OCCT, and headless
-// Firefox ships no software WebGL backend — `getContext("webgl")` returns null
-// even with webgl.force-enabled, so the module script dies before the kernel is
-// ever exercised. Chromium's SwiftShader covers the geometry, which is the point
-// here; smoke.spec.ts still runs the WASM itself under both browsers.
-test.skip(({ browserName }) => browserName === "firefox", "headless Firefox has no WebGL");
-
 // Cold WASM compile dominates; the smoke test uses the same headroom.
 const LOAD_TIMEOUT = 50_000;
+
+/**
+ * Both demos construct a THREE.WebGLRenderer before touching OCCT, so without a
+ * WebGL context the module script dies before the kernel is ever exercised.
+ *
+ * Skipping locally keeps the suite runnable without a display, but skipping in
+ * CI would mean losing this coverage the moment the xvfb setup broke, and going
+ * green while doing it. So CI treats a missing context as the failure it is.
+ */
+async function requireWebGL(page: Page, browserName: string): Promise<void> {
+    await page.goto("about:blank");
+    const available = await page.evaluate(() => {
+        const canvas = document.createElement("canvas");
+        return Boolean(canvas.getContext("webgl2") ?? canvas.getContext("webgl"));
+    });
+    if (available) return;
+
+    const hint =
+        `${browserName} exposes no WebGL context. Firefox needs a real display: ` +
+        `run under xvfb-run, which sets DISPLAY and flips the project to headed ` +
+        `(see playwright.config.ts).`;
+    if (process.env["CI"]) throw new Error(hint);
+    test.skip(true, hint);
+}
 
 // `three` does not export ./package.json, so resolve the root by layout.
 const THREE_ROOT = normalize(join(import.meta.dirname, "../../node_modules/three"));
@@ -90,7 +107,8 @@ test("the vendored three matches the version the demos import", async () => {
     }
 });
 
-test("three-js example builds, tessellates, and loads glTF", async ({ page }) => {
+test("three-js example builds, tessellates, and loads glTF", async ({ page, browserName }) => {
+    await requireWebGL(page, browserName);
     const errors = collectErrors(page);
     const offences: string[] = [];
     await serveThreeLocally(page, offences);
@@ -113,7 +131,8 @@ test("three-js example builds, tessellates, and loads glTF", async ({ page }) =>
     expect(offences, "demo reached the network").toEqual([]);
 });
 
-test("step-viewer example loads its demo shape", async ({ page }) => {
+test("step-viewer example loads its demo shape", async ({ page, browserName }) => {
+    await requireWebGL(page, browserName);
     const errors = collectErrors(page);
     const offences: string[] = [];
     await serveThreeLocally(page, offences);


### PR DESCRIPTION
Restores the Firefox coverage that #227 gave up.

## Why it was skipped, and what actually fixes it

#227 skipped the demo specs on Firefox: headless Firefox exposes no WebGL context, and both demos construct a `THREE.WebGLRenderer` before touching OCCT, so the module script dies before the kernel is ever exercised.

I confirmed that is about the *display*, not the driver — forcing software GL (`LIBGL_ALWAYS_SOFTWARE=1`, `GALLIUM_DRIVER=llvmpipe`) alongside `webgl.force-enabled` still returns a null context headless. So the browser job now runs under `xvfb-run`, with Mesa's llvmpipe behind it.

## Design

- The Firefox project flips to headed **only when `DISPLAY` is set**. A contributor without a display still gets a working suite rather than a browser that refuses to launch.
- The skip is now a **capability probe** rather than a browser-name check, and it only skips **outside** CI.

That second point is the important one. Skipping in CI would mean silently losing this coverage the first moment the xvfb setup broke — green, and no longer testing anything. That is the exact failure mode this run of work has been about, so in CI a missing context raises instead, naming `xvfb-run` and the config file:

```
firefox exposes no WebGL context. Firefox needs a real display: run under
xvfb-run, which sets DISPLAY and flips the project to headed (see
playwright.config.ts).
```

## Verified

- Firefox skips cleanly without a display; Chromium unaffected (4 passed).
- With `CI=1`, the probe **fails** with the diagnostic instead of skipping — the anti-silent-pass path works.
- The version check no longer sits behind the browser skip, so it runs under both projects.

## What I could not verify locally

The xvfb path itself. There is no passwordless sudo on this machine to install Xvfb, so the runner is the first place it executes. The probe is deliberately written so that if this does not work, CI says exactly why rather than timing out on `#status`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Firefox coverage for demo specs by running Playwright under a real display in CI using `xvfb-run`. Add a WebGL capability probe that skips locally but fails in CI to prevent silent green runs.

- **Bug Fixes**
  - Run tests under `xvfb-run` and install `xvfb`, `libgl1-mesa-dri`, `mesa-utils` in CI; Chromium unaffected.
  - In `playwright.config.ts`, make Firefox headed only when `DISPLAY` is set and enable WebGL via prefs.
  - Replace browser-name skip with a WebGL runtime check; locally skips, in CI throws a clear error if no context.

<sup>Written for commit 1882a4274c0f7bda927ca0d5ab91ba0aa90bd218. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

