### PR TITLE
docs(ts): document tol3d as an accuracy floor at unit scale

### DIFF
--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -204,14 +204,24 @@ export enum SweepContact {
 
 /**
  * Approximation tolerances for the pipe-shell sweeps. All are absolute, not
- * relative to model size.
+ * relative to model size, so scaling the model by 10 and tightening the
+ * tolerance by 10 are the same operation.
  */
 export interface SweepToleranceOptions {
     /**
-     * 3D approximation tolerance. OCCT's default is an absolute `1e-4`, so
-     * models much larger than unit scale should raise this in proportion —
+     * 3D approximation tolerance. OCCT's default is an absolute `1e-4`, which
+     * binds in both directions.
+     *
+     * Models much larger than unit scale should raise it in proportion,
      * otherwise the surface approximation runs out of spans and the sweep
-     * degrades or fails outright.
+     * degrades or fails outright. Near unit scale that same default is the
+     * accuracy floor, and lowering it is how you buy digits. On a 4x4 square
+     * swept 20 along a guide encoding a 90 degree twist, whose exact volume is
+     * 320, the relative error is 1.3e-5 at the default, 3.3e-9 at `1e-6` and
+     * 6.2e-13 at `1e-9`, for roughly 2x and 4x the build time.
+     *
+     * The gain is monotonic by decade but not step to step, so measure on the
+     * geometry you actually build rather than assuming tighter is better.
      */
     tol3d?: number;
     /** Boundary tolerance. OCCT's default is an absolute `1e-4`. */


### PR DESCRIPTION
`SweepToleranceOptions` documented the absolute `1e-4` default only in the raise-it-for-large-models direction (span exhaustion, the 10x failure in #255). Near unit scale the same default is what caps accuracy, and lowering it is how callers buy digits. That half was missing, which is what the reporter in #255 hit: a residual 1.3e-5 they attributed to their own guide discretisation.

Adds the second direction, with measured numbers on the twist case from that issue.

## Measured

4x4 square swept 20 along a straight spine, guide encoding a 90 degree twist as a 64-segment polyline. Truth is exactly 320. Guide held fixed, so discretisation is constant across rows:

```
  tol3d/boundTol      rel.err     median build
  --------------------------------------------
  1e-4 (default)      1.27e-5      6.2 ms
  1e-6                3.30e-9     13.4 ms
  1e-9                6.23e-13    25.0 ms
```

The absoluteness is visible as an exact equivalence: f=10 at the default matches f=1 at `tol3d=1e-5` (9.44e-8), and f=100 matches `tol3d=1e-6` (3.30e-9). Scaling 10x and tightening 10x are the same operation.

Also noted: the gain is monotonic by decade but not step to step (`1e-7` measures 4.24e-8, worse than `1e-6`), so the doc tells callers to measure rather than assume tighter is better.

Docs only, no behaviour change. Posted to #255 as https://github.com/andymai/occt-wasm/issues/255#issuecomment-5349750381

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents `tol3d` as an absolute tolerance that sets an accuracy floor at unit scale, not just a value to raise for large models. Clarifies how lowering `tol3d` buys digits and adds measured accuracy/time tradeoffs. Docs-only; no behavior change.

- Updates JSDoc for `SweepToleranceOptions.tol3d` in `ts/src/types.ts`; API unchanged.
- Adds measured example: 4x4 square swept 20 with 90° twist; relative error at 1e-4 ≈ 1.3e-5 (6.2 ms), 1e-6 ≈ 3.3e-9 (13.4 ms), 1e-9 ≈ 6.2e-13 (25.0 ms).
- States equivalence: scaling a model by 10 and tightening `tol3d` by 10 are the same operation.
- Advises measuring on target geometry; improvements are monotonic by decade but not step-to-step.

<sup>Written for commit 4ca11d8783463dc9fdb17814e4f4ecbaa2a6d3c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

