### PR TITLE
fix(deps): bump nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "occt-wasm",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@commitlint/cli": "^21",
@@ -1731,9 +1730,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "occt-wasm",
-  "version": "3.8.3",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "occt-wasm",
-      "version": "3.8.3",
+      "version": "4.1.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "comlink": "^4.4.2"
@@ -2138,9 +2138,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
The blocking OSV scan has been failing on every push to `main`. It passes on pull requests because that variant is report-only, so `main` sat red by default and no PR ever surfaced it.

`nanoid` 3.3.16 carries GHSA-2v37-7h3g-55p8 (High, 8.2). It reaches both lockfiles through `vitest -> vite -> postcss`, which asks for `^3.3.16`, so 3.3.18 satisfies it and a plain `npm update nanoid` is enough in each.

Deliberately not an override: those pin a resolution and turn into a per-advisory treadmill once upstream moves.

Dev-only, so nothing changes in the shipped WASM or the published package contents.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update dev dependency `nanoid` to 3.3.18 to resolve GHSA-2v37-7h3g-55p8 and unblock the OSV scan on `main`. No changes to shipped WASM or published package.

- **Dependencies**
  - Bumped `nanoid` 3.3.16 → 3.3.18 via `vitest` → `vite` → `postcss`; updated both lockfiles; no overrides added.

<sup>Written for commit 220d08fb45eddca64b1c30fd564e2c67b89925df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

