### PR TITLE
fix(deps): bump fast-uri past GHSA-7p8r-x3mc-p8w7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,9 +1224,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
The blocking OSV scan has failed on every push to `main` since this advisory landed (runs [30851811333](https://github.com/andymai/occt-wasm/actions/runs/30851811333), [30851178832](https://github.com/andymai/occt-wasm/actions/runs/30851178832), and the rest).

```
| https://osv.dev/GHSA-7p8r-x3mc-p8w7 | 7.5 | npm | fast-uri (dev) | 3.1.4 | 3.1.5 | package-lock.json |
```

[GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), high / CVSS 7.5: host confusion via backslash authority introducer. Vulnerable range `>= 3.0.0, < 3.1.5`.

Same dev-only transitive as #237 (`@commitlint/cli` -> `ajv` -> `fast-uri`), and 3.1.4 is precisely the version that fix landed on, so the new advisory reopened it. Lockfile-only, three lines; `fast-uri` reaches neither the published npm package nor the crate.

`npm audit` at the root is clean after the bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `fast-uri` to 3.1.5 to resolve GHSA-7p8r-x3mc-p8w7 and unblock OSV scans. Lockfile-only change with no runtime or publish impact.

- **Dependencies**
  - Bumped `fast-uri` from 3.1.4 to 3.1.5 (fixes high-severity host confusion).
  - Dev-only transitive via `@commitlint/cli` → `ajv` → `fast-uri`.
  - `npm audit` is clean after the bump.

<sup>Written for commit eba313f58d35930f166f7e3a25cf693f96087b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

