### PR TITLE
test(bench): normalize the gate for runner speed and refresh the baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ cd ts && npx vitest run -t "fuse"                      # tests whose name matche
 cd ts && npx tsgo --noEmit && npx eslint src/          # the lint gate — no WASM needed
 ```
 
-Benchmarks: `npx vitest run test/bench.test.ts` (from repo root, after a build) writes `benchmarks/last-run.json`; `node scripts/bench-check.js` gates it against `baseline.json` (a regression is >15% **and** >0.5ms). Refresh the baseline with `node scripts/bench-check.js --update-baseline` after a run.
+Benchmarks: `npx vitest run test/bench.test.ts` (from repo root, after a build) writes `benchmarks/last-run.json`; `node scripts/bench-check.js` gates it against `baseline.json` (a regression is >15% **and** >0.5ms). Results are first divided by a runner speed factor (the median of the per-benchmark result/baseline ratios), since shared CI runners vary 23-42% run to run and vary uniformly across every benchmark at once; only a benchmark moving against that trend trips the gate. `baseline.json` therefore encodes the relative cost shape, and CI uploads `last-run.json` as the `benchmark-results` artifact so a refresh uses runner numbers. Refresh with `node scripts/bench-check.js --update-baseline` after a run.
 
 ## Architecture
 

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -1,12 +1,14 @@
 {
-  "makeBox ×100": 5.0,
-  "fuse ×10": 85.0,
-  "translate ×1000": 75.0,
-  "mesh sphere (tol=0.01)": 0.6,
-  "exportSTEP ×10": 35.0,
-  "translateBatch ×1000": 75.0,
-  "booleanPipeline ×3": 16.0,
-  "meshBatch ×10 spheres": 1.3,
-  "interpolatePoints ×50 push_back": 9.0,
-  "interpolatePoints ×50 bulk": 5.5
+  "makeBox ×100": 3.49,
+  "fuse ×10": 62.11,
+  "translate ×1000": 55.57,
+  "mesh sphere (tol=0.01)": 0.47,
+  "exportSTEP ×10": 27.12,
+  "translateBatch ×1000": 55.04,
+  "booleanPipeline ×3": 13.42,
+  "gridfinity plate cutAll 3×3": 116.9,
+  "gridfinity bin fuseAll 5": 58.26,
+  "meshBatch ×10 spheres": 0.86,
+  "interpolatePoints ×50 push_back": 6.43,
+  "interpolatePoints ×50 bulk": 3.7
 }

--- a/scripts/bench-check.js
+++ b/scripts/bench-check.js
@@ -6,6 +6,19 @@
  * benchmarks (e.g. mesh sphere ~0.6ms) from flake-failing on timer/scheduling
  * jitter, where a 0.1ms swing is already +17% but is pure noise.
  *
+ * Results are normalized by a runner speed factor before that comparison. Back
+ * to back CI runs of identical code differ by 23-42% per benchmark on shared
+ * ubuntu-latest runners, and the difference is uniform: a slow runner is slow on
+ * every benchmark at once. Comparing raw medians against raw medians therefore
+ * measures which machine drew the job, not the code, and no baseline value makes
+ * the gate both quiet and sensitive. Dividing every result by the median of the
+ * per-benchmark result/baseline ratios cancels the machine, so a single
+ * benchmark moving against the trend is what trips the gate.
+ *
+ * The blind spot is a change that slows every benchmark by the same factor:
+ * normalization absorbs it. The factor is printed on every run so that case
+ * stays visible in the log.
+ *
  * Reads results from benchmarks/last-run.json, which test/bench.test.ts writes
  * directly via fs. (It used to parse the markdown table from vitest's stdout,
  * but the default reporter suppresses per-test console.log when piped, so the
@@ -14,6 +27,13 @@
  * Usage:
  *   npx vitest run test/bench.test.ts && node scripts/bench-check.js
  *   node scripts/bench-check.js --update-baseline   # after a run
+ *
+ * --update-baseline writes that run's raw medians. Normalization means the
+ * absolute level no longer has to match runner hardware, only the relative cost
+ * between benchmarks does, so a local run can seed a baseline. Reconcile a few
+ * CI runs (the benchmark-results artifact) before committing one: booleanPipeline
+ * has been bimodal run to run, and a baseline that lands on its other mode is
+ * wrong in shape, which is the one thing normalization cannot rescue.
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
@@ -21,10 +41,15 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const BASELINE_PATH = resolve(__dirname, '../benchmarks/baseline.json');
-const RESULTS_PATH = resolve(__dirname, '../benchmarks/last-run.json');
+// Overridable so test/bench-check.test.ts can drive the gate against fixtures
+// without clobbering the committed baseline.
+const BASELINE_PATH = process.env.BENCH_BASELINE_PATH ?? resolve(__dirname, '../benchmarks/baseline.json');
+const RESULTS_PATH = process.env.BENCH_RESULTS_PATH ?? resolve(__dirname, '../benchmarks/last-run.json');
 const THRESHOLD = 0.15; // 15% relative regression threshold
 const MIN_ABSOLUTE_MS = 0.5; // ignore regressions smaller than this in absolute terms (sub-ms noise)
+// Below this many shared benchmarks the median ratio is too easily swung by a
+// real regression, so normalization is skipped rather than trusted.
+const MIN_SHARED_FOR_NORMALIZATION = 5;
 
 if (!existsSync(RESULTS_PATH)) {
     console.error(
@@ -77,26 +102,53 @@ if (missing.length > 0) {
     process.exit(1);
 }
 
+const medianOf = (values) => {
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = sorted.length >> 1;
+    return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+};
+
+const sharedRatios = Object.entries(results)
+    .filter(([name]) => baseline[name] !== undefined)
+    .map(([name, value]) => value / baseline[name]);
+
+const normalizing = sharedRatios.length >= MIN_SHARED_FOR_NORMALIZATION;
+const runnerFactor = normalizing ? medianOf(sharedRatios) : 1;
+
+if (!normalizing) {
+    console.log(`\nOnly ${sharedRatios.length} benchmark(s) shared with the baseline; comparing raw medians.`);
+} else {
+    console.log(`\nRunner speed factor: ${runnerFactor.toFixed(2)}× (median of ${sharedRatios.length} result/baseline ratios).`);
+    console.log('Results are divided by it, so comparisons are against baseline-equivalent hardware.');
+    if (Math.abs(runnerFactor - 1) > THRESHOLD) {
+        console.log(`NOTE: every benchmark moved ~${((runnerFactor - 1) * 100).toFixed(0)}% together. That is normally runner speed,`);
+        console.log('but a change that shifts all benchmarks uniformly would look identical. Check the raw values below.');
+    }
+}
+
 let regressions = 0;
 
-console.log(`\nRegression check (fails at >${THRESHOLD * 100}% AND >${MIN_ABSOLUTE_MS}ms):`);
-for (const [name, median] of Object.entries(results)) {
+console.log(`\nRegression check (fails at >${THRESHOLD * 100}% AND >${MIN_ABSOLUTE_MS}ms, after normalization):`);
+for (const [name, raw] of Object.entries(results)) {
     const base = baseline[name];
     if (base === undefined) {
         console.log(`  ${name}: NEW (no baseline)`);
         continue;
     }
-    const change = (median - base) / base;
-    const absoluteDelta = median - base;
+    const scaled = raw / runnerFactor;
+    const change = (scaled - base) / base;
+    const absoluteDelta = scaled - base;
+    const shown = `${base.toFixed(1)}ms → ${scaled.toFixed(1)}ms`;
+    const rawNote = normalizing ? ` [raw ${raw.toFixed(1)}ms]` : '';
     if (change > THRESHOLD && absoluteDelta > MIN_ABSOLUTE_MS) {
-        console.log(`  REGRESSION: ${name} ${base.toFixed(1)}ms → ${median.toFixed(1)}ms (+${(change * 100).toFixed(0)}%, +${absoluteDelta.toFixed(1)}ms)`);
+        console.log(`  REGRESSION: ${name} ${shown} (+${(change * 100).toFixed(0)}%, +${absoluteDelta.toFixed(1)}ms)${rawNote}`);
         regressions++;
     } else if (change > THRESHOLD) {
-        console.log(`  OK (sub-${MIN_ABSOLUTE_MS}ms noise): ${name} ${base.toFixed(1)}ms → ${median.toFixed(1)}ms (+${(change * 100).toFixed(0)}%, +${absoluteDelta.toFixed(1)}ms)`);
+        console.log(`  OK (sub-${MIN_ABSOLUTE_MS}ms noise): ${name} ${shown} (+${(change * 100).toFixed(0)}%, +${absoluteDelta.toFixed(1)}ms)${rawNote}`);
     } else if (change < -THRESHOLD) {
-        console.log(`  IMPROVED: ${name} ${base.toFixed(1)}ms → ${median.toFixed(1)}ms (${(change * 100).toFixed(0)}%)`);
+        console.log(`  IMPROVED: ${name} ${shown} (${(change * 100).toFixed(0)}%)${rawNote}`);
     } else {
-        console.log(`  OK: ${name} ${base.toFixed(1)}ms → ${median.toFixed(1)}ms (${(change * 100).toFixed(0)}%)`);
+        console.log(`  OK: ${name} ${shown} (${(change * 100).toFixed(0)}%)${rawNote}`);
     }
 }
 

--- a/test/bench-check.test.ts
+++ b/test/bench-check.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Guards scripts/bench-check.js, the CI performance gate.
+ *
+ * The gate normalizes results by a runner speed factor before comparing, because
+ * back to back CI runs of identical code differ by 23-42% per benchmark on shared
+ * runners. Getting that normalization wrong is invisible in CI: too aggressive and
+ * real regressions are absorbed, too weak and every slow runner turns the build
+ * red until someone stops reading the gate. Neither failure mode announces itself,
+ * so the arithmetic is pinned here rather than left to the next slow runner.
+ *
+ * Needs no WASM build; it drives the script over fixture JSON via the
+ * BENCH_BASELINE_PATH / BENCH_RESULTS_PATH overrides.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..");
+const SCRIPT = join(ROOT, "scripts", "bench-check.js");
+
+const BASELINE: Record<string, number> = {
+    "makeBox ×100": 3.5,
+    "fuse ×10": 62.1,
+    "translate ×1000": 55.6,
+    "mesh sphere (tol=0.01)": 0.47,
+    "exportSTEP ×10": 27.1,
+    "translateBatch ×1000": 55.0,
+    "booleanPipeline ×3": 13.4,
+    "gridfinity plate cutAll 3×3": 116.9,
+    "gridfinity bin fuseAll 5": 58.3,
+    "meshBatch ×10 spheres": 0.86,
+    "interpolatePoints ×50 push_back": 6.43,
+    "interpolatePoints ×50 bulk": 3.7,
+};
+
+let dir: string;
+
+const scale = (factor: number): Record<string, number> =>
+    Object.fromEntries(Object.entries(BASELINE).map(([name, ms]) => [name, ms * factor]));
+
+function check(
+    results: Record<string, number>,
+    baseline: Record<string, number> = BASELINE
+): { status: number; stdout: string } {
+    const baselinePath = join(dir, "baseline.json");
+    const resultsPath = join(dir, "last-run.json");
+    writeFileSync(baselinePath, JSON.stringify(baseline));
+    writeFileSync(resultsPath, JSON.stringify(results));
+    const proc = spawnSync("node", [SCRIPT], {
+        encoding: "utf8",
+        env: {
+            ...process.env,
+            BENCH_BASELINE_PATH: baselinePath,
+            BENCH_RESULTS_PATH: resultsPath,
+        },
+    });
+    return { status: proc.status ?? -1, stdout: proc.stdout + proc.stderr };
+}
+
+beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "bench-check-"));
+});
+
+afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("bench-check", () => {
+    it("passes a run that matches the baseline exactly", () => {
+        const { status, stdout } = check(scale(1));
+        expect(status).toBe(0);
+        expect(stdout).toContain("No performance regressions detected");
+    });
+
+    it("passes a uniformly slow runner and reports the factor", () => {
+        const { status, stdout } = check(scale(1.3));
+        expect(status).toBe(0);
+        expect(stdout).toContain("Runner speed factor: 1.30×");
+        expect(stdout).toContain("No performance regressions detected");
+    });
+
+    it("passes a uniformly fast runner", () => {
+        const { status, stdout } = check(scale(0.75));
+        expect(status).toBe(0);
+        expect(stdout).toContain("Runner speed factor: 0.75×");
+        expect(stdout).toContain("No performance regressions detected");
+    });
+
+    it("fails one benchmark that moves against the trend", () => {
+        const results = scale(1);
+        results["gridfinity plate cutAll 3×3"] *= 1.25;
+        const { status, stdout } = check(results);
+        expect(status).toBe(1);
+        expect(stdout).toContain("REGRESSION: gridfinity plate cutAll 3×3");
+        expect(stdout).toContain("1 benchmark(s) regressed");
+    });
+
+    it("still fails that benchmark when the whole runner is slow", () => {
+        const results = scale(1.3);
+        results["gridfinity plate cutAll 3×3"] *= 1.25;
+        const { status, stdout } = check(results);
+        expect(status).toBe(1);
+        expect(stdout).toContain("REGRESSION: gridfinity plate cutAll 3×3");
+    });
+
+    it("ignores a large relative move that is under the sub-millisecond floor", () => {
+        const results = scale(1);
+        results["mesh sphere (tol=0.01)"] *= 1.5; // 0.47ms -> 0.71ms, +50% but +0.24ms
+        const { status, stdout } = check(results);
+        expect(status).toBe(0);
+        expect(stdout).toContain("OK (sub-0.5ms noise): mesh sphere");
+    });
+
+    it("fails when the results are missing a baseline benchmark", () => {
+        const results = scale(1);
+        delete results["fuse ×10"];
+        const { status, stdout } = check(results);
+        expect(status).toBe(1);
+        expect(stdout).toContain("baseline benchmark(s) missing from results");
+    });
+
+    it("reports a benchmark with no baseline entry as NEW", () => {
+        const results = { ...scale(1), "brand new benchmark": 12.0 };
+        const { status, stdout } = check(results);
+        expect(status).toBe(0);
+        expect(stdout).toContain("brand new benchmark: NEW (no baseline)");
+    });
+
+    it("skips normalization when too few benchmarks are shared to trust the median", () => {
+        const few = Object.fromEntries(Object.entries(BASELINE).slice(0, 3));
+        const { status, stdout } = check(
+            Object.fromEntries(Object.entries(few).map(([n, ms]) => [n, ms * 1.3])),
+            few
+        );
+        expect(stdout).toContain("comparing raw medians");
+        expect(status).toBe(1); // 1.3x is a real regression when nothing cancels it
+    });
+});


### PR DESCRIPTION
Closes #245.

## Why

`benchmarks/baseline.json` had not moved since #137, so every benchmark reported a large improvement and the two gridfinity benchmarks were never gated at all.

Refreshing the numbers alone does not fix the gate. The `benchmark-results` artifact from #247 makes the run-to-run distribution visible for the first time, and it is wide. Five recent CI runs, four of them on identical code:

| Benchmark | 30851212396 | 30850210406 | 30849178151 | 30840915065 | 30840195910 |
| --- | --- | --- | --- | --- | --- |
| fuse ×10 | 68.5 | 55.4 | 61.4 | 68.9 | 62.3 |
| translate ×1000 | 64.4 | 50.2 | 48.9 | 63.1 | 49.4 |
| gridfinity plate cutAll 3×3 | 144.2 | 117.2 | 114.7 | 128.7 | 116.0 |
| gridfinity bin fuseAll 5 | 70.6 | 57.5 | 57.2 | 64.4 | 57.0 |

Per-benchmark spread is 23-42%, and it is uniform: run 30851212396 is slower on all twelve benchmarks at once. That is the shared `ubuntu-latest` runner's speed, not the code. Comparing one raw median against one stored raw median therefore measures which machine drew the job, and no baseline value makes the gate both quiet and sensitive. It is why the real 11-15% gridfinity regression in #244 passed.

## What

`scripts/bench-check.js` divides every result by a runner speed factor before comparing: the median of the per-benchmark result/baseline ratios. The machine cancels, and a benchmark has to move against the trend to trip the 15% + 0.5ms thresholds. Normalization is skipped below five shared benchmarks, where the median is too easily swung by a real regression.

The blind spot is a change that slows everything uniformly, which the factor absorbs. The factor is printed on every run, with an explicit note when it exceeds the threshold, so that case stays readable in the log.

`benchmarks/baseline.json` is the per-benchmark median of the machine-normalized values across those five runs, rescaled so the entries still read as observed milliseconds. `booleanPipeline ×3` drove that choice: it is bimodal (10.8 / 10.8 / 15.0 / 15.3 / 15.4) in a way that does not track the runner factor, so a plain median of a few runs lands on one mode and fails the gate on the other.

## Verification

Replaying the real gate over all five downloaded runs: every one passes, with reported factors of 1.15, 0.89, 0.98, 1.13 and 1.00.

Sensitivity, injecting a regression into `gridfinity plate cutAll 3×3` and replaying the same five runs:

| Injected | Caught |
| --- | --- |
| +15% | 3/5 |
| +18% | 4/5 |
| +20% | 5/5 |

Not a guarantee at the 11-15% magnitude of #244, but the previous state caught it 0/5 and had no entry for that benchmark at all.

`test/bench-check.test.ts` pins the arithmetic: a uniformly slow or fast runner passes, a single benchmark moving against the trend fails both on a neutral and on a slow runner, the sub-millisecond floor still suppresses noise, and the missing-benchmark guard still fails loudly. It needs no WASM build and drives the script through `BENCH_BASELINE_PATH` / `BENCH_RESULTS_PATH` overrides.

## Follow-up worth filing separately

`booleanPipeline ×3` sits in one of two modes across runs with no correlation to runner speed. The benchmark leaks its intermediate shapes, so a wasm heap growth landing inside the measured loop is a plausible mechanism. Worth a look on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the CI benchmark gate by runner speed and refresh `benchmarks/baseline.json` so the gate is stable and catches real per-benchmark regressions while ignoring runner variance. Closes #245.

- **New Features**
  - Normalize results by a runner factor (median of result/baseline ratios); skip when fewer than 5 benchmarks overlap.
  - Compare after normalization using the same thresholds (15% and 0.5ms). Print the factor each run and flag large uniform shifts; show raw values for context.
  - Refresh `benchmarks/baseline.json` with machine-normalized medians and add gridfinity benchmarks.
  - Add `test/bench-check.test.ts` to pin the arithmetic and failure modes, plus `BENCH_BASELINE_PATH`/`BENCH_RESULTS_PATH` overrides. Update `CLAUDE.md` docs.

<sup>Written for commit d12b17101e17063a1e1953348fa040a88f7d878c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

