### PR TITLE
ci: ignore typescript major bumps in the ts npm group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,12 @@ updates:
     groups:
       npm:
         patterns: ["*"]
+    # tsgo (@typescript/native-preview) is the compiler; `typescript` is here
+    # only for eslint/typedoc's JS API, and @typescript-eslint peers on
+    # <6.1.0 — a TS 7 bump breaks `npm ci` with ERESOLVE.
+    ignore:
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]
     open-pull-requests-limit: 3
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
Dependabot proposed `typescript` `^6.0 → ^7.0` in #233, which took the whole group PR down with `npm ci` ERESOLVE.

The bump is wrong for this repo, and the reason isn't obvious from `package.json`:

- The type-checker is **`tsgo`**, from `@typescript/native-preview` — that's what `npm run typecheck` and the CI lint job invoke.
- `typescript` is in `devDependencies` only because **eslint and typedoc consume the JS-implemented compiler API**.
- `@typescript-eslint/*` v8 peers on `typescript >=4.8.4 <6.1.0`. v8.65.0's own changelog headline is *"add warning when TS 7 is detected"* — upstream isn't ready either.

So `typescript` should track TS 6 until typescript-eslint and typedoc support 7, independent of what the actual compiler does. This encodes that as an `ignore` rule so the constraint lives in config rather than only in CLAUDE.md prose, and so the other three bumps in the weekly group PR stop getting blocked by it.

Minor and patch `typescript` updates still flow through normally.

Follow-up: `@dependabot recreate` on #233 to reland it with just the eslint bumps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Dependabot to ignore major `typescript` bumps in the npm group. This prevents ERESOLVE during npm ci and keeps other weekly dependency updates flowing.

- **Dependencies**
  - Add `ignore` rule for `typescript` major updates; minor/patch still allowed.
  - Context: our type-checker is `tsgo` from `@typescript/native-preview`; `eslint`, `typedoc`, and `@typescript-eslint/*` depend on TS 6 and block TS 7.

<sup>Written for commit bf416868b0b1e806d8d5859fa650ead80a6bbd68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

