### PR TITLE
fix(deps): bump fast-uri and brace-expansion past their advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1614,9 +1614,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes the two open high-severity Dependabot alerts on `main`. Both are **dev-only transitives** of the root workspace — neither reaches the published npm package (`ts` ships `files: ["dist/"]`) or the Rust crate.

| Advisory | Package | Change | Reached via |
|---|---|---|---|
| [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) | `fast-uri` | 3.1.3 → 3.1.4 | `@commitlint/cli` → `@commitlint/config-validator` → `ajv` |
| [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | `brace-expansion` | 1.1.15 → 1.1.18 | `serve` → `serve-handler` → `minimatch@3` |

Produced with `npm update fast-uri brace-expansion --package-lock-only`. Lockfile-only, no manifest change, no breaking changes — both land inside the existing parent ranges.

### Known residual

`npm audit` additionally reports [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (`brace-expansion` unbounded-expansion OOM), which is **not** fixed here and is **not** one of the GitHub alerts. Its affected range is `<=5.0.7`, so the entire 1.x line is affected with no 1.x patch available. `minimatch@3.1.5` pins `brace-expansion: ^1.1.7`, so the only remedy npm offers is downgrading to `serve@6.5.8` — a breaking change to a local-demo-server devDependency, for a DoS in a tool we run by hand. Not worth it; leaving as-is deliberately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates dev-only transient dependencies to resolve two high-severity advisories. Lockfile-only; no impact on the published npm package or the Rust crate.

- **Dependencies**
  - Bumped `fast-uri` 3.1.3 → 3.1.4 (via `@commitlint/cli` → `@commitlint/config-validator` → `ajv`).
  - Bumped `brace-expansion` 1.1.15 → 1.1.18 (via `serve` → `serve-handler` → `minimatch@3`).

<sup>Written for commit 3278c81a3fa4a1c4d9023ed6fb111db13c4b6d40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

