### PR TITLE
fix(docker): copy README, examples, and benchmarks before the test step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,14 @@ COPY ts/scripts/ ts/scripts/
 # which OcctKernel.init() resolves relative to its own location).
 RUN cd ts && npm run build
 
+# The static-server suite serves the repo root, and ts/'s prepack copies
+# ../README.md into the package -- neither file is needed by the build itself,
+# so they are copied here, after the expensive layers, where a change to them
+# costs nothing.
+COPY README.md ./
+COPY examples/ examples/
+COPY benchmarks/ benchmarks/
+
 # Test
 RUN cd ts && npx vitest run
 


### PR DESCRIPTION
## The bug

`npm run docker:build` fails on a clean checkout. The standalone `Dockerfile` never copies `README.md`, `examples/`, or `benchmarks/`, so two `static-server` cases fail once the suite runs:

```
FAIL test/static-server.test.ts > resolves a directory to its index.html
  AssertionError: expected 404 to be 200
  (GET /examples/three-js/ — examples/ is not in the image)

FAIL test/static-server.test.ts > survives a malformed percent-escape
  AssertionError: expected 404 to be 200
  (the follow-up GET /README.md that proves the server still answers)
```

`bench.test.ts` also logs `ENOENT` for `benchmarks/last-run.json`, though its assertions still pass.

Separately, `ts/package.json`'s `prepack` runs `cp ../README.md README.md`, so `npm pack` inside the image fails for the same reason — which is how I ran into it, packing a local build.

CI doesn't catch this because it builds through the prebuilt builder image rather than this Dockerfile.

## The fix

Three `COPY` lines, placed after the WASM link and the TS build so editing any of them costs no cache. They are test fixtures, not build inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZh48So2uqvAN4qfN9rD6B


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `npm run docker:build` failing on a clean checkout by copying `README.md`, `examples/`, and `benchmarks/` into the image before the test step.

- The static-server tests serve files from the repo root, so the missing fixtures caused two 404 failures.
- `ts/package.json`'s `prepack` also expects `../README.md`, so `npm pack` inside the image now succeeds.
- The copies are placed after the WASM link and TS build so edits to these files don't invalidate the Docker cache.

<sup>Written for commit 9ea8365f26c77b15c22577ec23c760a4b93b6460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/occt-wasm/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

