### PR TITLE
ci(bench): upload benchmark results as an artifact

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -73,6 +73,17 @@ jobs:
           npx vitest run test/bench.test.ts
           node scripts/bench-check.js
 
+      # Refreshing benchmarks/baseline.json requires numbers measured on runner
+      # hardware, so the results have to leave the runner. Uploaded even when the
+      # gate fails, since that is exactly when the numbers are worth reading.
+      - name: Upload benchmark results
+        if: ${{ !cancelled() && !inputs.release }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-results
+          path: benchmarks/last-run.json
+          retention-days: 7
+
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
Makes the benchmark numbers available outside the runner, which is the prerequisite for refreshing `benchmarks/baseline.json`. Refs #245.

`test/bench.test.ts` writes `benchmarks/last-run.json` and `scripts/bench-check.js` reads it, but the job's only `upload-artifact` step publishes `ts/dist/`. The results were discarded with the runner, so regenerating a baseline on runner hardware meant scraping medians out of the job log by hand. With this, `--update-baseline` becomes download-and-commit, the same shape as the existing `occt-wasm.wasm.br-fresh` flow.

Guarded with `!cancelled()` rather than skipped on failure, so a run that trips the gate still publishes the numbers that tripped it.

Does not change the baseline or the gate. The refresh itself waits on #244 so it does not bake in the regression measured there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upload benchmark results (`benchmarks/last-run.json`) as a CI artifact so we can refresh `benchmarks/baseline.json` with runner-measured numbers instead of scraping logs. The artifact uploads even if the benchmark gate fails; no changes to the gate or baseline. Supports #245.

<sup>Written for commit 7340f7597f923833e3437055fca6ee34b1cdf18f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

