### PR TITLE
fix(deps): bump js-yaml past GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "occt-wasm",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@commitlint/cli": "^21",
@@ -1403,9 +1404,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears the one open high-severity Dependabot alert (#23).

`js-yaml` 4.3.0 is vulnerable to quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870, unbackported). Fixed in 4.3.1.

It reaches us only as a dev-tooling transitive: `@commitlint/cli → @commitlint/load → cosmiconfig → js-yaml`. Nothing shipped in the npm package or the crate touches it, and commitlint only parses our own config, so real exposure is nil — this just clears the alert. Lockfile-only change; `npm audit` now reports 0 vulnerabilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `js-yaml` to 4.3.1 to patch the `!!omap` DoS vulnerability in dev tooling. Lockfile-only; clears the high-severity alert with no runtime impact.

- **Dependencies**
  - Bump `js-yaml` from 4.3.0 to 4.3.1 (fixes CVE-2026-59870 / GHSA-5p4m-2wfm-xmqj).
  - Dev-only transitive via `@commitlint/cli` → `@commitlint/load` → `cosmiconfig`; no shipped code uses it. `npm audit` now reports 0 vulnerabilities.

<sup>Written for commit 4354e8782f4e399fad0130d6714d04a3488f765d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

